### PR TITLE
Disposal rework and mailing room

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -180,26 +180,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
-"abJ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "abW" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
@@ -312,12 +292,6 @@
 /obj/item/rig/medical/equipped,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/sleeper)
-"add" = (
-/obj/machinery/conveyor/south{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "adg" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
@@ -518,6 +492,13 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"afk" = (
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/obj/machinery/pile_ripper,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "afr" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -555,6 +536,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
+"afA" = (
+/obj/effect/floor_decal/industrial/warningred/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "afI" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -645,6 +631,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"agx" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "agD" = (
 /obj/machinery/smartfridge/secure/medbay/organs/stocked,
 /turf/simulated/floor/tiled/white/monofloor,
@@ -967,6 +957,17 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
+"ajw" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "ajH" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -1453,6 +1454,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"apc" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/material_resources/low_chance,
+/obj/random/powercell/small_safe_lonestar,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "apk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1571,13 +1582,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"aqq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
 "aqr" = (
 /obj/structure/table/glass,
 /obj/random/powercell,
@@ -1638,6 +1642,16 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
+"aqP" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/disposaldrop)
 "aqU" = (
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "medbay exit";
@@ -1792,6 +1806,28 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
+"asA" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 8
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/hand_labeler,
+/obj/item/clipboard{
+	pixel_x = 6;
+	pixel_y = -12
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = -11
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "asL" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/southleft{
@@ -2524,6 +2560,13 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"azB" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "azI" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance{
@@ -2708,6 +2751,14 @@
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
+"aBu" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "aBv" = (
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance_common,
@@ -2857,6 +2908,24 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
 /area/colony)
+"aCC" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/device/destTagger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "aCD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -2909,6 +2978,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"aCX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "aCY" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -3388,11 +3465,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/secrecroom)
-"aIn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "aIv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3548,15 +3620,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
-"aKA" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mail Office";
-	req_one_access = list(50,48,26)
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "aKG" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -5130,27 +5193,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/sec)
-"bcz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "bcF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5243,14 +5285,6 @@
 /obj/machinery/atm{
 	dir = 8;
 	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
-"bdA" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -5978,6 +6012,13 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"bkf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "bkg" = (
 /obj/random/booze,
 /obj/random/junkfood/onlypizza,
@@ -6686,29 +6727,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfacesec)
-"bsc" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stack/cable_coil/random,
-/obj/item/tool/screwdriver,
-/obj/item/stack/material/steel/random,
-/obj/item/stack/material/steel/random,
-/obj/item/stack/material/steel/random,
-/obj/item/circuitboard/vending,
-/obj/item/circuitboard/vending,
-/obj/item/circuitboard/vending,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "bsf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/wood{
@@ -7494,6 +7512,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"bzO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "bzQ" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -7633,6 +7660,15 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"bBw" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "bBy" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
@@ -8766,6 +8802,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"bMT" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "bNb" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/random/lowkeyrandom,
@@ -9775,13 +9826,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"bZh" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "bZi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10269,6 +10313,16 @@
 /obj/machinery/r_n_d/destructive_analyzer,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"cev" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "ceB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -10528,6 +10582,29 @@
 "chh" = (
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
+"chk" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stack/cable_coil/random,
+/obj/item/tool/screwdriver,
+/obj/item/stack/material/steel/random,
+/obj/item/stack/material/steel/random,
+/obj/item/stack/material/steel/random,
+/obj/item/circuitboard/vending,
+/obj/item/circuitboard/vending,
+/obj/item/circuitboard/vending,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "chz" = (
 /obj/landmark/join/start/medspec,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -10605,23 +10682,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"cid" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "cig" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -10648,6 +10708,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"cik" = (
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "cim" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/button/remote/blast_door{
@@ -10958,6 +11025,13 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/pros/foreman)
+"clC" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "clE" = (
 /obj/structure/railing{
 	dir = 4
@@ -11787,6 +11861,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"cuM" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction/untagged/flipped,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "cuN" = (
 /obj/structure/table/standard,
 /obj/machinery/light/small{
@@ -11824,6 +11918,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"cva" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "cvc" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -12342,14 +12441,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"cAD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "cAF" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -12516,15 +12607,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/chemistry)
-"cCj" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "cCl" = (
 /obj/structure/sign/security/court{
 	pixel_x = -16;
@@ -12708,6 +12790,42 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"cDO" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/random/contraband/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lathe_disk/low_chance,
+/obj/random/material_resources/low_chance,
+/obj/random/medical/low_chance,
+/obj/random/melee/low_chance,
+/obj/random/rig_module/rare/low_chance,
+/obj/random/rig_module/low_chance,
+/obj/random/rig/low_chance,
+/obj/random/rations/low_chance,
+/obj/random/voidsuit/low_chance,
+/obj/random/toolbox/low_chance,
+/obj/random/tool/advanced/low_chance,
+/obj/random/tool_upgrade/rare/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/techpart/low_chance,
+/obj/random/tank/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "cDT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -12999,26 +13117,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
-"cGC" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/sortjunction/untagged/flipped,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "cGH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -13307,6 +13405,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"cJw" = (
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "cJy" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -13404,14 +13508,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"cKA" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "cKJ" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -13851,21 +13947,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
-"cOS" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -14680,16 +14761,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"cWR" = (
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 4
-	},
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "cWS" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/structure/disposalpipe/segment,
@@ -15232,42 +15303,6 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai)
-"dcL" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/random/contraband/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lathe_disk/low_chance,
-/obj/random/material_resources/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/melee/low_chance,
-/obj/random/rig_module/rare/low_chance,
-/obj/random/rig_module/low_chance,
-/obj/random/rig/low_chance,
-/obj/random/rations/low_chance,
-/obj/random/voidsuit/low_chance,
-/obj/random/toolbox/low_chance,
-/obj/random/tool/advanced/low_chance,
-/obj/random/tool_upgrade/rare/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/techpart/low_chance,
-/obj/random/tank/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "dcQ" = (
 /obj/machinery/optable,
 /obj/machinery/light{
@@ -15534,11 +15569,6 @@
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
-"dfi" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "dfq" = (
 /obj/structure/cable/cyan{
 	d1 = 16;
@@ -15689,13 +15719,26 @@
 /obj/random/gun_energy_cheap,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"dgQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
+"dgP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "dgS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16035,16 +16078,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"dkp" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mail Office";
-	req_one_access = list(50,48,26)
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "dkt" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -16060,6 +16093,9 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"dkA" = (
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "dkE" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -16141,6 +16177,11 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"dls" = (
+/obj/structure/table/rack,
+/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "dlA" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -16385,6 +16426,19 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
+"dnI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "dnQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
@@ -16503,16 +16557,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"dpb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "dpc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -16963,6 +17007,12 @@
 /obj/effect/floor_decal/industrial/road/straight1,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"dtX" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "dua" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17871,6 +17921,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
+"dCo" = (
+/obj/structure/table/rack/shelf,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "dCp" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -17882,6 +17940,16 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/turret_protected/ai_upload)
+"dCw" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/engine_waste)
 "dCC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -18257,19 +18325,6 @@
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/hunter_cabin)
-"dFR" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/disposal/deliveryChute,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
 "dFS" = (
 /obj/effect/spider/stickyweb,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -18444,6 +18499,26 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"dHY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
+"dHZ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "dIe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19452,26 +19527,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
-"dSc" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "dSd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -19701,13 +19756,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"dUx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "dUD" = (
 /obj/random/junkfood/onlycake,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -20556,6 +20604,16 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"edf" = (
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "edn" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -21013,6 +21071,22 @@
 /obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ehh" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "ehj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -21069,6 +21143,16 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"ehQ" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "ehT" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -21756,15 +21840,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"eoK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "eoM" = (
 /obj/structure/catwalk,
 /obj/machinery/firealarm{
@@ -23106,13 +23181,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"eCt" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "eCy" = (
 /obj/structure/table/standard,
 /obj/item/gun/projectile/colt/ten{
@@ -23452,15 +23520,17 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"eGD" = (
-/obj/structure/table/rack/shelf,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
+"eGC" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/cargo_tech,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
+/area/nadezhda/quartermaster/office)
 "eGG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -24709,12 +24779,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"eRO" = (
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "eRP" = (
 /obj/structure/flora/small/grassa3,
 /turf/simulated/floor/asteroid/grass,
@@ -24903,13 +24967,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"eUH" = (
-/obj/machinery/conveyor/southwest/ccw{
-	id = "trash"
+"eUI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "eUJ" = (
 /obj/structure/table/woodentable,
 /obj/structure/sign/security/court{
@@ -25023,6 +25094,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"eWa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/conveyor_switch{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "eWc" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -25744,9 +25829,6 @@
 /obj/random/mob/roaches,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"fcD" = (
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "fcF" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/nonfiction/thescienceofright,
@@ -25800,16 +25882,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"fdE" = (
-/obj/random/junk/cigbutt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "fdG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -27789,20 +27861,6 @@
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"fxq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "fxv" = (
 /obj/structure/railing{
 	dir = 8
@@ -28195,6 +28253,13 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
+"fBE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "fBG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/lowkeyrandom,
@@ -28585,6 +28650,13 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
+"fFv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "fFD" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -29120,6 +29192,18 @@
 "fLN" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"fLO" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction{
+	name = "Cargo - Sorting Office";
+	sortType = "Cargo - Sorting Office"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "fLT" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -29336,6 +29420,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/fitness)
+"fNT" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "fNZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29364,13 +29466,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"fOx" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/machinery/pile_ripper,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "fOK" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/cyan{
@@ -29605,6 +29700,13 @@
 /mob/living/simple_animal/goose,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"fRt" = (
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "fRv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -29913,6 +30015,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"fVc" = (
+/obj/machinery/conveyor/southwest{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "fVe" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_y = 32
@@ -30034,15 +30142,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/teleporter)
-"fWy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "fWA" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/cable/green{
@@ -30588,6 +30687,13 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/armory)
+"gbV" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "gbZ" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/grille,
@@ -31374,35 +31480,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"giP" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "giR" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 10
@@ -31431,13 +31508,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"giX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "gjm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/autolathe/mechfab/loaded,
@@ -33240,16 +33310,6 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"gAH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "lonestar_mailing";
-	name = "Lonestar Mailing Room shutter control";
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "gAK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -34122,6 +34182,14 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gLM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "gLR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -34486,12 +34554,6 @@
 /obj/structure/noticeboard/anomaly,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
-"gPf" = (
-/obj/machinery/conveyor/southwest{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "gPg" = (
 /obj/structure/toilet{
 	dir = 4
@@ -34658,6 +34720,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"gQy" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "gQz" = (
 /obj/structure/flora/big/rocks3,
 /turf/unsimulated/mineral,
@@ -35312,6 +35384,15 @@
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"gWF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "gWK" = (
 /obj/effect/floor_decal/corner_oldtile,
 /obj/effect/floor_decal/corner_oldtile{
@@ -35412,19 +35493,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
-"gXw" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "gXz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -36480,6 +36548,17 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hjI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "hjL" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -37115,6 +37194,21 @@
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
+"hpM" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "hpN" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "11,17"
@@ -37163,6 +37257,10 @@
 "hqv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/gmaster)
+"hqx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "hqy" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -37747,16 +37845,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
-"hwN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "hwY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -37816,6 +37904,11 @@
 /obj/structure/curtain/open,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"hxB" = (
+/obj/machinery/mech_recharger,
+/obj/mecha/working/ripley,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "hxL" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
@@ -38060,6 +38153,13 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate)
+"hzG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/tagger{
+	sort_tag = "Cargo - Export"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "hzI" = (
 /obj/structure/railing{
 	dir = 4;
@@ -38842,12 +38942,6 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
-"hGP" = (
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "hGR" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "12,1"
@@ -39770,19 +39864,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"hOy" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	pixel_y = -7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "hOz" = (
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 1
@@ -40910,6 +40991,15 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/barracks)
+"hZW" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "hZY" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -40924,6 +41014,16 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"iac" = (
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = -32
+	},
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "iaf" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 4
@@ -41188,14 +41288,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
-"icF" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "icL" = (
 /obj/machinery/light{
 	dir = 1
@@ -41463,16 +41555,6 @@
 "ieZ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/merchant)
-"ifb" = (
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = -32
-	},
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
 "ifd" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -42226,24 +42308,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"imL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "imM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -42323,17 +42387,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"inn" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/item/trash/pistachios,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "inu" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
@@ -42396,6 +42449,21 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"inW" = (
+/obj/structure/plasticflaps,
+/obj/machinery/door/blast/shutters{
+	closed_layer = 4.2;
+	id = "lonestar_mailing2";
+	layer = 4.2;
+	name = "Mailing Shutters"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Mailing Room";
+	req_access = list(31)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "inZ" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -43130,6 +43198,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"ivE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "ivH" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -44101,6 +44177,15 @@
 /obj/random/junkfood/rotten/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"iHb" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_one_access = list(50,48,26)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "iHh" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -44930,6 +45015,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"iPm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "iPr" = (
 /obj/structure/table/bench/steel,
 /obj/effect/spider/stickyweb,
@@ -45163,24 +45259,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"iRZ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "iSj" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -45488,16 +45566,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"iVG" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/material_resources/low_chance,
-/obj/random/powercell/small_safe_lonestar,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "iVJ" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -46233,16 +46301,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
-"jdB" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "jdE" = (
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -46278,6 +46336,17 @@
 "jdO" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
+"jdR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "jdU" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -46923,15 +46992,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
-"jkv" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "jkx" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/dirt,
@@ -46964,6 +47024,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/server)
+"jkF" = (
+/obj/machinery/newscaster/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "jkJ" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/dirt,
@@ -47157,17 +47222,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"jmI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/north,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "jmM" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -47384,6 +47438,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"jot" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "jou" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/dirt,
@@ -47414,6 +47481,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"joL" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "joM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -47538,19 +47610,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/janitor)
-"jpQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
-	},
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "jpT" = (
 /obj/structure/invislight,
 /obj/structure/boulder,
@@ -47591,12 +47650,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
-"jqN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "jqO" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -49288,14 +49341,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
-"jIM" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "jIQ" = (
 /obj/structure/railing/grey,
 /obj/structure/flora/small/grassb2,
@@ -49410,26 +49455,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"jKf" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/device/scanner/price,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "jKi" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushc1,
@@ -51762,17 +51787,6 @@
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
-"kis" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mail Office";
-	req_one_access = list(50,48,26)
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "kit" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -52306,31 +52320,6 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
-"kog" = (
-/obj/machinery/button/remote/blast_door{
-	id = "lonestar_lobby";
-	name = "Lonestar Lobby shutter control";
-	pixel_y = 32
-	},
-/obj/structure/table/standard,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/device/scanner/price,
-/obj/item/stamp/denied,
-/obj/item/stamp,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "koh" = (
 /obj/structure/boulder,
 /obj/structure/cable/cyan{
@@ -52390,6 +52379,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"koR" = (
+/obj/structure/low_wall,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "koW" = (
 /obj/structure/closet/wall_mounted{
 	pixel_x = -32
@@ -52972,6 +52969,19 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"kuH" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "kuK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -53700,24 +53710,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/prisoncells)
-"kBa" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "kBc" = (
 /obj/structure/table/rack/shelf,
 /obj/random/scrap/beacon,
@@ -53777,17 +53769,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"kBW" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/landmark/join/start/cargo_tech,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "kCh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -54058,13 +54039,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"kEH" = (
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "kEJ" = (
 /obj/structure/table/steel,
 /obj/random/common_oddities/low_chance,
@@ -54474,6 +54448,15 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kKy" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "kKG" = (
 /obj/structure/sink{
 	pixel_y = -22
@@ -54853,13 +54836,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
-"kPl" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "kPp" = (
 /obj/structure/bed{
 	dir = 4
@@ -55911,20 +55887,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"lbS" = (
-/obj/effect/floor_decal/industrial/warningred/corner{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch{
-	id = "trash";
-	one_way = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "lbT" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -56062,13 +56024,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
-"ldg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/low_wall,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/disposaldrop)
 "ldh" = (
 /obj/item/device/radio/intercom{
 	pixel_y = 24
@@ -56661,6 +56616,13 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"lkq" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "lkK" = (
 /mob/living/simple_animal/pig{
 	desc = "This intelligent sow has strange, pointy ears.";
@@ -56772,6 +56734,12 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"llS" = (
+/obj/structure/sign/warning/moving_parts/small{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "llT" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "10,20"
@@ -57303,20 +57271,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"lsg" = (
-/obj/structure/plasticflaps,
-/obj/machinery/door/blast/shutters{
-	closed_layer = 4.2;
-	id = "lonestar_mailing2";
-	layer = 4.2;
-	name = "Mailing Shutters"
-	},
-/obj/machinery/door/window/southleft{
-	name = "Mailing Room";
-	req_access = list(31)
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "lsk" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/phone,
@@ -57380,10 +57334,34 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm3)
+"ltc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "ltj" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"ltl" = (
+/obj/structure/table/rack/shelf,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "ltn" = (
 /obj/machinery/computer/rdconsole/robotics,
 /obj/machinery/power/apc{
@@ -57536,6 +57514,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lux" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction{
+	name = "Cargo - Export";
+	sortType = "Cargo - Export"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "luB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -58630,11 +58618,6 @@
 "lGy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/cryo)
-"lGK" = (
-/obj/machinery/newscaster/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "lGO" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
@@ -58725,19 +58708,6 @@
 /obj/machinery/vending/engineering,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
-"lHI" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	name = "Mailing Desk";
-	req_access = list(31)
-	},
-/obj/machinery/door/blast/shutters{
-	id = "lonestar_mailing";
-	name = "Mailing Desk Shutters"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "lHL" = (
 /obj/machinery/camera/network/research{
 	dir = 4
@@ -58861,14 +58831,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lIP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "lIS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58925,6 +58887,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
+"lJk" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "lJl" = (
 /obj/structure/cyberplant,
 /obj/machinery/holoposter{
@@ -59044,6 +59024,26 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"lKu" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "lKx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -59103,16 +59103,6 @@
 /mob/living/simple_animal/hostile/diyaab,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"lKZ" = (
-/obj/effect/floor_decal/industrial/box/red,
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/engine_waste)
 "lLf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -59128,12 +59118,6 @@
 /obj/random/mob/spiders,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"lLH" = (
-/obj/machinery/conveyor/southeast/ccw{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "lLM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush2,
@@ -60194,6 +60178,16 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"lWO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "lonestar_mailing";
+	name = "Lonestar Mailing Room shutter control";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "lWU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -60851,11 +60845,6 @@
 /obj/structure/flora/big/rocks3,
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
-"mdS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "mdX" = (
 /obj/effect/spider/stickyweb,
 /obj/random/scrap/dense_weighted,
@@ -61208,6 +61197,15 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"mgo" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "mgp" = (
 /obj/machinery/light{
 	light_color = "#b9e8ea"
@@ -61714,21 +61712,6 @@
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
-"mlk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "mln" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -61967,6 +61950,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"mnp" = (
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "mns" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush3,
@@ -62166,21 +62155,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"mpQ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "mpR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -63451,16 +63425,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"mCW" = (
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred,
-/obj/machinery/autolathe,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "mCX" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Artificer Power Substation";
@@ -63886,17 +63850,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate)
-"mGL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "lonestar_mailing2";
-	name = "Lonestar Mailing Room shutter control";
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "mGO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -64100,15 +64053,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"mIH" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "mIJ" = (
 /obj/structure/table/standard,
 /obj/item/virusdish/random,
@@ -64378,19 +64322,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/sleeper)
-"mLw" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "mLx" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donkpockets,
@@ -64569,14 +64500,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"mNT" = (
-/obj/structure/table/rack/shelf,
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/toolbox/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "mNU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -65270,6 +65193,31 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/pros/prep)
+"mVd" = (
+/obj/machinery/button/remote/blast_door{
+	id = "lonestar_lobby";
+	name = "Lonestar Lobby shutter control";
+	pixel_y = 32
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/device/scanner/price,
+/obj/item/stamp/denied,
+/obj/item/stamp,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "mVk" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/big/bush3{
@@ -65713,13 +65661,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/crew_quarters/toilet/public)
-"mYZ" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/south{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "mZb" = (
 /obj/machinery/alarm{
 	desc = "This one has no access lock to allow for the vents to be turned on and off when needed.";
@@ -67112,10 +67053,6 @@
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"nmr" = (
-/obj/effect/floor_decal/industrial/box/corners,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "nmv" = (
 /obj/machinery/light{
 	dir = 8
@@ -67393,16 +67330,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"npx" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/tool/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "npy" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrocka1,
@@ -67927,13 +67854,6 @@
 /obj/landmark/join/late/cyborg,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
-"ntW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "ntX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -68151,6 +68071,17 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"nvP" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "nvR" = (
 /obj/structure/flora/small/trailrockb5,
 /obj/structure/flora/small/trailrocka1,
@@ -68324,15 +68255,6 @@
 "nxP" = (
 /turf/simulated/open,
 /area/nadezhda/engineering/engine_room)
-"nxT" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "nxX" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/fiction/littlewomen,
@@ -69404,6 +69326,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"nHv" = (
+/obj/effect/floor_decal/industrial/warningred,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "nHw" = (
 /obj/structure/salvageable/data,
 /turf/simulated/floor/bluegrid{
@@ -69449,6 +69376,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nHI" = (
+/obj/random/junk/cigbutt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "nIa" = (
 /obj/structure/flora/small/grassb4,
 /turf/unsimulated/wall/jungle,
@@ -70135,15 +70072,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
-"nOD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "nOG" = (
 /obj/machinery/light{
 	dir = 4
@@ -70170,17 +70098,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
-"nOQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "nOS" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
@@ -71840,13 +71757,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"oeN" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "oeR" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -72092,6 +72002,22 @@
 "ogV" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"ogZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/smartfridge/disk,
+/obj/item/computer_hardware/hard_drive/portable/design/logistics,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "ohb" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/structure/railing{
@@ -72165,6 +72091,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/merchant)
+"ohY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "lonestar_mailing2";
+	name = "Lonestar Mailing Room shutter control";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "ohZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72698,6 +72635,19 @@
 /obj/machinery/botany/extractor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"omt" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/disposal/deliveryChute,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "omv" = (
 /turf/simulated/wall/wood,
 /area/colony)
@@ -73216,21 +73166,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
-"orW" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
-"orY" = (
-/obj/machinery/conveyor/south{
-	id = "trash"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "osf" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -73641,6 +73576,14 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"ovX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "owa" = (
 /obj/structure/table/woodentable,
 /obj/item/folder,
@@ -74565,11 +74508,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"oEW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "oEX" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -74593,6 +74531,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"oFC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "oFI" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 4
@@ -74754,11 +74713,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"oHi" = (
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "oHo" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio3";
@@ -75688,6 +75642,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"oQy" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "oQz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75864,15 +75826,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
-"oSb" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "oSc" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -76051,6 +76004,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"oTC" = (
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred,
+/obj/machinery/autolathe,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "oTM" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -76106,14 +76069,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"oUx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "oUz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction{
@@ -76167,15 +76122,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"oUV" = (
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
+"oUY" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/engineering/engine_waste)
 "oVb" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/closet/l3closet/security,
@@ -76397,6 +76349,13 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"oWO" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "oWU" = (
 /obj/landmark/join/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76754,6 +76713,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"pap" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/low_wall,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/disposaldrop)
 "paC" = (
 /obj/item/contraband/poster/placed/recruitment/engineering,
 /turf/simulated/wall,
@@ -77180,13 +77147,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/atmos/surface)
-"peY" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "pfd" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/machinery/door/firedoor/multi_tile,
@@ -78196,20 +78156,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"ppr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "ppv" = (
 /obj/machinery/light,
 /obj/structure/catwalk,
@@ -79156,6 +79102,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
+"pyZ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "pzc" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/records,
@@ -79298,24 +79262,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"pAC" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "pAK" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -79665,16 +79611,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"pDH" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "pDL" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -80123,6 +80059,35 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"pJJ" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "pJK" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -80193,26 +80158,6 @@
 /obj/random/contraband,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/detectives_office)
-"pJZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "pKd" = (
 /obj/structure/table/steel,
 /obj/item/paper/crumpled,
@@ -80257,6 +80202,16 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"pKo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "pKp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -81054,6 +81009,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"pRt" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "pRx" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
@@ -81173,6 +81138,19 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"pSC" = (
+/obj/item/modular_computer/console/preset/trade{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warningred/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/quartermaster/hangarsupply)
 "pSF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82125,15 +82103,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"qby" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "qbG" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -82198,6 +82167,14 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qca" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "qcd" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/light/small,
@@ -82848,11 +82825,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/hallway/surface/section1)
-"qja" = (
-/obj/machinery/mech_recharger,
-/obj/mecha/working/ripley,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "qjb" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -82893,6 +82865,17 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/genetics)
+"qjp" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "qju" = (
 /obj/machinery/door/blast/regular/open{
 	id = "genetics1";
@@ -83076,17 +83059,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"qlf" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+"qla" = (
+/obj/effect/floor_decal/industrial/box/corners{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/sortjunction{
-	name = "Cargo - Sorting Office";
-	sortType = "Cargo - Sorting Office"
-	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/office)
 "qlg" = (
 /obj/structure/shuttle_part/science{
@@ -83211,24 +83188,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qmu" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/device/destTagger,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "qmz" = (
 /obj/machinery/door/holy{
 	name = "Church"
@@ -84026,6 +83985,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"qtQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "qtV" = (
 /obj/random/cluster/roaches_hoard,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -84072,17 +84036,6 @@
 "quF" = (
 /turf/simulated/mineral,
 /area/nadezhda/command/crematorium)
-"quH" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "quI" = (
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -84409,20 +84362,6 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
-"qxY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/conveyor_switch{
-	id = "deliveries"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "qyc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -84436,14 +84375,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
-"qyg" = (
-/obj/structure/low_wall,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/hangarsupply)
 "qyh" = (
 /obj/structure/flora/small/rock5,
 /obj/structure/flora/small/grassb3,
@@ -84891,6 +84822,15 @@
 /obj/item/ammo_casing/rocket/emp,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
+"qDe" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "qDf" = (
 /obj/structure/table/steel,
 /obj/item/pen,
@@ -85079,6 +85019,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qEQ" = (
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "qET" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -85537,6 +85486,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qIM" = (
+/obj/effect/floor_decal/industrial/box/corners,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "qIN" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -88117,6 +88070,26 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"rkX" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/folder/yellow,
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/device/scanner/price,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "rlb" = (
 /obj/machinery/body_scanconsole,
 /obj/effect/floor_decal/industrial/hatch,
@@ -88315,6 +88288,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"rmT" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "rmU" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "panicRoom";
@@ -88366,16 +88344,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
-"rnx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "rny" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -88660,22 +88628,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"rqq" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "rqu" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -88698,14 +88650,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"rqR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "rqU" = (
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
@@ -89475,6 +89419,23 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
+"ryZ" = (
+/obj/effect/floor_decal/industrial/warningred/corner{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "trash";
+	one_way = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/industrial/danger/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "rza" = (
 /obj/machinery/autolathe,
 /obj/structure/cable/green{
@@ -89869,12 +89830,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"rDp" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/engineering/engine_waste)
 "rDr" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -90607,13 +90562,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"rLL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/tagger{
-	sort_tag = "Cargo - Export"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "rLR" = (
 /obj/structure/invislight,
 /obj/structure/disposalpipe/segment{
@@ -92157,13 +92105,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory)
-"saw" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor/east{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "sax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/smoking/small{
@@ -92420,13 +92361,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"scF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "scH" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/plastic/random,
@@ -92447,6 +92381,15 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm1)
+"scX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "scY" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -92783,14 +92726,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
-"sgU" = (
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/corners,
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "sgY" = (
 /obj/item/toy/plushie/spider,
 /obj/effect/spider/stickyweb,
@@ -92803,11 +92738,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"shg" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/hangarsupply)
 "shh" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4;
@@ -92862,10 +92792,34 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/inside_colony)
+"shB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "shD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"shH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "shR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94056,6 +94010,19 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"stB" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	name = "Mailing Desk";
+	req_access = list(31)
+	},
+/obj/machinery/door/blast/shutters{
+	id = "lonestar_mailing";
+	name = "Mailing Desk Shutters"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "stI" = (
 /obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
@@ -95132,6 +95099,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"sDy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "sDz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -95194,6 +95166,14 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
+"sEc" = (
+/obj/machinery/smelter/cargo_t2_parts{
+	input_side = 8;
+	output_side = 4;
+	refuse_output_side = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "sEh" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -95528,10 +95508,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
-"sIg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "sIn" = (
 /obj/machinery/door/airlock/vault{
 	name = "Lonestar Vault";
@@ -96036,6 +96012,13 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/virology)
+"sNX" = (
+/obj/machinery/conveyor/southwest/ccw{
+	id = "trash"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "sOd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -96122,14 +96105,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"sOD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "sOE" = (
 /obj/machinery/door/airlock/maintenance_rnd{
 	req_access = list(5)
@@ -96412,6 +96387,14 @@
 /obj/item/gun/energy/concillium,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
+"sRA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "sRJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/morgue)
@@ -97386,16 +97369,6 @@
 /obj/item/spider_shadow_trap,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"tcp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/sortjunction{
-	name = "Cargo - Export";
-	sortType = "Cargo - Export"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "tcw" = (
 /obj/machinery/computer/shuttle_control/multi/vasiliy,
 /turf/simulated/shuttle/floor/science{
@@ -97571,6 +97544,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"tep" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "tes" = (
 /obj/structure/showcase{
 	desc = "Ancient robotic frame, that is long deactivated and rusted solid. However, it still strikes am awesome pose, that somehow makes you think of justice and righteousness.";
@@ -98011,9 +97990,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
-"tjO" = (
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "tjR" = (
 /obj/item/holder/cat/fluff/bones,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -99416,6 +99392,15 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/hallway/main/stairwell)
+"tyC" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "tyF" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots,
@@ -100194,6 +100179,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"tFZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "tGa" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -100887,6 +100879,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"tMS" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "tMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal,
@@ -101731,11 +101733,6 @@
 	opacity = 0
 	},
 /area/shuttle/surface_transport_lz)
-"tUn" = (
-/obj/effect/floor_decal/industrial/warningred/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "tUo" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/wall/wood_old,
@@ -102310,14 +102307,6 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/quartermaster/hangarsupply)
-"tZY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "uab" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 8
@@ -102345,6 +102334,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
+"uah" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "uar" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -103328,6 +103324,24 @@
 "ujg" = (
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/turret_protected/ai)
+"ujh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "ujo" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "14,10"
@@ -103367,6 +103381,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/barracks)
+"ujK" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "ujW" = (
 /obj/structure/table/reinforced,
 /obj/random/material_rare/low_chance,
@@ -104267,11 +104289,6 @@
 /obj/item/remains/unathi,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest)
-"usB" = (
-/obj/structure/table/rack,
-/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "usN" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "7,5"
@@ -105469,14 +105486,6 @@
 	icon_state = "2,1"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"uGQ" = (
-/obj/machinery/smelter/cargo_t2_parts{
-	input_side = 8;
-	output_side = 4;
-	refuse_output_side = 1
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "uGU" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -107156,20 +107165,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"uVg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "uVj" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -107692,6 +107687,19 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"vaJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
+	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "vaK" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -108189,6 +108197,15 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"vgh" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "vgm" = (
 /obj/structure/railing{
 	dir = 8
@@ -108837,14 +108854,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"vmk" = (
-/obj/structure/table/rack,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/science/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "vmn" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -109468,6 +109477,20 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"vta" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "vtb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/decal/cleanable/dirt,
@@ -110322,6 +110345,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"vCm" = (
+/obj/machinery/conveyor/southeast/ccw{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "vCo" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -110791,6 +110820,26 @@
 /obj/item/clothing/accessory/choker/gold_bell,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"vGY" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "vHj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -110845,17 +110894,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/hallways)
-"vHu" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "vHx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -112362,10 +112400,6 @@
 /obj/structure/flora/small/trailrocka1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"vVb" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/hangarsupply)
 "vVe" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -113324,6 +113358,13 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"wen" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "weo" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -113800,6 +113841,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"wjB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "wjP" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/wood/wild4,
@@ -115482,15 +115530,6 @@
 /obj/item/organ/internal/bone/l_leg,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wzW" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "wzY" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -115650,6 +115689,23 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"wBN" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "wBQ" = (
 /obj/machinery/light,
 /obj/structure/cable/green,
@@ -116103,12 +116159,6 @@
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/lakeside)
-"wGP" = (
-/obj/structure/sign/warning/moving_parts/small{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "wGV" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -116276,6 +116326,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"wIz" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "wID" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -116848,6 +116905,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"wOA" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "wOL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
@@ -117251,6 +117318,17 @@
 "wSD" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
+"wSP" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/item/trash/pistachios,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "wSR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -117299,19 +117377,6 @@
 /obj/structure/bed/chair/sofa/brown/right,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
-"wTo" = (
-/obj/item/modular_computer/console/preset/trade{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warningred/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/quartermaster/hangarsupply)
 "wTC" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -117458,6 +117523,14 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"wUY" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/corners,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -117672,6 +117745,14 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/absolutism/skyyard)
+"wWZ" = (
+/obj/structure/table/rack,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/science/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "wXb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -119694,15 +119775,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"xsR" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/disposaldrop)
 "xsU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -119981,15 +120053,6 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"xvD" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Cargo Bay";
-	req_one_access = list(50,48,26)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
 "xvE" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -120331,16 +120394,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
-"xyX" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "xzf" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light{
@@ -120849,17 +120902,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/pool)
-"xDD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "xDH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -121413,6 +121455,15 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"xIR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "xIT" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -121967,13 +122018,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"xOF" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "xOG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -122002,28 +122046,6 @@
 	},
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters)
-"xPi" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 8
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/hand_labeler,
-/obj/item/clipboard{
-	pixel_x = 6;
-	pixel_y = -12
-	},
-/obj/item/pen{
-	pixel_x = 6;
-	pixel_y = -11
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "xPq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/junk,
@@ -122799,22 +122821,6 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/engineering/engine_room)
-"xWJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/smartfridge/disk,
-/obj/item/computer_hardware/hard_drive/portable/design/logistics,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "xWK" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/light_switch{
@@ -123935,6 +123941,9 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"yjo" = (
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "yjw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -187916,10 +187925,10 @@ kFn
 kFn
 kFn
 kFn
-eUH
-add
-add
-lLH
+sNX
+cJw
+cJw
+vCm
 kFn
 cZb
 rWi
@@ -188115,13 +188124,13 @@ epk
 fyk
 cZb
 kFn
-kPl
-mYZ
-orY
-gPf
-vVb
-vVb
-saw
+gbV
+azB
+qEQ
+fVc
+agx
+agx
+uah
 kFn
 kFn
 rWi
@@ -188317,14 +188326,14 @@ llJ
 kFn
 kFn
 kFn
-qyg
-shg
-icF
-icF
-lbS
-tUn
-eCt
-eGD
+koR
+rmT
+nvP
+nvP
+ryZ
+afA
+clC
+ltl
 kFn
 kFn
 kFn
@@ -188523,8 +188532,8 @@ fjZ
 fjZ
 fjZ
 fjZ
-pDH
-oHi
+tMS
+nHv
 vYW
 vYW
 vYW
@@ -188708,7 +188717,7 @@ fyk
 fyk
 fyk
 fyk
-wGP
+llS
 fyk
 fyk
 fyk
@@ -188725,8 +188734,8 @@ fjZ
 fjZ
 fjZ
 fjZ
-wzW
-oHi
+bBw
+nHv
 vYW
 vYW
 vYW
@@ -188907,14 +188916,14 @@ bbM
 mln
 qvS
 gFl
-oUx
-dFR
-ifb
-oSb
-eRO
-eRO
-kEH
-oUV
+aCX
+omt
+iac
+gWF
+mnp
+mnp
+fRt
+hZW
 gFl
 ggO
 ggO
@@ -188927,7 +188936,7 @@ fjZ
 tTW
 fjZ
 dfz
-hwN
+pKo
 jsa
 hXC
 vYW
@@ -189109,19 +189118,19 @@ ybE
 mRV
 axX
 gFl
-mGL
-aIn
-qxY
-sIg
-iRZ
+ohY
+qtQ
+eWa
+hqx
+fNT
 saq
 gFl
-ldg
+pap
 gFl
 tkP
 pgF
 xBZ
-cWR
+gQy
 kFn
 jsa
 fjZ
@@ -189129,7 +189138,7 @@ fjZ
 fjZ
 fjZ
 fjZ
-hOy
+jot
 jsa
 vYW
 vYW
@@ -189310,20 +189319,20 @@ cPd
 hIx
 ydV
 whU
-lsg
-jqN
-peY
+inW
+tep
+oWO
 qcf
 syw
 rkj
 fsB
-aKA
+tyC
 cvM
 sVQ
 xBZ
 xBZ
 uZB
-mIH
+kKy
 kFn
 tZQ
 fjZ
@@ -189331,8 +189340,8 @@ fjZ
 nkT
 fjZ
 fjZ
-xWJ
-mCW
+ogZ
+oTC
 vYW
 vYW
 oLc
@@ -189510,22 +189519,22 @@ opg
 lJl
 cPd
 lnZ
-cOS
-nOD
-dkp
+hpM
+scX
+cev
 pFc
 lrJ
 eSx
 aJQ
 nTw
 ogT
-kis
+dHY
 cPg
 wcV
 wcV
 lea
 xBZ
-sgU
+wUY
 kFn
 wUm
 mgH
@@ -189533,7 +189542,7 @@ mgH
 mgH
 nOd
 tAY
-wTo
+pSC
 kFn
 jvw
 wnm
@@ -189712,22 +189721,22 @@ mcu
 oaq
 cPd
 gNJ
-mpQ
-dUx
-lHI
-gAH
-xyX
-fcD
-xPi
-qmu
+bMT
+fBE
+stB
+lWO
+edf
+dkA
+asA
+aCC
 sbX
-xsR
+aqP
 cRH
 xax
 blV
 lIS
-fWy
-giX
+qDe
+bkf
 kFn
 rln
 mft
@@ -189735,7 +189744,7 @@ nuS
 nuS
 obl
 mft
-jIM
+aBu
 xjs
 mft
 mft
@@ -189914,8 +189923,8 @@ mei
 btk
 cPd
 asW
-cid
-bdA
+wBN
+ujK
 ggO
 ggO
 ggO
@@ -189937,7 +189946,7 @@ nuS
 nuS
 bgW
 nuS
-aqq
+lkq
 ttk
 nuS
 nuS
@@ -190116,8 +190125,8 @@ qkJ
 wGi
 cPd
 gdi
-pAC
-nxT
+pyZ
+dHZ
 kGy
 iZX
 iWN
@@ -190139,7 +190148,7 @@ nuS
 nuS
 obl
 nuS
-aqq
+lkq
 mft
 nuS
 nuS
@@ -190318,8 +190327,8 @@ uag
 uag
 cPd
 cWM
-rqq
-qby
+ehh
+bzO
 eJi
 eUF
 tdr
@@ -190329,19 +190338,19 @@ xBZ
 xBZ
 lVE
 xkN
-kBW
-oEW
-mlk
-dpb
-oEW
-xvD
-rnx
-mdS
-mdS
-mdS
-lIP
-mdS
-rqR
+eGC
+sDy
+ltc
+pRt
+sDy
+iHb
+shB
+cva
+cva
+cva
+gLM
+cva
+ivE
 dFh
 mft
 mft
@@ -190520,8 +190529,8 @@ bbM
 bbM
 laP
 gtO
-dSc
-qby
+vGY
+bzO
 qWv
 xBZ
 eil
@@ -190531,8 +190540,8 @@ xBZ
 xBZ
 eNq
 ggO
-kog
-sOD
+mVd
+qca
 tek
 wWr
 dHk
@@ -190722,8 +190731,8 @@ iBR
 iBR
 uNp
 qTF
-abJ
-nOQ
+lKu
+hjI
 oix
 pPK
 iJc
@@ -190734,7 +190743,7 @@ xBZ
 xBZ
 khK
 jKq
-ntW
+wjB
 lfZ
 hwk
 pHK
@@ -190924,8 +190933,8 @@ whU
 bbM
 dXp
 fEV
-cGC
-cAD
+cuM
+sRA
 pyL
 tsp
 htt
@@ -190935,8 +190944,8 @@ fUT
 lLQ
 nkM
 tdq
-tcp
-qlf
+lux
+fLO
 eMb
 glW
 uZB
@@ -191138,9 +191147,9 @@ xjC
 yaY
 cQe
 iWF
-tZY
+ovX
 wzk
-pJZ
+dgP
 pKX
 fdN
 tFK
@@ -191340,9 +191349,9 @@ sLF
 ggO
 ggO
 gZK
-jKf
+rkX
 vVY
-eoK
+xIR
 xBZ
 nXr
 qoz
@@ -191540,9 +191549,9 @@ hGS
 hYm
 mLj
 ggO
-iVG
+apc
 xBZ
-bsc
+chk
 slD
 xBZ
 xBZ
@@ -191742,9 +191751,9 @@ fmD
 uqD
 ima
 ggO
-cCj
+mgo
 xBZ
-npx
+ehQ
 uWr
 xBZ
 pRU
@@ -191945,11 +191954,11 @@ rRT
 rir
 ggO
 ggO
-jmI
-scF
-scF
-scF
-dcL
+jdR
+tFZ
+tFZ
+tFZ
+cDO
 ieZ
 cNR
 xFh
@@ -192147,11 +192156,11 @@ dtp
 dLz
 ggO
 ggO
-mNT
-nmr
-orW
-hGP
-tjO
+dCo
+qIM
+dtX
+qla
+yjo
 ieZ
 ieZ
 ieZ
@@ -192350,9 +192359,9 @@ jZn
 ggO
 ggO
 ggO
-usB
-qja
-vmk
+dls
+hxB
+wWZ
 ggO
 bpF
 bpF
@@ -192373,9 +192382,9 @@ dUM
 qag
 hrP
 tip
-quH
+qjp
 rSI
-lGK
+jkF
 hgO
 hgO
 nEC
@@ -192575,11 +192584,11 @@ tyv
 hrP
 hrP
 tip
-bZh
+wIz
 nEC
-jpQ
-bcz
-dgQ
+vaJ
+oFC
+fFv
 nEC
 tip
 cZb
@@ -192779,7 +192788,7 @@ xOl
 jBC
 uMg
 jIn
-jdB
+wOA
 sFu
 hyM
 lEl
@@ -192977,9 +192986,9 @@ dZI
 jmv
 jdr
 kfg
-xDD
+iPm
 tip
-kBa
+lJk
 hgO
 kGt
 jYT
@@ -193184,8 +193193,8 @@ sOw
 sVn
 hgO
 hFX
-fOx
-inn
+afk
+wSP
 wNc
 tip
 cZb
@@ -193386,8 +193395,8 @@ sOw
 sVn
 hgO
 odF
-xOF
-vHu
+cik
+ajw
 cXt
 tip
 cZb
@@ -193587,9 +193596,9 @@ ecn
 sOw
 sVn
 hgO
-dfi
-uGQ
-fdE
+joL
+sEc
+nHI
 nEC
 tip
 cZb
@@ -193785,11 +193794,11 @@ hLP
 iHG
 jdr
 gOA
-ppr
-rDp
-mLw
-rLL
-jkv
+vta
+oUY
+kuH
+hzG
+vgh
 jYT
 nuH
 nEC
@@ -193987,13 +193996,13 @@ wVo
 lJZ
 kqf
 gOA
-imL
+ujh
 tip
 eWe
 hgO
-cKA
-lKZ
-oeN
+oQy
+dCw
+wen
 nyB
 ikn
 tip
@@ -194186,10 +194195,10 @@ pcX
 dOp
 nbC
 kjH
-giP
-uVg
-gXw
-fxq
+pJJ
+shH
+dnI
+eUI
 tip
 gpu
 rVb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -15,9 +15,9 @@
 /area/nadezhda/medical/genetics)
 "aae" = (
 /obj/machinery/door/airlock/mining{
+	id_tag = "foremandoor";
 	name = "Foreman Quarters";
-	req_access = list(79);
-	id_tag = "foremandoor"
+	req_access = list(79)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -71,14 +71,14 @@
 /area/nadezhda/pros/prep)
 "aaN" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = 24;
 	frequency = 1380;
 	id_tag = "vasiliy_dokuchaev_shuttle1";
-	tag_exterior_door = "research_shuttle_outer_back";
-	tag_interior_door = "research_shuttle_inner_back";
+	pixel_y = 24;
 	req_access = list(13);
 	tag_airpump = "research_shuttle_pump_back";
-	tag_chamber_sensor = "research_shuttle_sensor_back"
+	tag_chamber_sensor = "research_shuttle_sensor_back";
+	tag_exterior_door = "research_shuttle_outer_back";
+	tag_interior_door = "research_shuttle_inner_back"
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
@@ -180,6 +180,26 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
+"abJ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "abW" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
@@ -292,6 +312,12 @@
 /obj/item/rig/medical/equipped,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/sleeper)
+"add" = (
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "adg" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
@@ -492,13 +518,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"afk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "afr" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -683,9 +702,9 @@
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "ahu" = (
 /obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 25;
+	layer = 4.2;
 	pixel_x = -13;
-	layer = 4.2
+	pixel_y = 25
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
@@ -1552,6 +1571,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"aqq" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "aqr" = (
 /obj/structure/table/glass,
 /obj/random/powercell,
@@ -2860,8 +2886,8 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology)
@@ -3362,6 +3388,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/secrecroom)
+"aIn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "aIv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3517,6 +3548,15 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
+"aKA" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "aKG" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -3639,13 +3679,13 @@
 /area/nadezhda/rnd/rbreakroom)
 "aLR" = (
 /obj/machinery/door/airlock/multi_tile/metal{
+	dir = 1;
 	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "research_shuttle_outer";
 	locked = 1;
 	name = "Vasiliy Dokuchaev External Access";
-	req_access = list(13);
-	dir = 1
+	req_access = list(13)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "4,11"
@@ -3857,8 +3897,8 @@
 "aOb" = (
 /obj/item/farmbot_arm_assembly{
 	created_name = "GardenBot";
-	name = "Replacement Gardener - water tank/robot arm assembly";
-	desc = "A water tank with a robot arm permanently grafted to it. Looks like its only one set away from making all the gardenerds unemployed."
+	desc = "A water tank with a robot arm permanently grafted to it. Looks like its only one set away from making all the gardenerds unemployed.";
+	name = "Replacement Gardener - water tank/robot arm assembly"
 	},
 /obj/item/device/assembly/prox_sensor,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -4482,17 +4522,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"aWk" = (
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "aWq" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -5101,6 +5130,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/sec)
+"bcz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "bcF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5193,6 +5243,14 @@
 /obj/machinery/atm{
 	dir = 8;
 	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
+"bdA" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -5494,13 +5552,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"bgl" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "bgB" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -5578,10 +5629,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"bht" = (
-/obj/machinery/autolathe,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "bhu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6047,7 +6094,7 @@
 	input_tag = "air_in";
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -6639,6 +6686,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfacesec)
+"bsc" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stack/cable_coil/random,
+/obj/item/tool/screwdriver,
+/obj/item/stack/material/steel/random,
+/obj/item/stack/material/steel/random,
+/obj/item/stack/material/steel/random,
+/obj/item/circuitboard/vending,
+/obj/item/circuitboard/vending,
+/obj/item/circuitboard/vending,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "bsf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/wood{
@@ -6979,9 +7049,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
+	id_tag = "psychcell1";
 	name = "Cell 1";
-	req_access = list(64);
-	id_tag = "psychcell1"
+	req_access = list(64)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8500,8 +8570,8 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "bKS" = (
 /obj/structure/window/reinforced{
-	pixel_x = -3;
-	dir = 8
+	dir = 8;
+	pixel_x = -3
 	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -8862,11 +8932,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/swo/quarters)
-"bPn" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "bPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/medical,
@@ -9229,9 +9294,9 @@
 "bUs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/command{
+	id_tag = "ceodoor";
 	name = "Surface Operations Manager's Office";
-	req_access = list(41);
-	id_tag = "ceodoor"
+	req_access = list(41)
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
@@ -9395,34 +9460,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"bVF" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "bVG" = (
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/stand_clear/red,
@@ -9738,6 +9775,13 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"bZh" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "bZi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -9923,8 +9967,8 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OPlus,
 /obj/structure/closet/secure_closet/freezer/blood{
-	req_access = list(45);
-	name = "secure blood fridge"
+	name = "secure blood fridge";
+	req_access = list(45)
 	},
 /obj/item/storage/freezer,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -10114,8 +10158,8 @@
 	pixel_x = -30
 	},
 /obj/structure/window/reinforced{
-	pixel_x = -3;
-	dir = 1
+	dir = 1;
+	pixel_x = -3
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
@@ -10561,6 +10605,23 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"cid" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "cig" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -10726,8 +10787,8 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/item/stamp/warden{
-	pixel_y = 12;
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 12
 	},
 /obj/item/paper_bin{
 	pixel_y = -3
@@ -11219,21 +11280,21 @@
 "cph" = (
 /obj/structure/table/woodentable,
 /obj/machinery/button/remote/airlock{
-	pixel_x = -2;
-	pixel_y = 7;
+	dir = 4;
 	id = "premierdoor";
 	name = "Premier Door Open Control";
-	dir = 4;
+	pixel_x = -2;
+	pixel_y = 7;
 	req_access = list(20)
 	},
 /obj/machinery/button/remote/airlock{
-	pixel_x = -2;
-	pixel_y = -6;
+	dir = 4;
 	id = "premierdoor";
 	name = "Premier Door Bolt Control";
-	dir = 4;
-	specialfunctions = 4;
-	req_access = list(20)
+	pixel_x = -2;
+	pixel_y = -6;
+	req_access = list(20);
+	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/command/captain/quarters)
@@ -11600,13 +11661,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
-"csU" = (
-/obj/machinery/conveyor/north{
-	id = "disposals upper";
-	operating = 1
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "csV" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
@@ -12288,6 +12342,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"cAD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "cAF" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -12455,10 +12517,14 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/chemistry)
 "cCj" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/disposaldrop)
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "cCl" = (
 /obj/structure/sign/security/court{
 	pixel_x = -16;
@@ -12933,6 +12999,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
+"cGC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction/untagged/flipped,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "cGH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -13318,6 +13404,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"cKA" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "cKJ" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -13760,6 +13854,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"cOS" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "cOU" = (
 /obj/machinery/door/unpowered/simple/wood/saloon,
 /obj/machinery/door/firedoor,
@@ -13991,7 +14100,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -14514,19 +14623,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/triage_blackshield)
-"cWi" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 2;
-	name = "Cargo - Sorting Office";
-	sortType = "Cargo - Sorting Office"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "cWk" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/closet/crate/plastic,
@@ -14584,6 +14680,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"cWR" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "cWS" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/structure/disposalpipe/segment,
@@ -14969,8 +15075,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	operating = 0
+	operating = 0;
+	pixel_x = 28
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -15126,6 +15232,42 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai)
+"dcL" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/random/contraband/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lathe_disk/low_chance,
+/obj/random/material_resources/low_chance,
+/obj/random/medical/low_chance,
+/obj/random/melee/low_chance,
+/obj/random/rig_module/rare/low_chance,
+/obj/random/rig_module/low_chance,
+/obj/random/rig/low_chance,
+/obj/random/rations/low_chance,
+/obj/random/voidsuit/low_chance,
+/obj/random/toolbox/low_chance,
+/obj/random/tool/advanced/low_chance,
+/obj/random/tool_upgrade/rare/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/techpart/low_chance,
+/obj/random/tank/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "dcQ" = (
 /obj/machinery/optable,
 /obj/machinery/light{
@@ -15392,6 +15534,11 @@
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
+"dfi" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "dfq" = (
 /obj/structure/cable/cyan{
 	d1 = 16;
@@ -15542,6 +15689,13 @@
 /obj/random/gun_energy_cheap,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"dgQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "dgS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15846,16 +16000,6 @@
 "djy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/hut_cell1)
-"djG" = (
-/obj/structure/bookcase{
-	desc = "A wooden shelving unit used for storing all sorts of literature and logs.";
-	name = "Receiver Beacon Log Case"
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "djJ" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/carpet/bcarpet,
@@ -15882,8 +16026,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/item/clothing/head/rank/first_officer{
-	pixel_y = 9;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 9
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -15891,6 +16035,16 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"dkp" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "dkt" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -16094,21 +16248,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"dmD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
-/obj/structure/sign/warning/moving_parts/small{
-	dir = 8;
-	pixel_x = 12
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "dmF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16307,17 +16446,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/organ_lab)
-"doD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "doE" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -16375,6 +16503,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"dpb" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "dpc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -17696,14 +17834,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
-"dBO" = (
-/obj/structure/bookcase{
-	desc = "A wooden shelving unit used for storing all sorts of literature and logs.";
-	name = "Sender Beacon Log Case"
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "dBU" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -18127,6 +18257,19 @@
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/hunter_cabin)
+"dFR" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/disposal/deliveryChute,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "dFS" = (
 /obj/effect/spider/stickyweb,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -18339,21 +18482,6 @@
 	icon_state = "7,10"
 	},
 /area/nadezhda/engineering/engine_room)
-"dIo" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "dIp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19324,6 +19452,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
+"dSc" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "dSd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -19553,6 +19701,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dUx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "dUD" = (
 /obj/random/junkfood/onlycake,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -20689,9 +20844,9 @@
 	id_tag = "research_shuttle_pump_back"
 	},
 /obj/machinery/airlock_sensor{
-	pixel_x = -25;
 	frequency = 1380;
-	id_tag = "research_shuttle_sensor_back"
+	id_tag = "research_shuttle_sensor_back";
+	pixel_x = -25
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,8"
@@ -21366,8 +21521,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/wall_obelisk/silver{
-	pixel_y = -10;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = -10
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -21381,9 +21536,9 @@
 /area/nadezhda/security/hut_cell1)
 "enj" = (
 /obj/machinery/door/airlock/command{
+	id_tag = "premierdoor";
 	name = "Premier Office";
-	req_access = list(20);
-	id_tag = "premierdoor"
+	req_access = list(20)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -21480,13 +21635,13 @@
 /obj/structure/curtain/open/privacy,
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = -32;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -32
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_y = -32;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -32
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white/cargo,
@@ -21601,6 +21756,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"eoK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "eoM" = (
 /obj/structure/catwalk,
 /obj/machinery/firealarm{
@@ -21685,8 +21849,8 @@
 "epG" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/regular{
-	id = "ProspShop";
-	dir = 4
+	dir = 4;
+	id = "ProspShop"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/pros/prep)
@@ -22733,12 +22897,12 @@
 /area/nadezhda/hallway/side/f2section1)
 "ezY" = (
 /mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "crimson viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm.";
 	color = "#f7140c";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm.";
+	faction = "neutral";
+	health = 250;
 	maxHealth = 250;
-	health = 250
+	name = "crimson viper"
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest)
@@ -22942,6 +23106,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"eCt" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "eCy" = (
 /obj/structure/table/standard,
 /obj/item/gun/projectile/colt/ten{
@@ -23281,6 +23452,15 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"eGD" = (
+/obj/structure/table/rack/shelf,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "eGG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -23855,17 +24035,6 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"eMM" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "eMN" = (
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -24540,6 +24709,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"eRO" = (
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "eRP" = (
 /obj/structure/flora/small/grassa3,
 /turf/simulated/floor/asteroid/grass,
@@ -24728,6 +24903,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"eUH" = (
+/obj/machinery/conveyor/southwest/ccw{
+	id = "trash"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "eUJ" = (
 /obj/structure/table/woodentable,
 /obj/structure/sign/security/court{
@@ -24898,10 +25080,10 @@
 	},
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
-	pixel_x = -32;
 	id = "researchlockdown";
-	pixel_y = 8;
-	name = "Research Lockdown"
+	name = "Research Lockdown";
+	pixel_x = -32;
+	pixel_y = 8
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
@@ -25562,6 +25744,9 @@
 /obj/random/mob/roaches,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"fcD" = (
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "fcF" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/nonfiction/thescienceofright,
@@ -25615,6 +25800,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"fdE" = (
+/obj/random/junk/cigbutt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "fdG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -25630,9 +25825,9 @@
 /area/nadezhda/engineering/engine_room)
 "fdN" = (
 /obj/machinery/door/airlock/command{
+	id_tag = "ceodoor";
 	name = "Surface Operations Manager's Office";
-	req_access = list(41);
-	id_tag = "ceodoor"
+	req_access = list(41)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25669,9 +25864,9 @@
 "fed" = (
 /obj/effect/overlay/water,
 /obj/structure/flora/ausbushes/reedbush{
+	layer = 4.2;
 	pixel_x = 6;
-	pixel_y = 18;
-	layer = 4.2
+	pixel_y = 18
 	},
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/shallow,
@@ -26865,8 +27060,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	operating = 0
+	operating = 0;
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -27346,17 +27541,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"fuM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "fuO" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/dirt,
@@ -27406,8 +27590,8 @@
 	dir = 8
 	},
 /obj/structure/mirror{
-	pixel_x = 28;
-	icon_state = "mirror_broke"
+	icon_state = "mirror_broke";
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
@@ -27605,6 +27789,20 @@
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"fxq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "fxv" = (
 /obj/structure/railing{
 	dir = 8
@@ -27963,14 +28161,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"fBm" = (
-/obj/machinery/conveyor/northeast{
-	id = "disposals upper";
-	operating = 1
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "fBt" = (
 /obj/structure/window/basic{
 	dir = 8
@@ -28107,29 +28297,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"fCE" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/device/scanner/price,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "fCM" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/traps,
@@ -29197,6 +29364,13 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"fOx" = (
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/obj/machinery/pile_ripper,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "fOK" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/cyan{
@@ -29651,20 +29825,20 @@
 /obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger/wallcharger{
-	pixel_y = 5;
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = 5
 	},
 /obj/machinery/recharger/wallcharger{
-	pixel_y = -6;
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = -6
 	},
 /obj/machinery/recharger{
 	pixel_x = -5;
 	pixel_y = 3
 	},
 /obj/machinery/recharger{
-	pixel_y = 3;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
@@ -29767,8 +29941,8 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OPlus,
 /obj/structure/closet/secure_closet/freezer/blood{
-	req_access = list(45);
-	name = "secure blood fridge"
+	name = "secure blood fridge";
+	req_access = list(45)
 	},
 /obj/item/storage/freezer,
 /turf/simulated/floor/tiled/white/monofloor,
@@ -29860,6 +30034,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/teleporter)
+"fWy" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "fWA" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/cable/green{
@@ -30348,10 +30531,6 @@
 /mob/living/carbon/superior_animal/giant_spider/plasma,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"gbq" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/office)
 "gbs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31195,6 +31374,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"giP" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "giR" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 10
@@ -31223,6 +31431,13 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"giX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "gjm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/autolathe/mechfab/loaded,
@@ -31755,9 +31970,9 @@
 /area/nadezhda/engineering/atmos)
 "goL" = (
 /obj/machinery/door/airlock/command{
+	id_tag = "cbodoor";
 	name = "CBO's Office";
-	req_access = list(40);
-	id_tag = "cbodoor"
+	req_access = list(40)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32102,29 +32317,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"grl" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "grr" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/small/busha3,
@@ -32504,17 +32696,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"guQ" = (
-/obj/machinery/conveyor/north{
-	id = "disposals upper";
-	operating = 1
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "guU" = (
 /obj/machinery/microwave,
 /obj/structure/table/marble,
@@ -33059,6 +33240,16 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"gAH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "lonestar_mailing";
+	name = "Lonestar Mailing Room shutter control";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "gAK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -33199,7 +33390,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -34295,6 +34486,12 @@
 /obj/structure/noticeboard/anomaly,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
+"gPf" = (
+/obj/machinery/conveyor/southwest{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "gPg" = (
 /obj/structure/toilet{
 	dir = 4
@@ -34513,8 +34710,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/lab)
@@ -35215,6 +35412,19 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
+"gXw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "gXz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -35377,10 +35587,10 @@
 /area/shuttle/surface_transport_lz)
 "gZU" = (
 /obj/machinery/button/remote/blast_door{
-	pixel_y = 4;
-	pixel_x = -8;
 	id = "checkpointlockdown";
-	name = "Checkpoint Lockdown"
+	name = "Checkpoint Lockdown";
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/maingate)
@@ -36036,8 +36246,8 @@
 "hgB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
-	pixel_x = -3;
-	dir = 8
+	dir = 8;
+	pixel_x = -3
 	},
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -36464,19 +36674,19 @@
 /obj/item/stamp/ce,
 /obj/item/modular_computer/tablet/lease/preset/command,
 /obj/machinery/button/remote/airlock{
-	pixel_x = 6;
-	pixel_y = 5;
 	id = "gmdoor";
 	name = "GM Door Open Control";
+	pixel_x = 6;
+	pixel_y = 5;
 	req_access = list(19)
 	},
 /obj/machinery/button/remote/airlock{
-	pixel_x = -6;
-	pixel_y = 5;
 	id = "gmdoor";
 	name = "GM Door Bolt Control";
-	specialfunctions = 4;
-	req_access = list(19)
+	pixel_x = -6;
+	pixel_y = 5;
+	req_access = list(19);
+	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/command/gmaster)
@@ -37537,6 +37747,16 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"hwN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "hwY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -37667,27 +37887,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/hallway/surface/section1)
-"hyp" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "hyq" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush3,
@@ -38643,6 +38842,12 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
+"hGP" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "hGR" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "12,1"
@@ -39565,6 +39770,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"hOy" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "hOz" = (
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 1
@@ -40412,14 +40630,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"hXW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "hXY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40740,16 +40950,12 @@
 	},
 /obj/random/furniture/pottedplant,
 /obj/structure/sign/departmentold/science/small{
-	pixel_x = 32;
-	name = "TELESCIENCE"
+	name = "TELESCIENCE";
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"iau" = (
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "iaw" = (
 /obj/item/bedsheet/clown,
 /obj/structure/bed/padded,
@@ -40982,6 +41188,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"icF" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "icL" = (
 /obj/machinery/light{
 	dir = 1
@@ -41212,14 +41426,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/bar)
-"ieK" = (
-/obj/machinery/conveyor/north{
-	id = "disposals upper";
-	operating = 1
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "ieQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -41257,6 +41463,16 @@
 "ieZ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/merchant)
+"ifb" = (
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = -32
+	},
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "ifd" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -42010,6 +42226,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"imL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "imM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -42089,6 +42323,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"inn" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/item/trash/pistachios,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "inu" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
@@ -43107,15 +43352,15 @@
 	dir = 8
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = -1;
 	frequency = 1380;
 	id_tag = "vasiliy_dokuchaev_shuttle1";
-	tag_exterior_door = "research_shuttle_outer_back";
-	tag_interior_door = "research_shuttle_inner_back";
+	pixel_x = -25;
+	pixel_y = -1;
 	req_access = list(13);
 	tag_airpump = "research_shuttle_pump_back";
 	tag_chamber_sensor = "research_shuttle_sensor_back";
-	pixel_x = -25
+	tag_exterior_door = "research_shuttle_outer_back";
+	tag_interior_door = "research_shuttle_inner_back"
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,8"
@@ -44328,25 +44573,6 @@
 /obj/item/folder/black,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/crew_quarters/hydroponics)
-"iLJ" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "iLR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -44921,16 +45147,6 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"iRP" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	pixel_y = -7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "iRT" = (
 /obj/structure/spider_nest,
 /obj/effect/decal/cleanable/dirt,
@@ -44947,6 +45163,24 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"iRZ" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "iSj" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -45126,15 +45360,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
-"iUt" = (
-/obj/structure/closet/crate/trashcart,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "iUu" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder/up,
@@ -45263,6 +45488,16 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"iVG" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/material_resources/low_chance,
+/obj/random/powercell/small_safe_lonestar,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "iVJ" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -45998,6 +46233,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
+"jdB" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "jdE" = (
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -46678,6 +46923,15 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
+"jkv" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "jkx" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/dirt,
@@ -46903,6 +47157,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"jmI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "jmM" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -47060,15 +47325,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
-"jnV" = (
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "jnW" = (
 /obj/structure/sign/department/bar,
 /turf/simulated/wall/r_wall,
@@ -47282,6 +47538,19 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/janitor)
+"jpQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
+	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "jpT" = (
 /obj/structure/invislight,
 /obj/structure/boulder,
@@ -47322,6 +47591,12 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
+"jqN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "jqO" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -47375,29 +47650,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"jro" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "jrq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -47877,10 +48129,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
-"jvo" = (
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "jvp" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
@@ -48291,21 +48539,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
-"jAl" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "jAm" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,13"
@@ -48965,32 +49198,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/kitchen)
-"jHK" = (
-/obj/machinery/button/remote/blast_door{
-	id = "lonestar_lobby";
-	name = "Lonestar Lobby shutter control";
-	pixel_y = 32
-	},
-/obj/structure/table/standard,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/device/scanner/price,
-/obj/item/stamp/denied,
-/obj/item/stamp,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "jHL" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -49081,6 +49288,14 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
+"jIM" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "jIQ" = (
 /obj/structure/railing/grey,
 /obj/structure/flora/small/grassb2,
@@ -49195,6 +49410,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jKf" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/folder/yellow,
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/device/scanner/price,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "jKi" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushc1,
@@ -49208,8 +49443,8 @@
 "jKn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /obj/machinery/door/airlock/glass_research{
 	name = "Research and Development";
@@ -49371,16 +49606,6 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/sleeper)
-"jMi" = (
-/obj/machinery/conveyor/south{
-	id = "deliveries"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "jMj" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush2,
@@ -49739,10 +49964,6 @@
 	icon_state = "2,6"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"jPx" = (
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/engine_waste)
 "jPz" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -50515,8 +50736,8 @@
 /obj/machinery/button/remote/blast_door{
 	id = "fencelockdown";
 	name = "section shutters";
-	pixel_y = -28;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -28
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -50632,9 +50853,9 @@
 	},
 /obj/machinery/button/remote/airlock{
 	id = "mcshutters";
-	req_access = list(58);
+	name = "Shutters Control";
 	pixel_y = 25;
-	name = "Shutters Control"
+	req_access = list(58)
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
@@ -50857,8 +51078,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/command/teleporter)
@@ -51435,39 +51656,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"khh" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/random/contraband/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lathe_disk/low_chance,
-/obj/random/material_resources/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/melee/low_chance,
-/obj/random/rig_module/rare/low_chance,
-/obj/random/rig_module/low_chance,
-/obj/random/rig/low_chance,
-/obj/random/rations/low_chance,
-/obj/random/voidsuit/low_chance,
-/obj/random/toolbox/low_chance,
-/obj/random/tool/advanced/low_chance,
-/obj/random/tool_upgrade/rare/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/techpart/low_chance,
-/obj/random/tank/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "kho" = (
 /obj/random/tool/advanced,
 /obj/effect/spider/stickyweb,
@@ -51574,6 +51762,17 @@
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
+"kis" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "kit" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -52107,6 +52306,31 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
+"kog" = (
+/obj/machinery/button/remote/blast_door{
+	id = "lonestar_lobby";
+	name = "Lonestar Lobby shutter control";
+	pixel_y = 32
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/device/scanner/price,
+/obj/item/stamp/denied,
+/obj/item/stamp,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "koh" = (
 /obj/structure/boulder,
 /obj/structure/cable/cyan{
@@ -52502,8 +52726,8 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
@@ -53476,6 +53700,24 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/prisoncells)
+"kBa" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "kBc" = (
 /obj/structure/table/rack/shelf,
 /obj/random/scrap/beacon,
@@ -53535,6 +53777,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"kBW" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/landmark/join/start/cargo_tech,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "kCh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -53805,6 +54058,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"kEH" = (
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "kEJ" = (
 /obj/structure/table/steel,
 /obj/random/common_oddities/low_chance,
@@ -54214,16 +54474,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kKF" = (
-/obj/item/modular_computer/console/preset/trade{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warningred/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/quartermaster/hangarsupply)
 "kKG" = (
 /obj/structure/sink{
 	pixel_y = -22
@@ -54505,14 +54755,6 @@
 "kOj" = (
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"kOq" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Cargo Bay";
-	req_one_access = list(50,48,26)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
 "kOv" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/hatch,
@@ -54557,22 +54799,6 @@
 "kOR" = (
 /turf/simulated/wall,
 /area/nadezhda/maintenance/surfacesec)
-"kOY" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/corners,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "kOZ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -54627,6 +54853,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
+"kPl" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "kPp" = (
 /obj/structure/bed{
 	dir = 4
@@ -55557,7 +55790,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -55678,6 +55911,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"lbS" = (
+/obj/effect/floor_decal/industrial/warningred/corner{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "trash";
+	one_way = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "lbT" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -55768,29 +56015,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"lcK" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "lcQ" = (
 /obj/item/modular_computer/console/preset/medical/monitor{
 	dir = 4
@@ -56020,7 +56244,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -57079,6 +57303,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"lsg" = (
+/obj/structure/plasticflaps,
+/obj/machinery/door/blast/shutters{
+	closed_layer = 4.2;
+	id = "lonestar_mailing2";
+	layer = 4.2;
+	name = "Mailing Shutters"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Mailing Room";
+	req_access = list(31)
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "lsk" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/phone,
@@ -57448,13 +57686,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"lvT" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/machinery/recycler,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "lvU" = (
 /obj/machinery/genetics/cloner,
 /obj/structure/disposalpipe/trunk{
@@ -57541,14 +57772,6 @@
 	icon_state = "15,4"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"lxb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "lxe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -57654,21 +57877,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"lyy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "lyz" = (
 /obj/machinery/button/remote/blast_door{
 	id = "genetics1";
@@ -58355,16 +58563,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/rock,
 /area/colony)
-"lFQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "lGe" = (
 /obj/effect/floor_decal/industrial/loading/red,
 /obj/landmark/join/start/roboticist,
@@ -58432,6 +58630,11 @@
 "lGy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/cryo)
+"lGK" = (
+/obj/machinery/newscaster/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "lGO" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
@@ -58522,6 +58725,19 @@
 /obj/machinery/vending/engineering,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
+"lHI" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	name = "Mailing Desk";
+	req_access = list(31)
+	},
+/obj/machinery/door/blast/shutters{
+	id = "lonestar_mailing";
+	name = "Mailing Desk Shutters"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "lHL" = (
 /obj/machinery/camera/network/research{
 	dir = 4
@@ -58645,6 +58861,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lIP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "lIS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58879,6 +59103,16 @@
 /mob/living/simple_animal/hostile/diyaab,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"lKZ" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/engine_waste)
 "lLf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -58894,6 +59128,12 @@
 /obj/random/mob/spiders,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"lLH" = (
+/obj/machinery/conveyor/southeast/ccw{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "lLM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush2,
@@ -60035,13 +60275,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"lXx" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "lXy" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing,
@@ -60618,6 +60851,11 @@
 /obj/structure/flora/big/rocks3,
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
+"mdS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "mdX" = (
 /obj/effect/spider/stickyweb,
 /obj/random/scrap/dense_weighted,
@@ -61319,16 +61557,6 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/crew_quarters/hydroponics)
-"mju" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Disposals";
-	req_one_access = list(50,48,26)
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "mjE" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/disposalpipe/segment,
@@ -61486,6 +61714,21 @@
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
+"mlk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "mln" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -61923,6 +62166,21 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"mpQ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "mpR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -62188,15 +62446,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"msC" = (
-/obj/item/computer_hardware/hard_drive/portable/design/logistics,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/machinery/smartfridge/disk,
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "msD" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -62933,8 +63182,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	operating = 0
+	operating = 0;
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacesec)
@@ -63093,9 +63342,9 @@
 /area/nadezhda/security/maingate/east)
 "mBL" = (
 /obj/structure/flora/ausbushes/reedbush{
+	layer = 4.2;
 	pixel_x = 6;
-	pixel_y = 18;
-	layer = 4.2
+	pixel_y = 18
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
@@ -63202,18 +63451,16 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"mCU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+"mCW" = (
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred,
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
+/area/nadezhda/quartermaster/hangarsupply)
 "mCX" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Artificer Power Substation";
@@ -63639,6 +63886,17 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate)
+"mGL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "lonestar_mailing2";
+	name = "Lonestar Mailing Room shutter control";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "mGO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -63842,6 +64100,15 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"mIH" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "mIJ" = (
 /obj/structure/table/standard,
 /obj/item/virusdish/random,
@@ -64111,6 +64378,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/sleeper)
+"mLw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "mLx" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donkpockets,
@@ -64289,6 +64569,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"mNT" = (
+/obj/structure/table/rack/shelf,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "mNU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -64897,23 +65185,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"mTJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "mTT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/colony)
-"mTV" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "mTW" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/suit/space/void/odst/corps,
@@ -65407,16 +65682,16 @@
 	dir = 8;
 	id = "crodoor";
 	name = "CRO Door Bolt Control";
+	pixel_y = -10;
 	req_access = list(30);
-	specialfunctions = 4;
-	pixel_y = -10
+	specialfunctions = 4
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 8;
 	id = "crodoor";
 	name = "CRO Door Open Control";
-	req_access = list(30);
-	pixel_y = 7
+	pixel_y = 7;
+	req_access = list(30)
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65438,6 +65713,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/crew_quarters/toilet/public)
+"mYZ" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "mZb" = (
 /obj/machinery/alarm{
 	desc = "This one has no access lock to allow for the vents to be turned on and off when needed.";
@@ -65750,9 +66032,9 @@
 /area/nadezhda/outside/forest)
 "nby" = (
 /obj/machinery/door/airlock/glass_command{
+	id_tag = "gmdoor";
 	name = "Guild Masters Office";
-	req_access = list(19);
-	id_tag = "gmdoor"
+	req_access = list(19)
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -65816,16 +66098,6 @@
 /obj/structure/crematorium,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/crematorium)
-"nbN" = (
-/obj/vehicle/train/cargo/trolley,
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "nbO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -66231,14 +66503,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"ngc" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/item/trash/pistachios,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "nge" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment{
@@ -66430,8 +66694,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/lab)
@@ -66848,6 +67112,10 @@
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"nmr" = (
+/obj/effect/floor_decal/industrial/box/corners,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "nmv" = (
 /obj/machinery/light{
 	dir = 8
@@ -66868,14 +67136,6 @@
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"nmL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/north,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "nmR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -67133,6 +67393,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"npx" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "npy" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrocka1,
@@ -67657,6 +67927,13 @@
 /obj/landmark/join/late/cyborg,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
+"ntW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "ntX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -67683,8 +67960,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	operating = 0
+	operating = 0;
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan,
 /turf/simulated/floor/tiled/techmaint,
@@ -67702,8 +67979,8 @@
 "nut" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/smoking/small{
-	pixel_y = -30;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = -30
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
@@ -67904,12 +68181,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
-"nwk" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "nwq" = (
 /obj/item/organ/internal/bone/head{
 	pixel_y = -5
@@ -68053,6 +68324,15 @@
 "nxP" = (
 /turf/simulated/open,
 /area/nadezhda/engineering/engine_room)
+"nxT" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "nxX" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/fiction/littlewomen,
@@ -68346,17 +68626,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/medical/morgue)
-"nAt" = (
-/obj/machinery/conveyor/south{
-	id = "deliveries"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "nAG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -68559,21 +68828,21 @@
 "nCu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/airlock{
+	id = "psychcell3";
 	name = "Cell 3 Door Bolts";
-	pixel_y = -5;
-	id = "psychcell3"
+	pixel_y = -5
 	},
 /obj/machinery/button/remote/airlock{
+	id = "psychcell2";
 	name = "Cell 2 Door Bolts";
-	pixel_y = 6;
 	pixel_x = 6;
-	id = "psychcell2"
+	pixel_y = 6
 	},
 /obj/machinery/button/remote/airlock{
+	id = "psychcell1";
 	name = "Cell 1 Door Bolts";
-	pixel_y = 6;
 	pixel_x = -6;
-	id = "psychcell1"
+	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
@@ -69103,25 +69372,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"nHd" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "nHh" = (
 /obj/random/material/low_chance,
 /obj/random/structures/low_chance,
@@ -69885,6 +70135,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
+"nOD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "nOG" = (
 /obj/machinery/light{
 	dir = 4
@@ -69911,6 +70170,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
+"nOQ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "nOS" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
@@ -70963,9 +71233,9 @@
 "nYY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 25;
+	layer = 4.2;
 	pixel_x = -13;
-	layer = 4.2
+	pixel_y = 25
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
@@ -71264,8 +71534,8 @@
 	pixel_x = 8
 	},
 /obj/structure/closet/secure_closet/freezer/blood{
-	req_access = list(45);
-	name = "secure blood fridge"
+	name = "secure blood fridge";
+	req_access = list(45)
 	},
 /obj/item/storage/freezer,
 /obj/item/reagent_containers/blood/OPlus,
@@ -71570,6 +71840,13 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"oeN" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "oeR" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -71696,14 +71973,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
-"ofU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -72947,6 +73216,21 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
+"orW" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
+"orY" = (
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "osf" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -74281,6 +74565,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"oEW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "oEX" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -74465,6 +74754,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"oHi" = (
+/obj/effect/floor_decal/industrial/warningred,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "oHo" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio3";
@@ -74898,17 +75192,6 @@
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"oKM" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/corners,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "oKN" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -75279,7 +75562,7 @@
 	input_tag = "tox_in";
 	name = "Plasma Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -75581,6 +75864,15 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"oSb" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "oSc" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -75814,6 +76106,14 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"oUx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "oUz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction{
@@ -75867,6 +76167,15 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"oUV" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "oVb" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/closet/l3closet/security,
@@ -76715,9 +77024,9 @@
 /area/nadezhda/maintenance/undergroundfloor2north)
 "pdB" = (
 /obj/machinery/door/airlock/command{
+	id_tag = "crodoor";
 	name = "Soteria Research Overseer's Office";
-	req_access = list(30);
-	id_tag = "crodoor"
+	req_access = list(30)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -76871,6 +77180,13 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/atmos/surface)
+"peY" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "pfd" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/machinery/door/firedoor/multi_tile,
@@ -77880,6 +78196,20 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"ppr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "ppv" = (
 /obj/machinery/light,
 /obj/structure/catwalk,
@@ -78053,8 +78383,8 @@
 /area/shuttle/vasiliy_shuttle_area)
 "prz" = (
 /obj/machinery/requests_console/preset/steward{
-	pixel_x = -35;
-	dir = 8
+	dir = 8;
+	pixel_x = -35
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
@@ -78721,8 +79051,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	operating = 0
+	operating = 0;
+	pixel_x = 28
 	},
 /obj/structure/cable/cyan,
 /turf/simulated/floor/plating/under,
@@ -78853,20 +79183,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
-"pzh" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 8;
-	name = "biomatter chute"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
 "pzi" = (
 /obj/machinery/light{
 	dir = 4
@@ -78982,6 +79298,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"pAC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "pAK" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -79331,6 +79665,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"pDH" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "pDL" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -79519,19 +79863,19 @@
 	dir = 8
 	},
 /obj/machinery/button/remote/airlock{
-	pixel_x = 6;
-	pixel_y = 5;
 	id = "ceodoor";
 	name = "CEO Door Open Control";
+	pixel_x = 6;
+	pixel_y = 5;
 	req_access = list(41)
 	},
 /obj/machinery/button/remote/airlock{
-	pixel_x = -6;
-	pixel_y = 5;
 	id = "ceodoor";
 	name = "CEO Door Bolt Control";
-	specialfunctions = 4;
-	req_access = list(41)
+	pixel_x = -6;
+	pixel_y = 5;
+	req_access = list(41);
+	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
@@ -79849,6 +80193,26 @@
 /obj/random/contraband,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/detectives_office)
+"pJZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "pKd" = (
 /obj/structure/table/steel,
 /obj/item/paper/crumpled,
@@ -80013,17 +80377,6 @@
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"pLP" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "pLR" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/tiled/cafe,
@@ -80076,12 +80429,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
-"pMq" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "pMr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -81279,7 +81626,7 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 1;
 	pixel_y = 3;
-	preloaded_reagents = list("plasma"=30)
+	preloaded_reagents = list("plasma" = 30)
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -81360,8 +81707,8 @@
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/glass/bottle/tricord{
-	pixel_y = 7;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 7
 	},
 /obj/item/reagent_containers/glass/bottle/inaprovaline,
 /obj/item/reagent_containers/glass/bottle/antitoxin{
@@ -81778,6 +82125,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"qby" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "qbG" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -82133,13 +82489,13 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "vasiliy_dokuchaev_shuttle2";
+	pixel_x = 8;
 	pixel_y = 21;
 	req_one_access = list(13,48);
 	tag_airpump = "research_shuttle_pump";
 	tag_chamber_sensor = "research_shuttle_sensor";
 	tag_exterior_door = "research_shuttle_outer";
-	tag_interior_door = "research_shuttle_inner";
-	pixel_x = 8
+	tag_interior_door = "research_shuttle_inner"
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "10,12"
@@ -82492,6 +82848,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/hallway/surface/section1)
+"qja" = (
+/obj/machinery/mech_recharger,
+/obj/mecha/working/ripley,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "qjb" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -82570,9 +82931,9 @@
 	pixel_x = 8
 	},
 /obj/item/reagent_containers/food/drinks/mug/moebius{
-	pixel_y = 10;
+	layer = 4;
 	pixel_x = 4;
-	layer = 4
+	pixel_y = 10
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/rnd/rbreakroom)
@@ -82715,6 +83076,18 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"qlf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction{
+	name = "Cargo - Sorting Office";
+	sortType = "Cargo - Sorting Office"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "qlg" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "1,8"
@@ -82838,6 +83211,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qmu" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/device/destTagger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "qmz" = (
 /obj/machinery/door/holy{
 	name = "Church"
@@ -83681,6 +84072,17 @@
 "quF" = (
 /turf/simulated/mineral,
 /area/nadezhda/command/crematorium)
+"quH" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "quI" = (
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -84007,6 +84409,20 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
+"qxY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/conveyor_switch{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "qyc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -84020,6 +84436,14 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"qyg" = (
+/obj/structure/low_wall,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "qyh" = (
 /obj/structure/flora/small/rock5,
 /obj/structure/flora/small/grassb3,
@@ -84312,17 +84736,6 @@
 /obj/random/booze/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"qBv" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "qBx" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/structure/invislight,
@@ -85488,9 +85901,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
+	id_tag = "psychcell2";
 	name = "Cell 2";
-	req_access = list(64);
-	id_tag = "psychcell2"
+	req_access = list(64)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -86253,8 +86666,8 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/command/teleporter)
@@ -86698,8 +87111,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/command/cro)
@@ -87953,6 +88366,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
+"rnx" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "rny" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -88237,6 +88660,22 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"rqq" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "rqu" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -88259,6 +88698,14 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"rqR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "rqU" = (
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
@@ -88456,22 +88903,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
-"rty" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/random/powercell/low_chance,
-/obj/item/device/destTagger,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "rtA" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -89438,6 +89869,12 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"rDp" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/engineering/engine_waste)
 "rDr" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -89476,16 +89913,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"rDK" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "rDM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -90052,17 +90479,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
-"rKz" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Disposals";
-	req_one_access = list(50,48,26)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "rKB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -90191,6 +90607,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"rLL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/tagger{
+	sort_tag = "Cargo - Export"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "rLR" = (
 /obj/structure/invislight,
 /obj/structure/disposalpipe/segment{
@@ -91734,6 +92157,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory)
+"saw" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "sax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/smoking/small{
@@ -91802,9 +92232,9 @@
 /area/nadezhda/hallway/surface/section1)
 "sbt" = (
 /obj/machinery/door/airlock/vault{
+	locked = 1;
 	name = "Lonestar Vault";
-	req_access = list(41);
-	locked = 1
+	req_access = list(41)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -91894,13 +92324,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"sbN" = (
-/obj/structure/disposalpipe/sortjunction/untagged,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "sbP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -91997,6 +92420,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"scF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "scH" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/plastic/random,
@@ -92353,6 +92783,14 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"sgU" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/corners,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "sgY" = (
 /obj/item/toy/plushie/spider,
 /obj/effect/spider/stickyweb,
@@ -92365,6 +92803,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"shg" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "shh" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4;
@@ -92395,17 +92838,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/surface/section1)
-"shm" = (
-/obj/vehicle/train/cargo/engine,
-/obj/effect/floor_decal/industrial/box/corners,
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "shu" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/table/rack,
@@ -93348,8 +93780,8 @@
 	pixel_x = -4
 	},
 /obj/item/gun/projectile/automatic/buff_autoshotgun{
-	pixel_y = 9;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 9
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
@@ -93554,8 +93986,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	operating = 0
+	operating = 0;
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -94576,9 +95008,9 @@
 	power_rating = 30000
 	},
 /obj/machinery/airlock_sensor{
-	pixel_y = 28;
 	frequency = 1380;
-	id_tag = "research_shuttle_sensor"
+	id_tag = "research_shuttle_sensor";
+	pixel_y = 28
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "10,12"
@@ -94656,20 +95088,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"sCZ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/conveyor_switch{
-	id = "disposals upper"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "sDa" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -95070,8 +95488,8 @@
 /area/nadezhda/outside/inside_colony)
 "sHF" = (
 /obj/structure/flora/ausbushes/reedbush{
-	pixel_y = -4;
-	layer = 4.2
+	layer = 4.2;
+	pixel_y = -4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
@@ -95110,6 +95528,10 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"sIg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "sIn" = (
 /obj/machinery/door/airlock/vault{
 	name = "Lonestar Vault";
@@ -95523,9 +95945,9 @@
 "sMk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/remote/blast_door{
-	pixel_x = -30;
+	id = "BS001";
 	name = "tunnel shutters control";
-	id = "BS001"
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical_blackshield)
@@ -95700,6 +96122,14 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"sOD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "sOE" = (
 /obj/machinery/door/airlock/maintenance_rnd{
 	req_access = list(5)
@@ -95708,8 +96138,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
@@ -95746,19 +96176,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"sOO" = (
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/machinery/conveyor/north{
-	id = "disposals upper";
-	operating = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
 "sOP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
@@ -95995,16 +96412,6 @@
 /obj/item/gun/energy/concillium,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
-"sRD" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "sRJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/morgue)
@@ -96979,6 +97386,16 @@
 /obj/item/spider_shadow_trap,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"tcp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction{
+	name = "Cargo - Export";
+	sortType = "Cargo - Export"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "tcw" = (
 /obj/machinery/computer/shuttle_control/multi/vasiliy,
 /turf/simulated/shuttle/floor/science{
@@ -97491,16 +97908,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
-"tiv" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/office)
 "tix" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -97604,6 +98011,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
+"tjO" = (
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "tjR" = (
 /obj/item/holder/cat/fluff/bones,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -98204,10 +98614,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"tqA" = (
-/obj/vehicle/train/cargo/trolley,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "tqH" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/danger,
@@ -98828,7 +99234,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -99599,8 +100005,8 @@
 "tEF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/multi_tile/metal{
-	req_access = list(5);
-	name = "Vasiliy Dokuchaev Internal Access"
+	name = "Vasiliy Dokuchaev Internal Access";
+	req_access = list(5)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,11"
@@ -100087,7 +100493,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor"="Tank")
+	sensors = list("waste_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -100594,10 +101000,6 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
-"tNH" = (
-/obj/random/cluster/termite_no_despawn_hoard,
-/turf/simulated/mineral,
-/area/colony)
 "tNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/research{
@@ -100628,12 +101030,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/medical/sleeper)
-"tNW" = (
-/obj/machinery/conveyor/south{
-	id = "deliveries"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "tNX" = (
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance{
@@ -101147,17 +101543,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"tSH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor_switch{
-	id = "deliveries"
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "tSJ" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "F1-A2";
@@ -101346,6 +101731,11 @@
 	opacity = 0
 	},
 /area/shuttle/surface_transport_lz)
+"tUn" = (
+/obj/effect/floor_decal/industrial/warningred/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "tUo" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/wall/wood_old,
@@ -101389,8 +101779,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/command/teleporter)
@@ -101537,10 +101927,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/sechall)
-"tWn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "tWw" = (
 /obj/effect/floor_decal/industrial/road{
 	dir = 1;
@@ -101924,6 +102310,14 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/quartermaster/hangarsupply)
+"tZY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "uab" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 8
@@ -102336,15 +102730,6 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
-"uec" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Disposals";
-	req_one_access = list(50,48,26)
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "ues" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -102564,9 +102949,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
+	id_tag = "crodoor";
 	name = "Soteria Research Overseer's Office";
-	req_access = list(30);
-	id_tag = "crodoor"
+	req_access = list(30)
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/command/cro)
@@ -102854,13 +103239,13 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "vasiliy_dokuchaev_shuttle2";
+	pixel_x = 23;
+	pixel_y = -7;
 	req_one_access = list(13,48);
 	tag_airpump = "research_shuttle_pump";
 	tag_chamber_sensor = "research_shuttle_sensor";
 	tag_exterior_door = "research_shuttle_outer";
-	tag_interior_door = "research_shuttle_inner";
-	pixel_x = 23;
-	pixel_y = -7
+	tag_interior_door = "research_shuttle_inner"
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
@@ -103061,13 +103446,13 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/metal{
+	dir = 1;
 	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "research_shuttle_inner";
 	locked = 1;
 	name = "Vasiliy Dokuchaev Internal Access";
-	req_access = list(13);
-	dir = 1
+	req_access = list(13)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "9,11"
@@ -103178,8 +103563,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	operating = 0
+	operating = 0;
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -103714,8 +104099,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/telesci_inhibitor/mini{
-	pixel_y = 30;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -103882,6 +104267,11 @@
 /obj/item/remains/unathi,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest)
+"usB" = (
+/obj/structure/table/rack,
+/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "usN" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "7,5"
@@ -104014,14 +104404,6 @@
 /obj/machinery/multistructure/bioreactor_part/unloader,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"uuC" = (
-/obj/vehicle/train/cargo/trolley,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "uuD" = (
 /obj/structure/sink{
 	dir = 4;
@@ -105087,6 +105469,14 @@
 	icon_state = "2,1"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"uGQ" = (
+/obj/machinery/smelter/cargo_t2_parts{
+	input_side = 8;
+	output_side = 4;
+	refuse_output_side = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "uGU" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -105196,15 +105586,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
-"uHQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "uHS" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -105511,8 +105892,8 @@
 /obj/structure/cable/cyan,
 /obj/machinery/power/apc{
 	name = "South APC";
-	pixel_y = -28;
-	operating = 0
+	operating = 0;
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -105799,13 +106180,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"uMI" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/landmark/join/start/cargo_tech,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "uMK" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -106782,6 +107156,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"uVg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "uVj" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -107200,8 +107588,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	operating = 0
+	operating = 0;
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -107592,9 +107980,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/glass{
+	id_tag = "psychcell3";
 	name = "Cell 3";
-	req_access = list(64);
-	id_tag = "psychcell3"
+	req_access = list(64)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -107995,8 +108383,8 @@
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/power/wall_obelisk/silver{
-	pixel_y = -11;
-	pixel_x = 33
+	pixel_x = 33;
+	pixel_y = -11
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -108378,32 +108766,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"vlA" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stack/cable_coil/random,
-/obj/item/tool/screwdriver,
-/obj/item/stack/material/steel/random,
-/obj/item/stack/material/steel/random,
-/obj/item/stack/material/steel/random,
-/obj/item/circuitboard/vending,
-/obj/item/circuitboard/vending,
-/obj/item/circuitboard/vending,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "vlF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/cyan{
@@ -108475,6 +108837,14 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"vmk" = (
+/obj/structure/table/rack,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/science/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "vmn" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -109311,7 +109681,7 @@
 /obj/machinery/reagentgrinder/portable,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/beaker{
-	preloaded_reagents = list("plasma"=30)
+	preloaded_reagents = list("plasma" = 30)
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
@@ -110373,8 +110743,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
@@ -110421,17 +110791,6 @@
 /obj/item/clothing/accessory/choker/gold_bell,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"vGW" = (
-/obj/machinery/smelter/cargo_t2_parts{
-	name = "primary smelter";
-	output_side = 4;
-	refuse_output_side = 1
-	},
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "vHj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -110486,6 +110845,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/hallways)
+"vHu" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "vHx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -110774,28 +111144,20 @@
 	dir = 8
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = 14;
 	frequency = 1380;
 	id_tag = "vasiliy_dokuchaev_shuttle1";
-	tag_exterior_door = "research_shuttle_outer_back";
-	tag_interior_door = "research_shuttle_inner_back";
+	pixel_x = -25;
+	pixel_y = 14;
 	req_access = list(13);
 	tag_airpump = "research_shuttle_pump_back";
 	tag_chamber_sensor = "research_shuttle_sensor_back";
-	pixel_x = -25
+	tag_exterior_door = "research_shuttle_outer_back";
+	tag_interior_door = "research_shuttle_inner_back"
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,8"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"vKC" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/office)
 "vKG" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
@@ -111109,8 +111471,8 @@
 /area/nadezhda/command/bridge)
 "vMT" = (
 /obj/structure/flora/ausbushes/reedbush{
-	pixel_y = -4;
-	layer = 4.2
+	layer = 4.2;
+	pixel_y = -4
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
@@ -111960,8 +112322,8 @@
 "vUC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/multi_tile/metal{
-	req_access = list(5);
-	name = "Vasiliy Dokuchaev Internal Access"
+	name = "Vasiliy Dokuchaev Internal Access";
+	req_access = list(5)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,12"
@@ -112000,6 +112362,10 @@
 /obj/structure/flora/small/trailrocka1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"vVb" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "vVe" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -112450,8 +112816,8 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	operating = 0
+	operating = 0;
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -114653,8 +115019,8 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	operating = 0
+	operating = 0;
+	pixel_x = 28
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -115116,26 +115482,15 @@
 /obj/item/organ/internal/bone/l_leg,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wzV" = (
-/obj/structure/disposaloutlet{
+"wzW" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "wzY" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -115445,8 +115800,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/closet/secure_closet/freezer/blood{
-	req_access = list(45);
-	name = "secure blood fridge"
+	name = "secure blood fridge";
+	req_access = list(45)
 	},
 /obj/item/reagent_containers/blood/OPlus,
 /obj/item/reagent_containers/blood/OPlus,
@@ -115748,6 +116103,12 @@
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/lakeside)
+"wGP" = (
+/obj/structure/sign/warning/moving_parts/small{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "wGV" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -115877,14 +116238,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"wIh" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/table/rack/shelf,
-/obj/structure/railing,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "wIs" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -116946,6 +117299,19 @@
 /obj/structure/bed/chair/sofa/brown/right,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
+"wTo" = (
+/obj/item/modular_computer/console/preset/trade{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warningred/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/quartermaster/hangarsupply)
 "wTC" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -117830,8 +118196,8 @@
 	},
 /obj/machinery/door/window/southright,
 /obj/machinery/door/blast/regular{
-	id = "ProspShop";
-	dir = 4
+	dir = 4;
+	id = "ProspShop"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/pros/prep)
@@ -119615,11 +119981,15 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"xvs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/west,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
+"xvD" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_one_access = list(50,48,26)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "xvE" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -119961,6 +120331,16 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
+"xyX" = (
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "xzf" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light{
@@ -119997,7 +120377,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -120043,11 +120423,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
-"xzP" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "xzQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/organ/internal/bone/chest{
@@ -120394,20 +120769,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
-"xCo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "xCw" = (
 /obj/machinery/light{
 	dir = 4
@@ -120488,6 +120849,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/pool)
+"xDD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "xDH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -121595,6 +121967,13 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"xOF" = (
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "xOG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -121623,6 +122002,28 @@
 	},
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters)
+"xPi" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 8
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/hand_labeler,
+/obj/item/clipboard{
+	pixel_x = 6;
+	pixel_y = -12
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = -11
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "xPq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/junk,
@@ -122398,6 +122799,22 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/engineering/engine_room)
+"xWJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/smartfridge/disk,
+/obj/item/computer_hardware/hard_drive/portable/design/logistics,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "xWK" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/light_switch{
@@ -123660,8 +124077,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	name = "RESEARCH LOCKDOWN";
-	id = "researchlockdown"
+	id = "researchlockdown";
+	name = "RESEARCH LOCKDOWN"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/command/teleporter)
@@ -186286,10 +186703,10 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
+pen
+pen
+pen
+pen
 cZb
 cZb
 cZb
@@ -186486,13 +186903,13 @@ fyk
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+pen
+pen
+pen
+pen
+pen
+pen
+pen
 cZb
 cZb
 rWi
@@ -186688,12 +187105,12 @@ fyk
 cZb
 cZb
 cZb
+pen
 cZb
+pen
+pen
+pen
 cZb
-pen
-pen
-pen
-pen
 cZb
 cZb
 cZb
@@ -186891,7 +187308,7 @@ cZb
 cZb
 cZb
 pen
-pen
+cZb
 pen
 pen
 pen
@@ -187092,11 +187509,11 @@ fyk
 cZb
 cZb
 cZb
-pen
 cZb
-pen
-pen
-pen
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -187294,14 +187711,14 @@ fyk
 cZb
 cZb
 cZb
-pen
 cZb
-pen
-pen
-pen
-pen
-pen
 cZb
+kFn
+kFn
+kFn
+kFn
+kFn
+kFn
 cZb
 rWi
 muP
@@ -187495,15 +187912,15 @@ fyk
 fyk
 fyk
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kFn
+kFn
+kFn
+kFn
+eUH
+add
+add
+lLH
+kFn
 cZb
 rWi
 tIf
@@ -187697,16 +188114,16 @@ cuK
 epk
 fyk
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kFn
+kPl
+mYZ
+orY
+gPf
+vVb
+vVb
+saw
+kFn
+kFn
 rWi
 uvi
 bCO
@@ -187900,14 +188317,14 @@ llJ
 kFn
 kFn
 kFn
-kFn
-kFn
-kFn
-kFn
-kFn
-kFn
-kFn
-kFn
+qyg
+shg
+icF
+icF
+lbS
+tUn
+eCt
+eGD
 kFn
 kFn
 kFn
@@ -188106,8 +188523,8 @@ fjZ
 fjZ
 fjZ
 fjZ
-djG
-dBO
+pDH
+oHi
 vYW
 vYW
 vYW
@@ -188291,7 +188708,7 @@ fyk
 fyk
 fyk
 fyk
-fyk
+wGP
 fyk
 fyk
 fyk
@@ -188308,8 +188725,8 @@ fjZ
 fjZ
 fjZ
 fjZ
-mTV
-jvo
+wzW
+oHi
 vYW
 vYW
 vYW
@@ -188490,14 +188907,14 @@ bbM
 mln
 qvS
 gFl
-fBm
-csU
-vGW
-guQ
-csU
-csU
-ieK
-sOO
+oUx
+dFR
+ifb
+oSb
+eRO
+eRO
+kEH
+oUV
 gFl
 ggO
 ggO
@@ -188510,7 +188927,7 @@ fjZ
 tTW
 fjZ
 dfz
-afk
+hwN
 jsa
 hXC
 vYW
@@ -188692,19 +189109,19 @@ ybE
 mRV
 axX
 gFl
-pzh
-mTJ
-oKM
-sCZ
-kOY
+mGL
+aIn
+qxY
+sIg
+iRZ
 saq
 gFl
 ldg
 gFl
 tkP
 pgF
-uZB
-nbN
+xBZ
+cWR
 kFn
 jsa
 fjZ
@@ -188712,7 +189129,7 @@ fjZ
 fjZ
 fjZ
 fjZ
-iRP
+hOy
 jsa
 vYW
 vYW
@@ -188893,20 +189310,20 @@ cPd
 hIx
 ydV
 whU
-gFl
-jAl
-pMq
+lsg
+jqN
+peY
 qcf
 syw
 rkj
 fsB
-uec
+aKA
 cvM
 sVQ
 xBZ
 xBZ
 uZB
-uuC
+mIH
 kFn
 tZQ
 fjZ
@@ -188914,8 +189331,8 @@ fjZ
 nkT
 fjZ
 fjZ
-afk
-jnV
+xWJ
+mCW
 vYW
 vYW
 oLc
@@ -189093,22 +189510,22 @@ opg
 lJl
 cPd
 lnZ
-nHd
-qwh
-mju
+cOS
+nOD
+dkp
 pFc
 lrJ
 eSx
 aJQ
 nTw
 ogT
-rKz
+kis
 cPg
 wcV
 wcV
 lea
-uZB
-tqA
+xBZ
+sgU
 kFn
 wUm
 mgH
@@ -189116,7 +189533,7 @@ mgH
 mgH
 nOd
 tAY
-kKF
+wTo
 kFn
 jvw
 wnm
@@ -189295,22 +189712,22 @@ mcu
 oaq
 cPd
 gNJ
-mRV
-whU
-cCj
-tWn
-wIh
-iau
-eMM
-iUt
+mpQ
+dUx
+lHI
+gAH
+xyX
+fcD
+xPi
+qmu
 sbX
 xsR
 cRH
 xax
 blV
 lIS
-lxb
-shm
+fWy
+giX
 kFn
 rln
 mft
@@ -189318,7 +189735,7 @@ nuS
 nuS
 obl
 mft
-bPn
+jIM
 xjs
 mft
 mft
@@ -189497,8 +189914,8 @@ mei
 btk
 cPd
 asW
-hGK
-axX
+cid
+bdA
 ggO
 ggO
 ggO
@@ -189520,7 +189937,7 @@ nuS
 nuS
 bgW
 nuS
-nuS
+aqq
 ttk
 nuS
 nuS
@@ -189699,8 +190116,8 @@ qkJ
 wGi
 cPd
 gdi
-hyp
-bwI
+pAC
+nxT
 kGy
 iZX
 iWN
@@ -189722,7 +190139,7 @@ nuS
 nuS
 obl
 nuS
-nuS
+aqq
 mft
 nuS
 nuS
@@ -189901,8 +190318,8 @@ uag
 uag
 cPd
 cWM
-mln
-ilF
+rqq
+qby
 eJi
 eUF
 tdr
@@ -189912,19 +190329,19 @@ xBZ
 xBZ
 lVE
 xkN
-uMI
-xBZ
-xCo
-deb
-xBZ
-kOq
-uHQ
-mft
-mft
-mft
-obl
-mft
-mft
+kBW
+oEW
+mlk
+dpb
+oEW
+xvD
+rnx
+mdS
+mdS
+mdS
+lIP
+mdS
+rqR
 dFh
 mft
 mft
@@ -190103,8 +190520,8 @@ bbM
 bbM
 laP
 gtO
-lcK
-ilF
+dSc
+qby
 qWv
 xBZ
 eil
@@ -190114,8 +190531,8 @@ xBZ
 xBZ
 eNq
 ggO
-jHK
-iWF
+kog
+sOD
 tek
 wWr
 dHk
@@ -190305,8 +190722,8 @@ iBR
 iBR
 uNp
 qTF
-grl
-ofU
+abJ
+nOQ
 oix
 pPK
 iJc
@@ -190317,7 +190734,7 @@ xBZ
 xBZ
 khK
 jKq
-xBZ
+ntW
 lfZ
 hwk
 pHK
@@ -190507,8 +190924,8 @@ whU
 bbM
 dXp
 fEV
-jro
-hXW
+cGC
+cAD
 pyL
 tsp
 htt
@@ -190518,8 +190935,8 @@ fUT
 lLQ
 nkM
 tdq
-sbN
-cWi
+tcp
+qlf
 eMb
 glW
 uZB
@@ -190721,9 +191138,9 @@ xjC
 yaY
 cQe
 iWF
-fuM
+tZY
 wzk
-iLJ
+pJZ
 pKX
 fdN
 tFK
@@ -190923,9 +191340,9 @@ sLF
 ggO
 ggO
 gZK
-fCE
+jKf
 vVY
-mCU
+eoK
 xBZ
 nXr
 qoz
@@ -191123,11 +191540,11 @@ hGS
 hYm
 mLj
 ggO
-bht
+iVG
 xBZ
-vlA
+bsc
 slD
-cvM
+xBZ
 xBZ
 nXr
 sUH
@@ -191325,11 +191742,11 @@ fmD
 uqD
 ima
 ggO
-msC
+cCj
 xBZ
-rty
+npx
 uWr
-cvM
+xBZ
 pRU
 ieZ
 ieZ
@@ -191528,11 +191945,11 @@ rRT
 rir
 ggO
 ggO
-nmL
-cvM
-xBZ
-cvM
-khh
+jmI
+scF
+scF
+scF
+dcL
 ieZ
 cNR
 xFh
@@ -191730,11 +192147,11 @@ dtp
 dLz
 ggO
 ggO
-gbq
-dmD
-tSH
-doD
-gbq
+mNT
+nmr
+orW
+hGP
+tjO
 ieZ
 ieZ
 ieZ
@@ -191753,14 +192170,14 @@ fEh
 dUM
 gDM
 hrP
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+tip
+tip
+tip
+tip
+tip
+tip
+tip
+tip
 cZb
 cZb
 ayB
@@ -191932,12 +192349,12 @@ uiv
 jZn
 ggO
 ggO
-vKC
-jMi
-tNW
-nAt
-tiv
 ggO
+usB
+qja
+vmk
+ggO
+bpF
 bpF
 bpF
 bpF
@@ -191956,12 +192373,12 @@ dUM
 qag
 hrP
 tip
-tip
-tip
-tip
-tip
-tip
-tip
+quH
+rSI
+lGK
+hgO
+hgO
+nEC
 tip
 cZb
 cZb
@@ -192134,12 +192551,12 @@ oMy
 swx
 rZl
 bpF
-ggO
-ggO
-ggO
-ggO
-ggO
-ggO
+bpF
+bpF
+bpF
+bpF
+bpF
+bpF
 aTG
 oVl
 cvg
@@ -192158,11 +192575,11 @@ tyv
 hrP
 hrP
 tip
-qBv
-rSI
-xvs
-hgO
-hgO
+bZh
+nEC
+jpQ
+bcz
+dgQ
 nEC
 tip
 cZb
@@ -192362,8 +192779,8 @@ xOl
 jBC
 uMg
 jIn
-aWk
-wzV
+jdB
+sFu
 hyM
 lEl
 tip
@@ -192560,12 +192977,12 @@ dZI
 jmv
 jdr
 kfg
-lyy
+xDD
 tip
-dIo
+kBa
 hgO
 kGt
-sFu
+jYT
 hyM
 dXR
 tip
@@ -192767,8 +193184,8 @@ sOw
 sVn
 hgO
 hFX
-jYT
-ngc
+fOx
+inn
 wNc
 tip
 cZb
@@ -192969,8 +193386,8 @@ sOw
 sVn
 hgO
 odF
-lXx
-pLP
+xOF
+vHu
 cXt
 tip
 cZb
@@ -193170,9 +193587,9 @@ ecn
 sOw
 sVn
 hgO
-nwk
-jYT
-bgl
+dfi
+uGQ
+fdE
 nEC
 tip
 cZb
@@ -193368,11 +193785,11 @@ hLP
 iHG
 jdr
 gOA
-ecn
-sOw
-sVn
-hgO
-xzP
+ppr
+rDp
+mLw
+rLL
+jkv
 jYT
 nuH
 nEC
@@ -193570,13 +193987,13 @@ wVo
 lJZ
 kqf
 gOA
-lyy
+imL
 tip
 eWe
 hgO
-xzP
-lvT
-sRD
+cKA
+lKZ
+oeN
 nyB
 ikn
 tip
@@ -193769,15 +194186,15 @@ pcX
 dOp
 nbC
 kjH
-bVF
-oLI
-rDK
-lFQ
+giP
+uVg
+gXw
+fxq
 tip
 gpu
 rVb
 nEC
-jPx
+nEC
 nEC
 nyB
 gSZ
@@ -200153,7 +200570,7 @@ tad
 tad
 tad
 cZb
-tNH
+cZb
 cZb
 cZb
 cZb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -310,6 +310,13 @@
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/podrooms2)
+"ado" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "adt" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/grassb5,
@@ -492,13 +499,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"afk" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/machinery/pile_ripper,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "afr" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -536,11 +536,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
-"afA" = (
-/obj/effect/floor_decal/industrial/warningred/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "afI" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -575,6 +570,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"agg" = (
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "agj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -631,10 +636,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"agx" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/hangarsupply)
 "agD" = (
 /obj/machinery/smartfridge/secure/medbay/organs/stocked,
 /turf/simulated/floor/tiled/white/monofloor,
@@ -957,17 +958,6 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
-"ajw" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "ajH" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -1048,6 +1038,17 @@
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"akS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "akZ" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/orangedouble,
@@ -1454,16 +1455,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"apc" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/material_resources/low_chance,
-/obj/random/powercell/small_safe_lonestar,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "apk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1642,16 +1633,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
-"aqP" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/disposaldrop)
 "aqU" = (
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "medbay exit";
@@ -1806,28 +1787,6 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
-"asA" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 8
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/hand_labeler,
-/obj/item/clipboard{
-	pixel_x = 6;
-	pixel_y = -12
-	},
-/obj/item/pen{
-	pixel_x = 6;
-	pixel_y = -11
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "asL" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/southleft{
@@ -2493,6 +2452,19 @@
 /obj/structure/invislight,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/inside_colony)
+"azc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "azd" = (
 /obj/item/modular_computer/console/preset/medical/monitor{
 	dir = 8
@@ -2560,13 +2532,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"azB" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/south{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "azI" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance{
@@ -2692,6 +2657,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"aAV" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "aAW" = (
 /obj/structure/table/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -2751,14 +2723,18 @@
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
-"aBu" = (
-/obj/machinery/hologram/holopad,
+"aBq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	name = "Cargo - Sorting Office";
+	sortType = "Cargo - Sorting Office"
 	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
+/area/nadezhda/quartermaster/office)
 "aBv" = (
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance_common,
@@ -2908,24 +2884,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
 /area/colony)
-"aCC" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/packageWrap,
-/obj/item/device/destTagger,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "aCD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -2978,14 +2936,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
-"aCX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "aCY" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -4248,6 +4198,10 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"aRM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "aRU" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -5028,6 +4982,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cro)
+"bba" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "bbf" = (
 /mob/living/simple_animal/chicken{
 	name = "Commander Clucky"
@@ -5663,6 +5623,15 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"bhs" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "bhu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6012,13 +5981,6 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"bkf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "bkg" = (
 /obj/random/booze,
 /obj/random/junkfood/onlypizza,
@@ -6106,6 +6068,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"bln" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 8
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/hand_labeler,
+/obj/item/clipboard{
+	pixel_x = 6;
+	pixel_y = -12
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = -11
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "bls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -6727,6 +6711,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfacesec)
+"bsc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "bsf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/wood{
@@ -6768,6 +6760,14 @@
 /obj/random/common_oddities/low_chance,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/bridge)
+"bsV" = (
+/obj/structure/table/rack/shelf,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "btf" = (
 /obj/machinery/power/port_gen/pacman/scrap/anchored,
 /obj/structure/cable/yellow,
@@ -7512,15 +7512,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"bzO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "bzQ" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -7660,15 +7651,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"bBw" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "bBy" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
@@ -8264,6 +8246,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"bIb" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "bIc" = (
 /obj/item/remains/ribcage,
 /turf/simulated/floor/asteroid/grass,
@@ -8802,21 +8813,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"bMT" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "bNb" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/random/lowkeyrandom,
@@ -8951,6 +8947,12 @@
 /obj/random/flora/small_jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"bOZ" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "bPf" = (
 /obj/structure/table,
 /obj/effect/spider/stickyweb,
@@ -8999,6 +9001,19 @@
 	},
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
+"bPM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/disposal/deliveryChute,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "bPX" = (
 /obj/structure/sink{
 	density = 1;
@@ -10313,16 +10328,6 @@
 /obj/machinery/r_n_d/destructive_analyzer,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"cev" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mail Office";
-	req_one_access = list(50,48,26)
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "ceB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -10582,29 +10587,6 @@
 "chh" = (
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
-"chk" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stock_parts/console_screen,
-/obj/item/stack/cable_coil/random,
-/obj/item/tool/screwdriver,
-/obj/item/stack/material/steel/random,
-/obj/item/stack/material/steel/random,
-/obj/item/stack/material/steel/random,
-/obj/item/circuitboard/vending,
-/obj/item/circuitboard/vending,
-/obj/item/circuitboard/vending,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "chz" = (
 /obj/landmark/join/start/medspec,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -10708,13 +10690,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"cik" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "cim" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/button/remote/blast_door{
@@ -11025,11 +11000,12 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/pros/foreman)
-"clC" = (
-/obj/effect/floor_decal/industrial/warningred{
+"cly" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "clE" = (
@@ -11861,26 +11837,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"cuM" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/sortjunction/untagged/flipped,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "cuN" = (
 /obj/structure/table/standard,
 /obj/machinery/light/small{
@@ -11918,11 +11874,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"cva" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "cvc" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -12037,6 +11988,26 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
+"cwa" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "cwk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12145,6 +12116,17 @@
 /obj/structure/scrap/science/large,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/teleporter)
+"cxj" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "cxr" = (
 /obj/structure/table/bench/steel,
 /obj/machinery/light/small,
@@ -12790,42 +12772,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"cDO" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/random/contraband/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lathe_disk/low_chance,
-/obj/random/material_resources/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/melee/low_chance,
-/obj/random/rig_module/rare/low_chance,
-/obj/random/rig_module/low_chance,
-/obj/random/rig/low_chance,
-/obj/random/rations/low_chance,
-/obj/random/voidsuit/low_chance,
-/obj/random/toolbox/low_chance,
-/obj/random/tool/advanced/low_chance,
-/obj/random/tool_upgrade/rare/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/techpart/low_chance,
-/obj/random/tank/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "cDT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -13190,6 +13136,17 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"cHx" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "cHC" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -13247,6 +13204,15 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"cHT" = (
+/obj/structure/table/rack/shelf,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "cHX" = (
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
@@ -13405,12 +13371,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"cJw" = (
-/obj/machinery/conveyor/south{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "cJy" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -15284,6 +15244,20 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dci" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/conveyor_switch{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "dct" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light/small,
@@ -15719,26 +15693,6 @@
 /obj/random/gun_energy_cheap,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"dgP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "dgS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15791,6 +15745,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"dhq" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "dhs" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/table/standard,
@@ -16093,9 +16054,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"dkA" = (
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/quartermaster/disposaldrop)
 "dkE" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -16177,11 +16135,6 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"dls" = (
-/obj/structure/table/rack,
-/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "dlA" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -16426,19 +16379,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
-"dnI" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "dnQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
@@ -16710,6 +16650,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/merchant)
+"dqA" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "dqC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16746,6 +16695,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"drj" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "drp" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush3,
@@ -17007,12 +16970,6 @@
 /obj/effect/floor_decal/industrial/road/straight1,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"dtX" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "dua" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17921,14 +17878,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
-"dCo" = (
-/obj/structure/table/rack/shelf,
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/toolbox/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "dCp" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -17940,16 +17889,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/turret_protected/ai_upload)
-"dCw" = (
-/obj/effect/floor_decal/industrial/box/red,
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/engine_waste)
 "dCC" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -18499,26 +18438,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"dHY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mail Office";
-	req_one_access = list(50,48,26)
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
-"dHZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "dIe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18857,6 +18776,12 @@
 /obj/random/structures,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/trashcave)
+"dLh" = (
+/obj/structure/sign/warning/moving_parts/small{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "dLi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -19300,6 +19225,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dPw" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "dPB" = (
 /obj/structure/closet/crate/secure/large,
 /obj/random/rig_module/low_chance,
@@ -20604,16 +20536,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"edf" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "edn" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -21071,22 +20993,6 @@
 /obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"ehh" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "ehj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -21143,16 +21049,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"ehQ" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/tool/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "ehT" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -21421,6 +21317,16 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"elt" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "elB" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -23520,17 +23426,6 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"eGC" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/landmark/join/start/cargo_tech,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "eGG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -24878,6 +24773,12 @@
 	},
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"eTv" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "eTA" = (
 /obj/structure/flora/rock/variant1,
 /obj/effect/decal/cleanable/rubble,
@@ -24967,20 +24868,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"eUI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "eUJ" = (
 /obj/structure/table/woodentable,
 /obj/structure/sign/security/court{
@@ -25094,20 +24981,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"eWa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/conveyor_switch{
-	id = "deliveries"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "eWc" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -27046,6 +26919,12 @@
 /obj/item/toy/weapon/sword,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"fog" = (
+/obj/machinery/conveyor/southeast/ccw{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "foj" = (
 /obj/structure/table/rack/shelf,
 /obj/machinery/light,
@@ -27646,6 +27525,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"fuV" = (
+/obj/structure/low_wall,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "fvd" = (
 /obj/structure/sink{
 	dir = 4;
@@ -27857,6 +27744,16 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/techshop)
+"fxj" = (
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = -32
+	},
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "fxl" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
@@ -28253,13 +28150,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
-"fBE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "fBG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/lowkeyrandom,
@@ -28650,13 +28540,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
-"fFv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "fFD" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -29192,18 +29075,6 @@
 "fLN" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"fLO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/sortjunction{
-	name = "Cargo - Sorting Office";
-	sortType = "Cargo - Sorting Office"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "fLT" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -29420,24 +29291,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/fitness)
-"fNT" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "fNZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29700,13 +29553,6 @@
 /mob/living/simple_animal/goose,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"fRt" = (
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "fRv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -30015,12 +29861,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"fVc" = (
-/obj/machinery/conveyor/southwest{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "fVe" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_y = 32
@@ -30142,6 +29982,20 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/teleporter)
+"fWz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "fWA" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/cable/green{
@@ -30511,6 +30365,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/command/panic_room)
+"gah" = (
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "gal" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin,
@@ -30687,13 +30544,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/armory)
-"gbV" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "gbZ" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/grille,
@@ -31480,6 +31330,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"giG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "giR" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 10
@@ -31508,6 +31367,14 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"gjl" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/corners,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "gjm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/autolathe/mechfab/loaded,
@@ -31764,6 +31631,14 @@
 "glS" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/barracks)
+"glT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "glU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -33361,6 +33236,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
+"gBl" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "gBs" = (
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
@@ -34182,14 +34067,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"gLM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "gLR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -34596,6 +34473,15 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
+"gPE" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "gPI" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -34720,16 +34606,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"gQy" = (
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 4
-	},
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "gQz" = (
 /obj/structure/flora/big/rocks3,
 /turf/unsimulated/mineral,
@@ -35384,15 +35260,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"gWF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "gWK" = (
 /obj/effect/floor_decal/corner_oldtile,
 /obj/effect/floor_decal/corner_oldtile{
@@ -35784,6 +35651,9 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
+"hbm" = (
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "hbo" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -36548,17 +36418,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hjI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "hjL" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -37186,6 +37045,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/medical/virology)
+"hpI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "hpK" = (
 /obj/structure/railing{
 	dir = 4;
@@ -37194,21 +37061,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
-"hpM" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "hpN" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "11,17"
@@ -37257,10 +37109,6 @@
 "hqv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/gmaster)
-"hqx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "hqy" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -37904,11 +37752,27 @@
 /obj/structure/curtain/open,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"hxB" = (
-/obj/machinery/mech_recharger,
-/obj/mecha/working/ripley,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
+"hxr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "hxL" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
@@ -38153,13 +38017,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate)
-"hzG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/tagger{
-	sort_tag = "Cargo - Export"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "hzI" = (
 /obj/structure/railing{
 	dir = 4;
@@ -38837,14 +38694,16 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4)
-"hFX" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/item/reagent_containers/glass/bucket{
-	desc = "It's a bucket. It looks.. stained.";
-	name = "suspicous bucket"
+"hGc" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "hGl" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -39093,6 +38952,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
+"hIm" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/packageWrap,
+/obj/item/device/destTagger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/quartermaster/disposaldrop)
 "hIn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40991,15 +40868,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/barracks)
-"hZW" = (
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
 "hZY" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -41014,16 +40882,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
-"iac" = (
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = -32
-	},
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
 "iaf" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 4
@@ -42157,6 +42015,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ilD" = (
+/obj/structure/table/rack,
+/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "ilF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -42312,6 +42175,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
+"imO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "imQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -42449,21 +42321,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"inW" = (
-/obj/structure/plasticflaps,
-/obj/machinery/door/blast/shutters{
-	closed_layer = 4.2;
-	id = "lonestar_mailing2";
-	layer = 4.2;
-	name = "Mailing Shutters"
-	},
-/obj/machinery/door/window/southleft{
-	name = "Mailing Room";
-	req_access = list(31)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "inZ" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -42753,6 +42610,13 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/turret_protected/ai_upload)
+"irP" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "irR" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "2,2"
@@ -42926,6 +42790,16 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"itm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "lonestar_mailing";
+	name = "Lonestar Mailing Room shutter control";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "ito" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -43107,6 +42981,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"iuP" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "iuR" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/barman_recipes,
@@ -43198,14 +43090,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"ivE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "ivH" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -44177,15 +44061,6 @@
 /obj/random/junkfood/rotten/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"iHb" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Cargo Bay";
-	req_one_access = list(50,48,26)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
 "iHh" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -44858,6 +44733,11 @@
 /obj/machinery/r_n_d/destructive_analyzer,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/research)
+"iNY" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "iOa" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -45015,17 +44895,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"iPm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "iPr" = (
 /obj/structure/table/bench/steel,
 /obj/effect/spider/stickyweb,
@@ -45443,6 +45312,13 @@
 /obj/structure/multiz/ladder/up,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/command/hallway)
+"iUx" = (
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "iUy" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
@@ -45478,6 +45354,16 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"iUM" = (
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred,
+/obj/machinery/autolathe,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "iVd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -45736,6 +45622,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"iXT" = (
+/obj/machinery/mech_recharger,
+/obj/mecha/working/ripley,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "iXY" = (
 /obj/machinery/light{
 	dir = 4
@@ -46336,17 +46227,6 @@
 "jdO" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
-"jdR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/north,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "jdU" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -47024,11 +46904,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/server)
-"jkF" = (
-/obj/machinery/newscaster/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "jkJ" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/dirt,
@@ -47438,19 +47313,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"jot" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	pixel_y = -7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "jou" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/dirt,
@@ -47481,11 +47343,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"joL" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "joM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -47691,6 +47548,26 @@
 	dir = 4;
 	pixel_y = 38
 	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
+"jrk" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "jrm" = (
@@ -48723,6 +48600,15 @@
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"jBX" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_one_access = list(50,48,26)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "jCd" = (
 /obj/item/device/lighting/glowstick/random,
 /obj/effect/spider/stickyweb,
@@ -48743,6 +48629,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"jCO" = (
+/obj/machinery/newscaster/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "jCQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -51400,6 +51291,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"keG" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "keJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/meter,
@@ -51932,6 +51838,29 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
+"kkj" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
+/obj/item/stack/cable_coil/random,
+/obj/item/tool/screwdriver,
+/obj/item/stack/material/steel/random,
+/obj/item/stack/material/steel/random,
+/obj/item/stack/material/steel/random,
+/obj/item/circuitboard/vending,
+/obj/item/circuitboard/vending,
+/obj/item/circuitboard/vending,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "kkl" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -52379,14 +52308,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"koR" = (
-/obj/structure/low_wall,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/hangarsupply)
 "koW" = (
 /obj/structure/closet/wall_mounted{
 	pixel_x = -32
@@ -52969,19 +52890,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"kuH" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "kuK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -53853,6 +53761,13 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"kDd" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "kDh" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -53950,6 +53865,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"kDT" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/material_resources/low_chance,
+/obj/random/powercell/small_safe_lonestar,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "kDU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -54448,15 +54373,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kKy" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "kKG" = (
 /obj/structure/sink{
 	pixel_y = -22
@@ -56350,6 +56266,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
+"lgP" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "lgV" = (
 /obj/machinery/camera/network/colony_underground,
 /obj/structure/closet/wall_mounted/emcloset{
@@ -56616,13 +56547,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
-"lkq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
 "lkK" = (
 /mob/living/simple_animal/pig{
 	desc = "This intelligent sow has strange, pointy ears.";
@@ -56734,12 +56658,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"llS" = (
-/obj/structure/sign/warning/moving_parts/small{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "llT" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "10,20"
@@ -56837,6 +56755,11 @@
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/nadezhda/command/tcommsat/computer)
+"lnH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "lnR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -57334,34 +57257,10 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm3)
-"ltc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "ltj" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"ltl" = (
-/obj/structure/table/rack/shelf,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "ltn" = (
 /obj/machinery/computer/rdconsole/robotics,
 /obj/machinery/power/apc{
@@ -57514,16 +57413,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lux" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/sortjunction{
-	name = "Cargo - Export";
-	sortType = "Cargo - Export"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "luB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -57784,6 +57673,15 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
+"lxq" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "lxA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -57930,6 +57828,26 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"lzd" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/folder/yellow,
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/device/scanner/price,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "lzf" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -58043,6 +57961,15 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
+"lBh" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "lBk" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -58795,6 +58722,21 @@
 /obj/item/ammo_magazine/ammobox/magnum_40/practice,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/range)
+"lIr" = (
+/obj/structure/plasticflaps,
+/obj/machinery/door/blast/shutters{
+	closed_layer = 4.2;
+	id = "lonestar_mailing2";
+	layer = 4.2;
+	name = "Mailing Shutters"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Mailing Room";
+	req_access = list(31)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "lIt" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -58887,24 +58829,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
-"lJk" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "lJl" = (
 /obj/structure/cyberplant,
 /obj/machinery/holoposter{
@@ -59024,26 +58948,6 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"lKu" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "lKx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -59507,6 +59411,15 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"lQl" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "lQm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techmaint,
@@ -59778,6 +59691,26 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
+"lSL" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "lSQ" = (
 /obj/structure/toilet,
 /obj/structure/curtain/open,
@@ -59994,6 +59927,10 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"lUA" = (
+/obj/effect/floor_decal/industrial/box/corners,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "lUB" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm4)
@@ -60178,16 +60115,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"lWO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "lonestar_mailing";
-	name = "Lonestar Mailing Room shutter control";
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "lWU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -60731,6 +60658,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"mcA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "mcB" = (
 /obj/structure/bed/double/padded{
 	dir = 4
@@ -61197,15 +61133,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
-"mgo" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/random/tool/low_chance,
-/obj/random/tool/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "mgp" = (
 /obj/machinery/light{
 	light_color = "#b9e8ea"
@@ -61950,12 +61877,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"mnp" = (
-/obj/machinery/conveyor/north{
-	id = "deliveries"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "mns" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush3,
@@ -62022,6 +61943,14 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
+"mof" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "mou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -62322,6 +62251,19 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"mry" = (
+/obj/item/modular_computer/console/preset/trade{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warningred/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/quartermaster/hangarsupply)
 "mrE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -62920,6 +62862,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/inside_colony)
+"myf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "myh" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -64860,6 +64813,17 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"mQR" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "mQZ" = (
 /turf/simulated/open,
 /area/asteroid/cave)
@@ -65193,31 +65157,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/pros/prep)
-"mVd" = (
-/obj/machinery/button/remote/blast_door{
-	id = "lonestar_lobby";
-	name = "Lonestar Lobby shutter control";
-	pixel_y = 32
-	},
-/obj/structure/table/standard,
-/obj/item/paper_bin{
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/device/scanner/price,
-/obj/item/stamp/denied,
-/obj/item/stamp,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "mVk" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/big/bush3{
@@ -66178,6 +66117,19 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/surfaceeast)
+"ndw" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "ndz" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/dirt,
@@ -66460,6 +66412,31 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"ngh" = (
+/obj/machinery/button/remote/blast_door{
+	id = "lonestar_lobby";
+	name = "Lonestar Lobby shutter control";
+	pixel_y = 32
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/device/scanner/price,
+/obj/item/stamp/denied,
+/obj/item/stamp,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "ngo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -67908,6 +67885,22 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"nuw" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "nuC" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "3,7"
@@ -68071,17 +68064,6 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"nvP" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "nvR" = (
 /obj/structure/flora/small/trailrockb5,
 /obj/structure/flora/small/trailrocka1,
@@ -69326,11 +69308,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"nHv" = (
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "nHw" = (
 /obj/structure/salvageable/data,
 /turf/simulated/floor/bluegrid{
@@ -69376,16 +69353,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nHI" = (
-/obj/random/junk/cigbutt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "nIa" = (
 /obj/structure/flora/small/grassb4,
 /turf/unsimulated/wall/jungle,
@@ -70125,6 +70092,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/cryo)
+"nPv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction{
+	name = "Cargo - Export";
+	sortType = "Cargo - Export"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "nPw" = (
 /obj/machinery/light/small,
 /obj/random/scrap/sparse_even/low_chance,
@@ -71509,6 +71486,24 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"obT" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "obX" = (
 /obj/structure/cable/green,
 /obj/machinery/alarm{
@@ -71803,6 +71798,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"ofm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "ofn" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/ammo_magazine/ammobox/light_rifle_257/practice,
@@ -72002,22 +72002,6 @@
 "ogV" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"ogZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/machinery/smartfridge/disk,
-/obj/item/computer_hardware/hard_drive/portable/design/logistics,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "ohb" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/structure/railing{
@@ -72091,17 +72075,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/merchant)
-"ohY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "lonestar_mailing2";
-	name = "Lonestar Mailing Room shutter control";
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "ohZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72635,19 +72608,6 @@
 /obj/machinery/botany/extractor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"omt" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/disposal/deliveryChute,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/quartermaster/disposaldrop)
 "omv" = (
 /turf/simulated/wall/wood,
 /area/colony)
@@ -72664,6 +72624,14 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"omE" = (
+/obj/structure/table/rack,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/science/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/office)
 "omO" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/table/bench/wooden,
@@ -73062,6 +73030,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"oqU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "oqZ" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/east)
@@ -73215,6 +73190,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"osE" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "osG" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/med_data{
@@ -73576,14 +73564,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"ovX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "owa" = (
 /obj/structure/table/woodentable,
 /obj/item/folder,
@@ -74376,6 +74356,22 @@
 /obj/random/gun_parts/low,
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
+"oDA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/smartfridge/disk,
+/obj/item/computer_hardware/hard_drive/portable/design/logistics,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "oDM" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_cee"
@@ -74531,27 +74527,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"oFC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "oFI" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 4
@@ -75583,6 +75558,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"oPL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "oPO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -75642,14 +75624,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"oQy" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "oQz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -76004,16 +75978,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"oTC" = (
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred,
-/obj/machinery/autolathe,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "oTM" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -76122,12 +76086,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"oUY" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/engineering/engine_waste)
 "oVb" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/closet/l3closet/security,
@@ -76349,13 +76307,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"oWO" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "oWU" = (
 /obj/landmark/join/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76713,14 +76664,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"pap" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/low_wall,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/disposaldrop)
 "paC" = (
 /obj/item/contraband/poster/placed/recruitment/engineering,
 /turf/simulated/wall,
@@ -77425,6 +77368,15 @@
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/hallway/main/stairwell)
+"phV" = (
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "pij" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
@@ -78007,6 +77959,16 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"por" = (
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/quartermaster/office)
 "pos" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -78417,6 +78379,26 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"psx" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/sortjunction/untagged/flipped,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "psy" = (
 /turf/simulated/wall/wood_old,
 /area/nadezhda/outside/scave)
@@ -79102,24 +79084,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
-"pyZ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "pzc" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/records,
@@ -80059,35 +80023,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"pJJ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "pJK" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -80202,16 +80137,6 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"pKo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "pKp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -81009,16 +80934,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"pRt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "pRx" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
@@ -81138,19 +81053,6 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"pSC" = (
-/obj/item/modular_computer/console/preset/trade{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warningred/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/quartermaster/hangarsupply)
 "pSF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82167,14 +82069,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"qca" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "qcd" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/light/small,
@@ -82865,17 +82759,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/genetics)
-"qjp" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "qju" = (
 /obj/machinery/door/blast/regular/open{
 	id = "genetics1";
@@ -83059,12 +82942,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"qla" = (
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "qlg" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "1,8"
@@ -83637,6 +83514,14 @@
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
+"qqT" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "qra" = (
 /obj/structure/table/standard,
 /obj/random/cloth/armor/low_chance,
@@ -83985,11 +83870,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"qtQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "qtV" = (
 /obj/random/cluster/roaches_hoard,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -84089,6 +83969,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qvk" = (
+/obj/effect/floor_decal/industrial/warningred/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "qvz" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -84320,6 +84205,13 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/asteroid/cave)
+"qxB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "qxC" = (
 /obj/landmark/storyevent/hidden_vent_antag,
 /obj/effect/decal/cleanable/dirt,
@@ -84530,6 +84422,17 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"qzA" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/item/trash/pistachios,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "qzL" = (
 /obj/machinery/computer{
 	dir = 4
@@ -84822,15 +84725,6 @@
 /obj/item/ammo_casing/rocket/emp,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
-"qDe" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "qDf" = (
 /obj/structure/table/steel,
 /obj/item/pen,
@@ -85019,15 +84913,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"qEQ" = (
-/obj/machinery/conveyor/south{
-	id = "trash"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "qET" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -85486,10 +85371,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"qIM" = (
-/obj/effect/floor_decal/industrial/box/corners,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "qIN" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -86361,6 +86242,23 @@
 	icon_state = "11,8"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"qST" = (
+/obj/effect/floor_decal/industrial/warningred/corner{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch{
+	id = "trash";
+	one_way = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/industrial/danger/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "qSV" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -86468,6 +86366,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qUn" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/random/tool/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "qUp" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -87963,6 +87871,24 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"rjH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "rjK" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "9,19";
@@ -88030,6 +87956,16 @@
 	icon_state = "7,3"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"rjW" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/disposaldrop)
 "rjZ" = (
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/dirt,
@@ -88070,26 +88006,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
-"rkX" = (
-/obj/structure/table/standard{
-	name = "plastic table frame"
-	},
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/device/scanner/price,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "rlb" = (
 /obj/machinery/body_scanconsole,
 /obj/effect/floor_decal/industrial/hatch,
@@ -88288,11 +88204,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"rmT" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/quartermaster/hangarsupply)
 "rmU" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "panicRoom";
@@ -88538,6 +88449,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"rpn" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "rpo" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -89419,23 +89347,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
-"ryZ" = (
-/obj/effect/floor_decal/industrial/warningred/corner{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch{
-	id = "trash";
-	one_way = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/industrial/danger/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "rza" = (
 /obj/machinery/autolathe,
 /obj/structure/cable/green{
@@ -90027,6 +89938,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"rFP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/low_wall,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/disposaldrop)
 "rFS" = (
 /obj/effect/floor_decal/industrial/danger/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -90161,6 +90080,16 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
+"rHK" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "rHM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91359,6 +91288,13 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"rTM" = (
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/obj/machinery/pile_ripper,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "rTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -92285,6 +92221,14 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"sbZ" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "scb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -92381,15 +92325,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm1)
-"scX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "scY" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -92677,6 +92612,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"sgw" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/engineering/engine_waste)
 "sgA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92738,6 +92679,17 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"shg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "shh" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4;
@@ -92792,34 +92744,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/inside_colony)
-"shB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "shD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"shH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "shR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94010,19 +93938,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"stB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	name = "Mailing Desk";
-	req_access = list(31)
-	},
-/obj/machinery/door/blast/shutters{
-	id = "lonestar_mailing";
-	name = "Mailing Desk Shutters"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/disposaldrop)
 "stI" = (
 /obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
@@ -94565,6 +94480,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"sxQ" = (
+/obj/machinery/smelter/cargo_t2_parts{
+	input_side = 8;
+	output_side = 4;
+	refuse_output_side = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "sxU" = (
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 9
@@ -95099,11 +95022,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"sDy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "sDz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -95166,14 +95084,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
-"sEc" = (
-/obj/machinery/smelter/cargo_t2_parts{
-	input_side = 8;
-	output_side = 4;
-	refuse_output_side = 1
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "sEh" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -96012,13 +95922,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/virology)
-"sNX" = (
-/obj/machinery/conveyor/southwest/ccw{
-	id = "trash"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "sOd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -96387,14 +96290,6 @@
 /obj/item/gun/energy/concillium,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
-"sRA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "sRJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/morgue)
@@ -97544,12 +97439,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"tep" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/disposaldrop)
 "tes" = (
 /obj/structure/showcase{
 	desc = "Ancient robotic frame, that is long deactivated and rusted solid. However, it still strikes am awesome pose, that somehow makes you think of justice and righteousness.";
@@ -97694,6 +97583,16 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"tgo" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/engine_waste)
 "tgt" = (
 /obj/structure/table/standard,
 /obj/machinery/light/small{
@@ -97712,6 +97611,15 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
+"tgO" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/item/reagent_containers/glass/bucket{
+	desc = "It's a bucket. It looks.. stained.";
+	name = "suspicous bucket"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "tgU" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -97945,6 +97853,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"tjq" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/box/corners{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "tjr" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/cleanable/dirt,
@@ -99392,15 +99318,6 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/hallway/main/stairwell)
-"tyC" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Mail Office";
-	req_one_access = list(50,48,26)
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/disposaldrop)
 "tyF" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots,
@@ -100179,13 +100096,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"tFZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "tGa" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -100429,6 +100339,10 @@
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/engineering/engine_room)
+"tIE" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/quartermaster/hangarsupply)
 "tIG" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/machinery/light/small,
@@ -100879,16 +100793,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
-"tMS" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "tMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal,
@@ -102149,6 +102053,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"tYI" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "tYK" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell,
@@ -102334,7 +102245,7 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
-"uah" = (
+"uaj" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor/east{
 	id = "trash"
@@ -103324,24 +103235,6 @@
 "ujg" = (
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/turret_protected/ai)
-"ujh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "ujo" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "14,10"
@@ -103371,6 +103264,42 @@
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
 /area/nadezhda/maintenance/surfacenorth)
+"ujy" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/random/contraband/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lathe_disk/low_chance,
+/obj/random/material_resources/low_chance,
+/obj/random/medical/low_chance,
+/obj/random/melee/low_chance,
+/obj/random/rig_module/rare/low_chance,
+/obj/random/rig_module/low_chance,
+/obj/random/rig/low_chance,
+/obj/random/rations/low_chance,
+/obj/random/voidsuit/low_chance,
+/obj/random/toolbox/low_chance,
+/obj/random/tool/advanced/low_chance,
+/obj/random/tool_upgrade/rare/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/techpart/low_chance,
+/obj/random/tank/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/random/medical_lowcost/low_chance,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "ujJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Sergeant Office";
@@ -103381,14 +103310,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/barracks)
-"ujK" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "ujW" = (
 /obj/structure/table/reinforced,
 /obj/random/material_rare/low_chance,
@@ -105712,6 +105633,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/virology)
+"uIE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "uIF" = (
 /obj/structure/bed/chair/office/light{
 	name = "foreman seat"
@@ -105805,6 +105731,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"uJx" = (
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "uJI" = (
 /obj/structure/closet/secure_closet/personal/security,
 /obj/effect/floor_decal/industrial/hatch,
@@ -105920,6 +105852,19 @@
 /mob/living/bot/cleanbot,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"uLa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
+	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "uLc" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -107619,6 +107564,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"uZS" = (
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "vac" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -107687,19 +107638,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"vaJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
-	},
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "vaK" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -107818,6 +107756,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/rnd/xenobiology)
+"vcf" = (
+/obj/machinery/conveyor/southwest{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "vch" = (
 /turf/unsimulated/mask,
 /area/colony)
@@ -107888,6 +107832,15 @@
 /obj/effect/floor_decal/industrial/loading/white,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"vcR" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "vcV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/oddity_guns,
@@ -108145,6 +108098,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"vfK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "lonestar_mailing2";
+	name = "Lonestar Mailing Room shutter control";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/disposaldrop)
 "vfN" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/autolathe/mechfab/loaded,
@@ -108197,15 +108161,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"vgh" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "vgm" = (
 /obj/structure/railing{
 	dir = 8
@@ -108339,6 +108294,17 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"vhI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "vhL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -108714,6 +108680,16 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"vkY" = (
+/obj/random/junk/cigbutt,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "vkZ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -108869,6 +108845,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"vmq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "vms" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/dirt,
@@ -108919,6 +108905,16 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/crew_quarters/techshop)
+"vmK" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Mail Office";
+	req_one_access = list(50,48,26)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/disposaldrop)
 "vmR" = (
 /obj/structure/table/standard,
 /obj/random/surgery_tool/low_chance,
@@ -109477,20 +109473,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"vta" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "vtb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/decal/cleanable/dirt,
@@ -109571,6 +109553,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
+"vtF" = (
+/obj/effect/floor_decal/industrial/warningred,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "vtG" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -110345,12 +110332,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"vCm" = (
-/obj/machinery/conveyor/southeast/ccw{
-	id = "trash"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "vCo" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -110820,26 +110801,6 @@
 /obj/item/clothing/accessory/choker/gold_bell,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"vGY" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "vHj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -110923,6 +110884,17 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
+"vHF" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/landmark/join/start/cargo_tech,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "vHP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood,
@@ -111142,6 +111114,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
+"vKp" = (
+/obj/machinery/conveyor/north{
+	id = "deliveries"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "vKq" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/head/helmet/ballistic/bulletproof/militia{
@@ -112569,6 +112548,13 @@
 /obj/random/furniture/painting,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm3)
+"vWt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/tagger{
+	sort_tag = "Cargo - Export"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "vWA" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -113358,13 +113344,6 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"wen" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "weo" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -113507,6 +113486,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"wfT" = (
+/obj/machinery/conveyor/southwest/ccw{
+	id = "trash"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "wfW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -113841,13 +113827,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"wjB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "wjP" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/wood/wild4,
@@ -115551,6 +115530,19 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"wAb" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	name = "Mailing Desk";
+	req_access = list(31)
+	},
+/obj/machinery/door/blast/shutters{
+	id = "lonestar_mailing";
+	name = "Mailing Desk Shutters"
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/quartermaster/disposaldrop)
 "wAc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -115689,23 +115681,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"wBN" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "wBQ" = (
 /obj/machinery/light,
 /obj/structure/cable/green,
@@ -116166,6 +116141,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"wGW" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "wGX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -116326,13 +116306,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"wIz" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
 "wID" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -116579,6 +116552,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"wKY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "wLe" = (
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -116905,16 +116893,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"wOA" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "wOL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
@@ -116959,6 +116937,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"wPn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "wPo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -117095,6 +117080,20 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
+"wQa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "wQf" = (
 /obj/structure/flora/big/bush3,
 /obj/effect/decal/cleanable/dirt,
@@ -117318,17 +117317,6 @@
 "wSD" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
-"wSP" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/item/trash/pistachios,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/engine_waste)
 "wSR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -117523,14 +117511,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"wUY" = (
-/obj/effect/floor_decal/industrial/box/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/corners,
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/quartermaster/office)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -117745,14 +117725,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/absolutism/skyyard)
-"wWZ" = (
-/obj/structure/table/rack,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/tool_upgrade/low_chance,
-/obj/random/science/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "wXb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -117943,6 +117915,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"wZe" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/quartermaster/disposaldrop)
 "wZg" = (
 /obj/structure/closet/crate/secure/large,
 /obj/effect/decal/cleanable/dirt,
@@ -118311,6 +118292,15 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
+"xed" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "xem" = (
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -118405,6 +118395,14 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
+"xfy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "xfF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -120169,6 +120167,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/hunter_cabin)
+"xwB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/engine_waste)
 "xwC" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -121455,15 +121460,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"xIR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/office)
 "xIT" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -123315,6 +123311,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
+"ybw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/office)
 "ybB" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -123941,9 +123945,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"yjo" = (
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/quartermaster/office)
 "yjw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -187925,10 +187926,10 @@ kFn
 kFn
 kFn
 kFn
-sNX
-cJw
-cJw
-vCm
+wfT
+uZS
+uZS
+fog
 kFn
 cZb
 rWi
@@ -188124,13 +188125,13 @@ epk
 fyk
 cZb
 kFn
-gbV
-azB
-qEQ
-fVc
-agx
-agx
-uah
+dhq
+irP
+phV
+vcf
+tIE
+tIE
+uaj
 kFn
 kFn
 rWi
@@ -188326,14 +188327,14 @@ llJ
 kFn
 kFn
 kFn
-koR
-rmT
-nvP
-nvP
-ryZ
-afA
-clC
-ltl
+fuV
+iNY
+cxj
+cxj
+qST
+qvk
+ado
+cHT
 kFn
 kFn
 kFn
@@ -188532,8 +188533,8 @@ fjZ
 fjZ
 fjZ
 fjZ
-tMS
-nHv
+elt
+vtF
 vYW
 vYW
 vYW
@@ -188717,7 +188718,7 @@ fyk
 fyk
 fyk
 fyk
-llS
+dLh
 fyk
 fyk
 fyk
@@ -188734,8 +188735,8 @@ fjZ
 fjZ
 fjZ
 fjZ
-bBw
-nHv
+lQl
+vtF
 vYW
 vYW
 vYW
@@ -188916,14 +188917,14 @@ bbM
 mln
 qvS
 gFl
-aCX
-omt
-iac
-gWF
-mnp
-mnp
-fRt
-hZW
+mof
+bPM
+fxj
+bhs
+uJx
+uJx
+vKp
+wZe
 gFl
 ggO
 ggO
@@ -188936,7 +188937,7 @@ fjZ
 tTW
 fjZ
 dfz
-pKo
+vmq
 jsa
 hXC
 vYW
@@ -189118,19 +189119,19 @@ ybE
 mRV
 axX
 gFl
-ohY
-qtQ
-eWa
-hqx
-fNT
+vfK
+uIE
+dci
+aRM
+tjq
 saq
 gFl
-pap
+rFP
 gFl
 tkP
 pgF
 xBZ
-gQy
+por
 kFn
 jsa
 fjZ
@@ -189138,7 +189139,7 @@ fjZ
 fjZ
 fjZ
 fjZ
-jot
+ndw
 jsa
 vYW
 vYW
@@ -189319,20 +189320,20 @@ cPd
 hIx
 ydV
 whU
-inW
-tep
-oWO
+lIr
+bba
+aAV
 qcf
 syw
 rkj
 fsB
-tyC
+lxq
 cvM
 sVQ
 xBZ
 xBZ
 uZB
-kKy
+gPE
 kFn
 tZQ
 fjZ
@@ -189340,8 +189341,8 @@ fjZ
 nkT
 fjZ
 fjZ
-ogZ
-oTC
+oDA
+iUM
 vYW
 vYW
 oLc
@@ -189519,22 +189520,22 @@ opg
 lJl
 cPd
 lnZ
-hpM
-scX
-cev
+lgP
+giG
+vmK
 pFc
 lrJ
 eSx
 aJQ
 nTw
 ogT
-dHY
+vhI
 cPg
 wcV
 wcV
 lea
 xBZ
-wUY
+gjl
 kFn
 wUm
 mgH
@@ -189542,7 +189543,7 @@ mgH
 mgH
 nOd
 tAY
-pSC
+mry
 kFn
 jvw
 wnm
@@ -189721,22 +189722,22 @@ mcu
 oaq
 cPd
 gNJ
-bMT
-fBE
-stB
-lWO
-edf
-dkA
-asA
-aCC
+keG
+oqU
+wAb
+itm
+agg
+hbm
+bln
+hIm
 sbX
-aqP
+rjW
 cRH
 xax
 blV
 lIS
-qDe
-bkf
+mcA
+oPL
 kFn
 rln
 mft
@@ -189744,7 +189745,7 @@ nuS
 nuS
 obl
 mft
-aBu
+cly
 xjs
 mft
 mft
@@ -189923,8 +189924,8 @@ mei
 btk
 cPd
 asW
-wBN
-ujK
+rpn
+qqT
 ggO
 ggO
 ggO
@@ -189946,7 +189947,7 @@ nuS
 nuS
 bgW
 nuS
-lkq
+kDd
 ttk
 nuS
 nuS
@@ -190125,8 +190126,8 @@ qkJ
 wGi
 cPd
 gdi
-pyZ
-dHZ
+obT
+vcR
 kGy
 iZX
 iWN
@@ -190148,7 +190149,7 @@ nuS
 nuS
 obl
 nuS
-lkq
+kDd
 mft
 nuS
 nuS
@@ -190327,8 +190328,8 @@ uag
 uag
 cPd
 cWM
-ehh
-bzO
+nuw
+imO
 eJi
 eUF
 tdr
@@ -190338,19 +190339,19 @@ xBZ
 xBZ
 lVE
 xkN
-eGC
-sDy
-ltc
-pRt
-sDy
-iHb
-shB
-cva
-cva
-cva
-gLM
-cva
-ivE
+vHF
+lnH
+wKY
+hGc
+lnH
+jBX
+gBl
+ofm
+ofm
+ofm
+xfy
+ofm
+glT
 dFh
 mft
 mft
@@ -190529,8 +190530,8 @@ bbM
 bbM
 laP
 gtO
-vGY
-bzO
+lSL
+imO
 qWv
 xBZ
 eil
@@ -190540,8 +190541,8 @@ xBZ
 xBZ
 eNq
 ggO
-mVd
-qca
+ngh
+hpI
 tek
 wWr
 dHk
@@ -190731,8 +190732,8 @@ iBR
 iBR
 uNp
 qTF
-lKu
-hjI
+jrk
+myf
 oix
 pPK
 iJc
@@ -190743,7 +190744,7 @@ xBZ
 xBZ
 khK
 jKq
-wjB
+wPn
 lfZ
 hwk
 pHK
@@ -190933,8 +190934,8 @@ whU
 bbM
 dXp
 fEV
-cuM
-sRA
+psx
+bsc
 pyL
 tsp
 htt
@@ -190944,8 +190945,8 @@ fUT
 lLQ
 nkM
 tdq
-lux
-fLO
+nPv
+aBq
 eMb
 glW
 uZB
@@ -191147,9 +191148,9 @@ xjC
 yaY
 cQe
 iWF
-ovX
+ybw
 wzk
-dgP
+cwa
 pKX
 fdN
 tFK
@@ -191349,9 +191350,9 @@ sLF
 ggO
 ggO
 gZK
-rkX
+lzd
 vVY
-xIR
+xed
 xBZ
 nXr
 qoz
@@ -191549,9 +191550,9 @@ hGS
 hYm
 mLj
 ggO
-apc
+kDT
 xBZ
-chk
+kkj
 slD
 xBZ
 xBZ
@@ -191751,9 +191752,9 @@ fmD
 uqD
 ima
 ggO
-mgo
+lBh
 xBZ
-ehQ
+qUn
 uWr
 xBZ
 pRU
@@ -191954,11 +191955,11 @@ rRT
 rir
 ggO
 ggO
-jdR
-tFZ
-tFZ
-tFZ
-cDO
+shg
+qxB
+qxB
+qxB
+ujy
 ieZ
 cNR
 xFh
@@ -192156,11 +192157,11 @@ dtp
 dLz
 ggO
 ggO
-dCo
-qIM
-dtX
-qla
-yjo
+bsV
+lUA
+bOZ
+eTv
+gah
 ieZ
 ieZ
 ieZ
@@ -192359,9 +192360,9 @@ jZn
 ggO
 ggO
 ggO
-dls
-hxB
-wWZ
+ilD
+iXT
+omE
 ggO
 bpF
 bpF
@@ -192382,9 +192383,9 @@ dUM
 qag
 hrP
 tip
-qjp
+cHx
 rSI
-jkF
+jCO
 hgO
 hgO
 nEC
@@ -192584,11 +192585,11 @@ tyv
 hrP
 hrP
 tip
-wIz
+dPw
 nEC
-vaJ
-oFC
-fFv
+uLa
+hxr
+xwB
 nEC
 tip
 cZb
@@ -192788,7 +192789,7 @@ xOl
 jBC
 uMg
 jIn
-wOA
+rHK
 sFu
 hyM
 lEl
@@ -192986,9 +192987,9 @@ dZI
 jmv
 jdr
 kfg
-iPm
+akS
 tip
-lJk
+iuP
 hgO
 kGt
 jYT
@@ -193192,9 +193193,9 @@ vuv
 sOw
 sVn
 hgO
-hFX
-afk
-wSP
+tgO
+rTM
+qzA
 wNc
 tip
 cZb
@@ -193395,8 +193396,8 @@ sOw
 sVn
 hgO
 odF
-cik
-ajw
+iUx
+mQR
 cXt
 tip
 cZb
@@ -193596,9 +193597,9 @@ ecn
 sOw
 sVn
 hgO
-joL
-sEc
-nHI
+wGW
+sxQ
+vkY
 nEC
 tip
 cZb
@@ -193794,11 +193795,11 @@ hLP
 iHG
 jdr
 gOA
-vta
-oUY
-kuH
-hzG
-vgh
+fWz
+sgw
+osE
+vWt
+dqA
 jYT
 nuH
 nEC
@@ -193996,13 +193997,13 @@ wVo
 lJZ
 kqf
 gOA
-ujh
+rjH
 tip
 eWe
 hgO
-oQy
-dCw
-wen
+sbZ
+tgo
+tYI
 nyB
 ikn
 tip
@@ -194195,10 +194196,10 @@ pcX
 dOp
 nbC
 kjH
-pJJ
-shH
-dnI
-eUI
+bIb
+drj
+azc
+wQa
 tip
 gpu
 rVb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -15745,13 +15745,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"dhq" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/hangarsupply)
 "dhs" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/table/standard,
@@ -58649,6 +58642,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
+"lHS" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/conveyor/south{
+	id = "trash"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/hangarsupply)
 "lHV" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -188125,7 +188128,7 @@ epk
 fyk
 cZb
 kFn
-dhq
+lHS
 irP
 phV
 vcf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Reroutes the disposals ending to make it go to church, then guild, then to LS for export. Makes it so that you can also ship directly to export.
</summary>
<hr>

Rr-routes the pipes so that unsorted stuff goes to the church, then to the guild, and anything leftover is sent to LS.
Also replaces the previous disposal room to be used as a mailing room. And where mailing once was, is now a mech spot for cargo.
	
<hr>
</details>

## Changelog
:cl:
add: new routing for pipes.
add: A new mech for cargo.
del: the cargo trolly. It's a buggy mess, might get added back in if it's ever fixed.
tweak: moved the recycler, and the smelter, recycler is now in cargo at the EOL, and the smelter is now in the guild.
fix: removes that random termite spawn out in the rocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
