### PR TITLE
Remove overlay stat logging at round end

### DIFF
--- a/code/controllers/subsystems/overlays.dm
+++ b/code/controllers/subsystems/overlays.dm
@@ -6,9 +6,6 @@ SUBSYSTEM_DEF(overlays)
 /datum/controller/subsystem/overlays/PreInit()
 	stats = list()
 
-/datum/controller/subsystem/overlays/Shutdown()
-	text2file(render_stats(stats), "[GLOB.log_directory]/overlay.log")
-
 /datum/controller/subsystem/overlays/Recover()
 	stats = SSoverlays.stats
 


### PR DESCRIPTION
## About The Pull Request
Maybe this is the problem on live?

## Changelog
:cl:
fix: SSoverlays no longer tries to write a big file on round end
/:cl:
