### PR TITLE
Fixes the Guild part of the disposal line

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -39,7 +39,7 @@
 			if(H.species.can_shred(user))
 				attack_generic(user,1,"slices")
 
-	if(!(user in climbers))
+	if(LAZYLEN(climbers) && !(user in climbers))
 		user.visible_message(SPAN_WARNING("[user.name] shakes \the [src]."), \
 					SPAN_NOTICE("You shake \the [src]."))
 		structure_shaken()

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -34253,9 +34253,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"gNL" = (
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/virology)
 "gNN" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/flora/jungle_tree,
@@ -37773,7 +37770,8 @@
 	dir = 1
 	},
 /obj/machinery/conveyor/east{
-	id = "disposals grinder"
+	id = "disposals grinder";
+	operating = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
@@ -41441,8 +41439,7 @@
 /obj/machinery/button/remote/blast_door{
 	id = "AI_maint_hatch";
 	name = "Maintenance Hatch Control";
-	pixel_x = -24;
-	req_access = null
+	pixel_x = -24
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -45317,10 +45314,11 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/command/hallway)
 "iUx" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
 /obj/structure/plasticflaps,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder";
+	operating = 1
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
 "iUy" = (
@@ -50726,7 +50724,8 @@
 /area/nadezhda/crew_quarters/pool)
 "jYT" = (
 /obj/machinery/conveyor/east{
-	id = "disposals grinder"
+	id = "disposals grinder";
+	operating = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
@@ -56774,8 +56773,7 @@
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_telecomm";
 	name = "Maintenance Hatch Control";
-	pixel_x = -24;
-	req_access = null
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/nadezhda/command/tcommsat/computer)
@@ -91343,7 +91341,8 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rTM" = (
 /obj/machinery/conveyor/east{
-	id = "disposals grinder"
+	id = "disposals grinder";
+	operating = 1
 	},
 /obj/machinery/pile_ripper,
 /turf/simulated/floor/plating/under,
@@ -94535,8 +94534,7 @@
 "sxQ" = (
 /obj/machinery/smelter/cargo_t2_parts{
 	input_side = 8;
-	output_side = 4;
-	refuse_output_side = 1
+	output_side = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
@@ -95275,7 +95273,8 @@
 /area/nadezhda/maintenance/substation/sec)
 "sFu" = (
 /obj/machinery/conveyor/east{
-	id = "disposals grinder"
+	id = "disposals grinder";
+	operating = 1
 	},
 /obj/item/scrap_lump,
 /turf/simulated/floor/plating/under,
@@ -176256,7 +176255,7 @@ edp
 odD
 otL
 huz
-gNL
+odD
 pdU
 dWI
 cyo

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -34253,6 +34253,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"gNL" = (
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/virology)
 "gNN" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/flora/jungle_tree,
@@ -45314,7 +45317,6 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/command/hallway)
 "iUx" = (
-/obj/structure/plasticflaps,
 /obj/machinery/conveyor/east{
 	id = "disposals grinder";
 	operating = 1
@@ -50727,6 +50729,7 @@
 	id = "disposals grinder";
 	operating = 1
 	},
+/obj/structure/plasticflaps,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
 "jZa" = (
@@ -71703,13 +71706,10 @@
 /obj/effect/floor_decal/border/carpet/orange/corner,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"odD" = (
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/virology)
 "odF" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/window/reinforced,
+/obj/structure/railing,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
 "odM" = (
@@ -176252,10 +176252,10 @@ cnr
 pHr
 cOx
 edp
-odD
+gNL
 otL
 huz
-odD
+gNL
 pdU
 dWI
 cyo
@@ -193469,7 +193469,7 @@ sOw
 sVn
 hgO
 odF
-iUx
+jYT
 mQR
 cXt
 tip
@@ -193873,7 +193873,7 @@ sgw
 osE
 vWt
 dqA
-jYT
+iUx
 nuH
 nEC
 tip


### PR DESCRIPTION
Pretty much the title, plus the conveyor line is changed to start on as to not clog the line in case of no Guild

## Changelog
:cl:
fix: guild smelter has correct outputs
code: changes a line as per shadow's instructions
tweak: guild conveyor starts on
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
