### PR TITLE
CWJ Oven overhaul

### DIFF
--- a/code/__DEFINES/cooking_with_jane.dm
+++ b/code/__DEFINES/cooking_with_jane.dm
@@ -80,9 +80,9 @@
 
 //Ignite times for reagents interacting with a stove.
 //The stove will catch fire if left on too long with flammable reagents in any of its holders.
-#define CWJ_IGNITE_TIME_LOW		1 HOUR
-#define CWJ_IGNITE_TIME_MEDIUM	30 MINUTES
-#define CWJ_IGNITE_TIME_HIGH	15 MINUTES
+#define CWJ_IGNITE_TIME_LOW		20 MINUTES
+#define CWJ_IGNITE_TIME_MEDIUM	12 MINUTES
+#define CWJ_IGNITE_TIME_HIGH	10 MINUTES
 
 //Determines how much quality is taken from a food each tick when a 'no recipe' response is made.
 #define CWJ_BASE_QUAL_REDUCTION 5

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -331,17 +331,13 @@
 	log_debug("     grill_data: [container.grill_data]")
 	#endif
 
-
-	if(container.grill_data[temperature[input]])
-		container.grill_data[temperature[input]] += reference_time
-	else
-		container.grill_data[temperature[input]] = reference_time
+	container.grill_data[temperature[input]] = reference_time
 
 
 	if(user && user.Adjacent(src))
-		container.process_item(src, user, lower_quality_on_fail=CWJ_BASE_QUAL_REDUCTION, send_message=TRUE)
+		container.process_item(src, user, lower_quality_on_fail=0, send_message=TRUE)
 	else
-		container.process_item(src, user,  lower_quality_on_fail=CWJ_BASE_QUAL_REDUCTION)
+		container.process_item(src, user,  lower_quality_on_fail=0)
 
 
 

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -16,6 +16,8 @@
 	var/list/cooking_timestamp = list(0, 0) //Timestamp of when cooking initialized so we know if the prep was disturbed at any point.
 	var/list/items[2]
 
+	var/datum/effect/effect/system/smoke_spread/bad/bsmoke = new /datum/effect/effect/system/smoke_spread/bad
+
 	use_power = 0
 	interact_offline = TRUE
 
@@ -33,6 +35,11 @@
 	var/obj/effect/flicker_overlay/hopper_insert
 	scan_types = list("scan_1")
 
+/obj/machinery/cooking_with_jane/grill/New()
+	..()
+	bsmoke.attach(src)
+	bsmoke.set_up(7, 0, src.loc)
+
 /obj/machinery/cooking_with_jane/grill/Initialize()
 	. = ..()
 	hopper_insert = new(src)
@@ -40,8 +47,12 @@
 //Did not want to use this...
 /obj/machinery/cooking_with_jane/grill/Process()
 
-	//if(on_fire)
-		//Do bad things if it is on fire.
+	if(on_fire)
+		if(stored_wood)
+			emit_fire()
+		else
+			on_fire = FALSE
+
 
 	for(var/i=1, i<=2, i++)
 		if(switches[i])
@@ -133,7 +144,21 @@
 	container.handle_burning()
 
 /obj/machinery/cooking_with_jane/grill/proc/handle_ignition(input)
+	if(!(items && istype(items, /obj/item/reagent_containers/cooking_with_jane/cooking_container)))
+		return
+
+	//Initial burst of smoke so it matches the fire alarm
+	bsmoke.start()
+
+	//Trigger fire alarms
+	var/area/area = get_area(src)
+	for(var/obj/machinery/firealarm/FA in area)
+		fire_alarm.triggerAlarm(loc, FA, 0)
+
 	on_fire = TRUE
+
+/obj/machinery/cooking_with_jane/grill/proc/emit_fire()
+	bsmoke.start()
 
 //Retrieve which quadrant of the baking pan is being used.
 /obj/machinery/cooking_with_jane/grill/proc/getInput(params)
@@ -152,6 +177,26 @@
 /obj/machinery/cooking_with_jane/grill/attackby(var/obj/item/used_item, var/mob/user, params)
 	if(default_deconstruction(used_item, user))
 		return
+
+	if(on_fire && istype(used_item, /obj/item/extinguisher))
+		var/obj/item/extinguisher/exting = used_item
+		if(!exting.safety)
+			if (exting.reagents.total_volume < 1)
+				to_chat(usr, SPAN_NOTICE("\The [exting] is empty."))
+				return
+
+			if (world.time < exting.last_use + 20)
+				return
+
+			exting.last_use = world.time
+
+			playsound(exting.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
+
+			exting.reagents.remove_any(20)
+
+			on_fire = FALSE
+
+			return
 
 	if(istype(used_item, /obj/item/stack/material/wood))
 		var/obj/item/stack/material/wood/stack = used_item

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -133,12 +133,7 @@
 	container.handle_burning()
 
 /obj/machinery/cooking_with_jane/grill/proc/handle_ignition(input)
-	if(!(items[input] && istype(items[input], /obj/item/reagent_containers/cooking_with_jane/cooking_container)))
-		return
-
-	var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container = items[input]
-	if(container.handle_ignition())
-		on_fire = TRUE
+	on_fire = TRUE
 
 //Retrieve which quadrant of the baking pan is being used.
 /obj/machinery/cooking_with_jane/grill/proc/getInput(params)

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -24,16 +24,22 @@
 
 	var/on_fire = FALSE //if the oven has caught fire or not.
 
+	var/datum/effect/effect/system/smoke_spread/bad/bsmoke = new /datum/effect/effect/system/smoke_spread/bad
+
 	circuit = /obj/item/circuitboard/cooking_with_jane/oven
 
 	scan_types = list("smile", "peep")
 
+/obj/machinery/cooking_with_jane/oven/New()
+	..()
+	bsmoke.attach(src)
+	bsmoke.set_up(10, 0, src.loc)
 
 //Did not want to use this...
 /obj/machinery/cooking_with_jane/oven/Process()
 
-	//if(on_fire)
-		//Do bad things if it is on fire.
+	if(on_fire)
+		emit_fire()
 
 	if(switches)
 		handle_cooking(null, FALSE)
@@ -103,48 +109,71 @@
 	if(!(items && istype(items, /obj/item/reagent_containers/cooking_with_jane/cooking_container)))
 		return
 
-	var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container = items
-	if(container.handle_ignition())
-		on_fire = TRUE
+	//Initial burst of smoke so it matches the fire alarm
+	bsmoke.start()
+
+	//Trigger fire alarms
+	var/area/area = get_area(src)
+	for(var/obj/machinery/firealarm/FA in area)
+		fire_alarm.triggerAlarm(loc, FA, 0)
+
+	on_fire = TRUE
+
+/obj/machinery/cooking_with_jane/oven/proc/emit_fire()
+	bsmoke.start()
 
 /obj/machinery/cooking_with_jane/oven/attackby(var/obj/item/used_item, var/mob/user, params)
 	if(default_deconstruction(used_item, user))
 		return
 
-	var/center_selected = getInput(params)
-
-	if(opened && center_selected)
-
-		if(istype(used_item, /obj/item/gripper))
-			var/obj/item/gripper/gripper = used_item
-			if(!gripper.wrapped && items)
-				var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container = items
-				var/turf/T = get_turf(src)
-				container.forceMove(T)
-				items = null
-				update_icon()
+	if(on_fire && istype(used_item, /obj/item/extinguisher))
+		var/obj/item/extinguisher/exting = used_item
+		if(!exting.safety)
+			if (exting.reagents.total_volume < 1)
+			to_chat(usr, SPAN_NOTICE("\The [exting] is empty."))
 			return
 
-		if(items != null)
+			if (world.time < exting.last_use + 20)
+				return
+
+			exting.last_use = world.time
+
+			playsound(exting.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
+
+			exting.reagents.remove_any(20)
+
+			on_fire = FALSE
+
+			return
+
+	if(istype(used_item, /obj/item/gripper))
+		var/obj/item/gripper/gripper = used_item
+		if(!gripper.wrapped && items)
 			var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container = items
+			var/turf/T = get_turf(src)
+			container.forceMove(T)
+			items = null
+			update_icon()
+		return
 
-			if(istype(used_item, /obj/item/spatula))
-				container.do_empty(user, target=src, reagent_clear = FALSE)
-			else
-				container.process_item(used_item, params)
+	if(items != null)
+		var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container = items
 
-		else if(istype(used_item, /obj/item/reagent_containers/cooking_with_jane/cooking_container))
-			to_chat(usr, SPAN_NOTICE("You put a [used_item] in the oven."))
-			if(usr.canUnEquip(used_item))
-				usr.unEquip(used_item, src)
-			else
-				used_item.forceMove(src)
-			items = used_item
-			if(switches == 1)
-				cooking_timestamp = world.time
+		if(istype(used_item, /obj/item/spatula))
+			container.do_empty(user, target=src, reagent_clear = FALSE)
+		else
+			container.process_item(used_item, params)
 
-	else
-		handle_open(user)
+	else if(istype(used_item, /obj/item/reagent_containers/cooking_with_jane/cooking_container))
+		to_chat(usr, SPAN_NOTICE("You put a [used_item] in the oven."))
+		if(usr.canUnEquip(used_item))
+			usr.unEquip(used_item, src)
+		else
+			used_item.forceMove(src)
+		items = used_item
+		if(switches == 1)
+			cooking_timestamp = world.time
+
 	update_icon()
 
 //Retrieve whether or not the oven door has been clicked.
@@ -206,12 +235,15 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/CtrlClick called ")
 	#endif
-	var/choice = alert(user,"Select an action","Select One:","Set temperature","Set timer","Cancel")
+	var/choice = alert(user,"Select an action","Select One:","Set temperature","Set timer","Start Oven","Cancel")
 	switch(choice)
 		if("Set temperature")
 			handle_temperature(user)
 		if("Set timer")
 			handle_timer(user)
+		if("Start Oven")
+			handle_switch(user)
+
 
 //Switch the cooking device on or off
 /obj/machinery/cooking_with_jane/oven/CtrlShiftClick(var/mob/user, params)
@@ -262,7 +294,7 @@
 	#endif
 	var/old_timerstamp = timerstamp
 	spawn(timer)
-		log_debug("Comparimg timerstamp() of [timerstamp] to old_timerstamp [old_timerstamp]")
+		log_debug("Comparing timerstamp() of [timerstamp] to old_timerstamp [old_timerstamp]")
 		if(old_timerstamp == timerstamp)
 			playsound(src, 'sound/items/lighter.ogg', 100, 1, 0)
 
@@ -319,12 +351,7 @@
 	log_debug("     oven_data: [container.oven_data]")
 	#endif
 
-
-	if(container.oven_data[temperature])
-		container.oven_data[temperature] += reference_time
-	else
-		container.oven_data[temperature] = reference_time
-
+	container.oven_data[temperature] = reference_time
 
 	if(user && user.Adjacent(src))
 		container.process_item(src, user, lower_quality_on_fail=CWJ_BASE_QUAL_REDUCTION, send_message=TRUE)

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -156,7 +156,7 @@
 			update_icon()
 		return
 
-	if(items != null)
+	if(items != null && opened)
 		var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container = items
 
 		if(istype(used_item, /obj/item/spatula))
@@ -165,14 +165,17 @@
 			container.process_item(used_item, params)
 
 	else if(istype(used_item, /obj/item/reagent_containers/cooking_with_jane/cooking_container))
-		to_chat(usr, SPAN_NOTICE("You put a [used_item] in the oven."))
-		if(usr.canUnEquip(used_item))
-			usr.unEquip(used_item, src)
+		if(opened)
+			to_chat(usr, SPAN_NOTICE("You put a [used_item] in the oven."))
+			if(usr.canUnEquip(used_item))
+				usr.unEquip(used_item, src)
+			else
+				used_item.forceMove(src)
+			items = used_item
+			if(switches == 1)
+				cooking_timestamp = world.time
 		else
-			used_item.forceMove(src)
-		items = used_item
-		if(switches == 1)
-			cooking_timestamp = world.time
+			handle_open()
 
 	update_icon()
 
@@ -352,9 +355,9 @@
 	container.oven_data[temperature] = reference_time
 
 	if(user && user.Adjacent(src))
-		container.process_item(src, user, lower_quality_on_fail=CWJ_BASE_QUAL_REDUCTION, send_message=TRUE)
+		container.process_item(src, user, lower_quality_on_fail=0, send_message=TRUE)
 	else
-		container.process_item(src, user,  lower_quality_on_fail=CWJ_BASE_QUAL_REDUCTION)
+		container.process_item(src, user,  lower_quality_on_fail=0)
 
 
 

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -130,8 +130,8 @@
 		var/obj/item/extinguisher/exting = used_item
 		if(!exting.safety)
 			if (exting.reagents.total_volume < 1)
-			to_chat(usr, SPAN_NOTICE("\The [exting] is empty."))
-			return
+				to_chat(usr, SPAN_NOTICE("\The [exting] is empty."))
+				return
 
 			if (world.time < exting.last_use + 20)
 				return
@@ -235,14 +235,12 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/CtrlClick called ")
 	#endif
-	var/choice = alert(user,"Select an action","Select One:","Set temperature","Set timer","Start Oven","Cancel")
+	var/choice = alert(user,"Select an action","Select One:","Set temperature","Set timer","Cancel")
 	switch(choice)
 		if("Set temperature")
 			handle_temperature(user)
 		if("Set timer")
 			handle_timer(user)
-		if("Start Oven")
-			handle_switch(user)
 
 
 //Switch the cooking device on or off

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -33,7 +33,7 @@
 /obj/machinery/cooking_with_jane/oven/New()
 	..()
 	bsmoke.attach(src)
-	bsmoke.set_up(10, 0, src.loc)
+	bsmoke.set_up(7, 0, src.loc)
 
 //Did not want to use this...
 /obj/machinery/cooking_with_jane/oven/Process()

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -134,7 +134,7 @@
 				container.process_item(used_item, params)
 
 		else if(istype(used_item, /obj/item/reagent_containers/cooking_with_jane/cooking_container))
-			to_chat(usr, SPAN_NOTICE("You put a [used_item] on the oven."))
+			to_chat(usr, SPAN_NOTICE("You put a [used_item] in the oven."))
 			if(usr.canUnEquip(used_item))
 				usr.unEquip(used_item, src)
 			else
@@ -188,7 +188,7 @@
 									burn_victim.adjustFireLoss(5)
 								if("Medium")
 									burn_victim.adjustFireLoss(2)
-							to_chat(burn_victim, SPAN_DANGER("You burn your hand a little taking the [items] off of the oven."))
+							to_chat(burn_victim, SPAN_DANGER("You burn your hand a little taking the [items] out of the oven."))
 				user.put_in_hands(items)
 				items = null
 			else

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -17,6 +17,8 @@
 	var/list/cooking_timestamp = list(0, 0, 0, 0) //Timestamp of when cooking initialized so we know if the prep was disturbed at any point.
 	var/list/items[4]
 
+	var/datum/effect/effect/system/smoke_spread/bad/bsmoke = new /datum/effect/effect/system/smoke_spread/bad
+
 	var/reference_time = 0 //The exact moment when we call the process routine, just to account for lag.
 	var/power_cost = 2500 //Power cost per process step for a particular burner
 	var/check_on_10 = 0
@@ -26,11 +28,17 @@
 	circuit = /obj/item/circuitboard/cooking_with_jane/stove
 	scan_types = list("scan_1")
 
+/obj/machinery/cooking_with_jane/stove/New()
+	..()
+	bsmoke.attach(src)
+	bsmoke.set_up(7, 0, src.loc)
+
 //Did not want to use this...
 /obj/machinery/cooking_with_jane/stove/Process()
 
-	//if(on_fire)
-		//Do bad things if it is on fire.
+	if(on_fire)
+		emit_fire()
+
 	for(var/i=1, i<=4, i++)
 		if(switches[i])
 			handle_cooking(null, i, FALSE)
@@ -104,7 +112,21 @@
 	container.handle_burning()
 
 /obj/machinery/cooking_with_jane/stove/proc/handle_ignition(input)
+	if(!(items && istype(items, /obj/item/reagent_containers/cooking_with_jane/cooking_container)))
+		return
+
+	//Initial burst of smoke so it matches the fire alarm
+	bsmoke.start()
+
+	//Trigger fire alarms
+	var/area/area = get_area(src)
+	for(var/obj/machinery/firealarm/FA in area)
+		fire_alarm.triggerAlarm(loc, FA, 0)
+
 	on_fire = TRUE
+
+/obj/machinery/cooking_with_jane/stove/proc/emit_fire()
+	bsmoke.start()
 
 //Retrieve which quadrant of the baking pan is being used.
 /obj/machinery/cooking_with_jane/stove/proc/getInput(params)
@@ -129,6 +151,26 @@
 /obj/machinery/cooking_with_jane/stove/attackby(var/obj/item/used_item, var/mob/user, params)
 	if(default_deconstruction(used_item, user))
 		return
+
+	if(on_fire && istype(used_item, /obj/item/extinguisher))
+		var/obj/item/extinguisher/exting = used_item
+		if(!exting.safety)
+			if (exting.reagents.total_volume < 1)
+				to_chat(usr, SPAN_NOTICE("\The [exting] is empty."))
+				return
+
+			if (world.time < exting.last_use + 20)
+				return
+
+			exting.last_use = world.time
+
+			playsound(exting.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
+
+			exting.reagents.remove_any(20)
+
+			on_fire = FALSE
+
+			return
 
 	var/input = getInput(params)
 

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -104,12 +104,7 @@
 	container.handle_burning()
 
 /obj/machinery/cooking_with_jane/stove/proc/handle_ignition(input)
-	if(!(items[input] && istype(items[input], /obj/item/reagent_containers/cooking_with_jane/cooking_container)))
-		return
-
-	var/obj/item/reagent_containers/cooking_with_jane/cooking_container/container = items[input]
-	if(container.handle_ignition())
-		on_fire = TRUE
+	on_fire = TRUE
 
 //Retrieve which quadrant of the baking pan is being used.
 /obj/machinery/cooking_with_jane/stove/proc/getInput(params)

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -291,10 +291,7 @@
 	#endif
 
 
-	if(container.stove_data[temperature[input]])
-		container.stove_data[temperature[input]] += reference_time
-	else
-		container.stove_data[temperature[input]] = reference_time
+	container.stove_data[temperature[input]] = reference_time
 
 
 	if(user && user.Adjacent(src))

--- a/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
+++ b/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
@@ -157,13 +157,23 @@
 		tracker = null
 	return return_value
 
-//TODO: Handle the contents of the container being ruined via burning.
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/handle_burning()
+	clear()
+	new obj/item/reagent_containers/food/snacks/badrecipe(container)
 	return
 
-//TODO: Handle the contents of the container lighting on actual fire.
-/obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/handle_ignition()
-	return FALSE
+//Deletes contents of container.
+//Used when food is burned, before replacing it with a burned mess
+/obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/clear()
+	QDEL_LIST(contents)
+	contents=list()
+	reagents.clear_reagents()
+	if(tracker)
+		qdel(tracker)
+		tracker = null
+	clear_cooking_data()
+	update_icon()
+
 
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/verb/empty()
 	set src in view(1)
@@ -215,17 +225,6 @@
 
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/AltClick(var/mob/user)
 	do_empty(user)
-
-//Deletes contents of container.
-//Used when food is burned, before replacing it with a burned mess
-/obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/clear()
-	QDEL_LIST(contents)
-	contents=list()
-	reagents.clear_reagents()
-	if(tracker)
-		qdel(tracker)
-		tracker = null
-	clear_cooking_data()
 
 
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/clear_cooking_data()

--- a/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
+++ b/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
@@ -159,7 +159,8 @@
 
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/handle_burning()
 	clear()
-	new obj/item/reagent_containers/food/snacks/badrecipe(container)
+	new /obj/item/reagent_containers/food/snacks/badrecipe(src)
+	update_icon()
 	return
 
 //Deletes contents of container.

--- a/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
+++ b/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
@@ -231,6 +231,7 @@
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/clear_cooking_data()
 	stove_data = list("High"=0 , "Medium" = 0, "Low"=0)
 	grill_data = list("High"=0 , "Medium" = 0, "Low"=0)
+	oven_data = list("High"=0 , "Medium" = 0, "Low"=0)
 
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/proc/label(var/number, var/CT = null)
 	//This returns something like "Fryer basket 1 - empty"

--- a/code/modules/cooking_with_jane/cooking_tracker.dm
+++ b/code/modules/cooking_with_jane/cooking_tracker.dm
@@ -188,7 +188,7 @@
 			else
 				recipe_string += ", or \a [pointer.current_recipe.name]"
 		if(user)
-			if(alert(user, "If you finish cooking now, you will create [recipe_string]. However, you feel there are possibilities beyond even this. Continue cooking anyways?",,"Yes","No") == "Yes")
+			if(alert(user, "If you finish cooking now, you will create [recipe_string]. However, you feel there are possibilities beyond even this. Finish the meal?",,"Yes","No") == "No")
 				//Cull finished recipe items
 				for (var/datum/cooking_with_jane/recipe_pointer/pointer in completed_list)
 					active_recipe_pointers.Remove(pointer)
@@ -205,10 +205,13 @@
 		if(user)
 			if(completed_list.len > 1)
 				completion_lockout = TRUE
-				var/choice = input(user, "There's two things you complete at this juncture!", "Choose One:") in completed_list
+				var/choice = input(user, "There's multiple things you can complete at this juncture!", "Choose One:") in completed_list
 				completion_lockout = FALSE
 				if(choice)
 					chosen_pointer = completed_list[choice]
+		#ifdef CWJ_DEBUG
+		log_debug("/recipe_tracker/proc/process_item: Chosen Pointer: [chosen_pointer]")
+		#endif
 
 	//Call a proc that follows one of the steps in question, so we have all the nice to_chat calls.
 	var/datum/cooking_with_jane/recipe_step/sample_step = valid_steps[1]
@@ -220,6 +223,7 @@
 	if(chosen_pointer)
 		chosen_pointer.current_recipe.create_product(chosen_pointer)
 		return CWJ_COMPLETE
+
 	populate_step_flags()
 
 	if(has_traversed)
@@ -283,6 +287,7 @@
 
 //Points to a specific step in a recipe while considering the optional paths that recipe can take.
 /datum/cooking_with_jane/recipe_pointer
+	var/name
 	var/datum/cooking_with_jane/recipe/current_recipe //The recipe being followed here.
 	var/datum/cooking_with_jane/recipe_step/current_step //The current step in the recipe we are following.
 
@@ -317,6 +322,8 @@
 	#ifdef CWJ_DEBUG
 		steps_taken["[current_step.unique_id]"]="Started with a [start_type]"
 	#endif
+
+	name = current_recipe.name
 
 //A list returning the next possible steps in a given recipe
 /datum/cooking_with_jane/recipe_pointer/proc/get_possible_steps()

--- a/code/modules/cooking_with_jane/recipes/recipe.dm
+++ b/code/modules/cooking_with_jane/recipes/recipe.dm
@@ -572,7 +572,8 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sliceable/bread
 	recipe_guide = "Put dough in an oven, bake for 30 seconds on medium."
 	step_builder = list(
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.5),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=1),
+		list(CWJ_ADD_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/butterslice, qmod=0.5, min=5),
 		list(CWJ_ADD_REAGENT_OPTIONAL, "woodpulp", 5),
 		list(CWJ_USE_OVEN, J_MED, 30 SECONDS)
 	)
@@ -583,8 +584,9 @@
 	step_builder = list(
 		list(CWJ_ADD_REAGENT, "blackpepper", 1),
 		list(CWJ_ADD_REAGENT, "sodiumchloride", 1),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.5),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.6),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.6),
+		list(CWJ_ADD_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/butterslice, qmod=0.5, min=5),
 		list(CWJ_USE_OVEN, J_MED, 30 SECONDS)
 	)
 

--- a/code/modules/cooking_with_jane/recipes/recipe_dough.dm
+++ b/code/modules/cooking_with_jane/recipes/recipe_dough.dm
@@ -3,8 +3,8 @@
 	cooking_container = BOWL
 	product_type = /obj/item/reagent_containers/food/snacks/dough
 	step_builder = list(
-		list(CWJ_ADD_REAGENT, "egg", 3),
-		list(CWJ_ADD_REAGENT, "flour", 10),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=1),
+		list(CWJ_ADD_REAGENT, "flour", 10, remain_percent=0),
 		list(CWJ_ADD_REAGENT, "water", 2, remain_percent=0)
 	)
 
@@ -14,9 +14,12 @@
 	product_type = /obj/item/reagent_containers/food/snacks/dough
 	product_count = 5
 	step_builder = list(
-		list(CWJ_ADD_REAGENT, "enzyme", 1, remain_percent=0),
-		list(CWJ_ADD_REAGENT, "egg", 15),
-		list(CWJ_ADD_REAGENT, "flour", 50),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=0.2),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=0.2),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=0.2),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=0.2),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/egg, qmod=0.2),
+		list(CWJ_ADD_REAGENT, "flour", 50, remain_percent=0),
 		list(CWJ_ADD_REAGENT, "water", 10, remain_percent=0)
 	)
 

--- a/code/modules/cooking_with_jane/recipes/recipe_dough.dm
+++ b/code/modules/cooking_with_jane/recipes/recipe_dough.dm
@@ -1,0 +1,49 @@
+
+/datum/cooking_with_jane/recipe/dough
+	cooking_container = BOWL
+	product_type = /obj/item/reagent_containers/food/snacks/dough
+	step_builder = list(
+		list(CWJ_ADD_REAGENT, "egg", 3),
+		list(CWJ_ADD_REAGENT, "flour", 10),
+		list(CWJ_ADD_REAGENT, "water", 2, remain_percent=0)
+	)
+
+/datum/cooking_with_jane/recipe/dough_batch
+	name="batch of dough"
+	cooking_container = BOWL
+	product_type = /obj/item/reagent_containers/food/snacks/dough
+	product_count = 5
+	step_builder = list(
+		list(CWJ_ADD_REAGENT, "enzyme", 1, remain_percent=0),
+		list(CWJ_ADD_REAGENT, "egg", 15),
+		list(CWJ_ADD_REAGENT, "flour", 50),
+		list(CWJ_ADD_REAGENT, "water", 10, remain_percent=0)
+	)
+
+/datum/cooking_with_jane/recipe/kneaded_dough
+	name="kneaded dough"
+	cooking_container = CUTTING_BOARD
+	product_type = /obj/item/reagent_containers/food/snacks/dough
+	step_builder = list(
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=1, max=70),
+		list(CWJ_ADD_REAGENT, "flour", 1, remain_percent=0),
+		list(CWJ_ADD_REAGENT, "enzyme", 1, remain_percent=0),
+		list(CWJ_USE_TOOL, QUALITY_HAMMERING, 1, max=10, qmod=0.3)
+	)
+
+/datum/cooking_with_jane/recipe/kneaded_dough_batch
+	name="batch of kneaded dough"
+	cooking_container = CUTTING_BOARD
+	product_type = /obj/item/reagent_containers/food/snacks/dough
+	product_count = 5
+	step_builder = list(
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.2, max=70),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.2, max=70),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.2, max=70),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.2, max=70),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/dough, qmod=0.2, max=70),
+		list(CWJ_ADD_REAGENT, "flour", 5, remain_percent=0),
+		list(CWJ_ADD_REAGENT, "enzyme", 5, remain_percent=0),
+		list(CWJ_USE_TOOL, QUALITY_HAMMERING, 1, max=10, qmod=0.3)
+	)
+

--- a/code/modules/cooking_with_jane/step_types/add_reagent.dm
+++ b/code/modules/cooking_with_jane/step_types/add_reagent.dm
@@ -30,7 +30,6 @@
 /datum/cooking_with_jane/recipe_step/add_reagent/check_conditions_met(var/obj/used_item, var/datum/cooking_with_jane/recipe_tracker/tracker)
 	var/obj/item/container = tracker.holder_ref.resolve()
 
-	
 	if((container.reagents.total_volume + required_reagent_amount - container.reagents.get_reagent_amount(required_reagent_id)) > container.reagents.maximum_volume)
 		return CWJ_CHECK_FULL
 
@@ -43,6 +42,8 @@
 	if(our_item.amount_per_transfer_from_this <= 0)
 		return CWJ_CHECK_INVALID
 	if(our_item.reagents.total_volume == 0)
+		return CWJ_CHECK_INVALID
+	if(our_item.reagents.get_reagent_amount(required_reagent_id) == 0)
 		return CWJ_CHECK_INVALID
 
 	return CWJ_CHECK_VALID

--- a/code/modules/cooking_with_jane/step_types/use_tool.dm
+++ b/code/modules/cooking_with_jane/step_types/use_tool.dm
@@ -1,6 +1,6 @@
 //A cooking step that involves using an item on the food.
 /datum/cooking_with_jane/recipe_step/use_tool
-	class=CWJ_USE_ITEM
+	class=CWJ_USE_TOOL
 	var/tool_type
 	var/tool_quality
 	var/inherited_quality_modifier = 0.1

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -289,6 +289,7 @@ var/global/chicken_count = 0
 		visible_message("[src] [pick("lays an egg.","squats down and croons.","begins making a huge racket.","begins clucking raucously.")]")
 		eggsleft--
 		var/obj/item/reagent_containers/food/snacks/egg/E = new(get_turf(src))
+		E.food_quality = 20
 		E.pixel_x = rand(-6,6)
 		E.pixel_y = rand(-6,6)
 		if(chicken_count < MAX_CHICKENS && prob(25)) //Statistically, one out of four eggs will be capable of hatching

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -80,7 +80,7 @@
 	var/reaction_sound = 'sound/effects/bubbles.ogg'
 
 	var/list/require_containers = list() // This reaction will only occure in these containers(Or their subtypes).
-	var/list/blacklist_containers = list(/obj/machinery/microwave) // This reaction will not occure in these containers(Or their subtypes).
+	var/list/blacklist_containers = list(/obj/machinery/microwave, /obj/item/reagent_containers/cooking_with_jane) // This reaction will not occure in these containers(Or their subtypes).
 
 	var/log_is_important = 0 // If this reaction should be considered important for logging. Important recipes message admins when mixed, non-important ones just log to file.
 

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1889,6 +1889,7 @@
 #include "code\modules\cooking_with_jane\cooking_items\spatula.dm"
 #include "code\modules\cooking_with_jane\recipes\recipe.dm"
 #include "code\modules\cooking_with_jane\recipes\recipe_donuts.dm"
+#include "code\modules\cooking_with_jane\recipes\recipe_dough.dm"
 #include "code\modules\cooking_with_jane\step_types\add_item.dm"
 #include "code\modules\cooking_with_jane\step_types\add_produce.dm"
 #include "code\modules\cooking_with_jane\step_types\add_reagent.dm"


### PR DESCRIPTION
- Prevents containers placed in an oven from storing time infinitely, leading to a feedback loop where it caused later recipes to be low quality.
- Cleans up typos in the oven action texts
- Measuring Cooking time should be improved across the board
- Food is burned if left to cook in an oven for too long
- Ovens, Grills and Stoves catch fire if left on with food too long; will trigger nearby fire alarms and require an extinguisher to put out.
- This "fire" is smoke that deals oxy damage if nearby without a gas mask or airtight suit
- Improved oven open/close interactions
- Added CWJ recipes for making and kneading up high quality dough, and making dough batches
- Small bug removed from use_tool step type
- Laid chicken eggs have  more food quality
- Improved Reagent quality calculation
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
