### PR TITLE
converts the HEV suit to new armor system

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -622,9 +622,9 @@ obj/item/clothing/head/sunhat/verb/toggle_style()
 	brightness_on = 5
 	light_overlay = "hardhat_light"
 	armor_list = list(
-		melee = 60,
-		bullet = 55,
-		energy = 50,
+		melee = 16,
+		bullet = 15,
+		energy = 13,
 		bomb = 75,
 		bio = 100,
 		rad = 100

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -477,9 +477,9 @@ obj/item/clothing/suit/gownrisque/alt
 	siemens_coefficient = 0.4
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor_list = list(
-		melee = 60,
-		bullet = 55,
-		energy = 50,
+		melee = 16,
+		bullet = 15,
+		energy = 13,
 		bomb = 75,
 		bio = 100,
 		rad = 100


### PR DESCRIPTION
Guess HEV suit got missed in the merge conflicts. OH well! Fixed now


changelog:

Converts the HEV suit over to the new armor system numbers. (so it no longer makes you near immortal) 