### PR TITLE
Hopefully fixes lodge bolt lance and minor smelter fixes.

### DIFF
--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -33,6 +33,8 @@
 
 /obj/machinery/smelter/cargo_t2_parts
 	input_side = WEST
+	output_side = NORTH
+	refuse_output_side = EAST
 
 /obj/machinery/smelter/cargo_t2_parts/Initialize()
 	. = ..()

--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -32,6 +32,7 @@
 	var/scrap_multiplier = 0.5 //50% refunds
 
 /obj/machinery/smelter/cargo_t2_parts
+	input_side = WEST
 
 /obj/machinery/smelter/cargo_t2_parts/Initialize()
 	. = ..()
@@ -296,11 +297,11 @@
 				var/material/M = get_material_by_name(mtype)
 				var/mat_ui_data = M.ui_data(user)
 				mat_ui_data["count"] = item_materials[mtype]
-			
+
 				if(istype(current_item, /obj/item/stack))
 					var/obj/item/stack/S = current_item
 					mat_ui_data["count"] *= S.amount
-				else 
+				else
 					mat_ui_data["count"] *= scrap_multiplier
 
 				item_materials_data += list(mat_ui_data)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -154,10 +154,10 @@
 	icon = 'icons/mob/64x64.dmi'
 	icon_state = "yaoguai"
 	icon_dead = "yaoguai_dead"
-	maxHealth = 400 * MEGAFAUNA_HEALTH_MOD
-	health = 400 * MEGAFAUNA_HEALTH_MOD
+	maxHealth = 300 * MEGAFAUNA_HEALTH_MOD
+	health = 300 * MEGAFAUNA_HEALTH_MOD
 	melee_damage_lower = 40 //Low health but an extremely powerful hitter
-	melee_damage_upper = 50 //You call 400 HP LOW HEALTH?! - Seb
+	melee_damage_upper = 50 //You call 400 HP LOW HEALTH?! - Seb //I got you Seb...little better now.
 	leather_amount = 10
 	bones_amount = 10
 	pixel_x = -16

--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -235,7 +235,7 @@
 	turns_per_move = 4
 	vision_range = 8
 	aggro_vision_range = 20
-	armor = list(melee = 5, bullet = 14, energy = 12, bomb = 5, bio = 10, agony = 10, rad = 25)	
+	armor = list(melee = 5, bullet = 14, energy = 12, bomb = 5, bio = 10, agony = 10, rad = 25)
 	inherent_mutations = list(MUTATION_GIGANTISM, MUTATION_CLUMSY, MUTATION_COUGHING, MUTATION_NERVOUSNESS, MUTATION_GREATER_CLOAKING)
 
 /mob/living/simple_animal/hostile/nightmare/MoveToTarget()
@@ -374,8 +374,8 @@
 	icon_dead = "slepnir_dead"
 	melee_damage_lower = 30
 	melee_damage_upper = 35
-	maxHealth = 550 * MEGAFAUNA_HEALTH_MOD
-	health = 550 * MEGAFAUNA_HEALTH_MOD
+	maxHealth = 350 * MEGAFAUNA_HEALTH_MOD
+	health = 350 * MEGAFAUNA_HEALTH_MOD
 	vision_range = 8
 	aggro_vision_range = 16
 	move_to_delay = 1

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -95,7 +95,7 @@
 // 9mm BIG BAWKS
 /obj/item/ammo_magazine/ammobox/pistol_35/large
 	name = "ammunition box (9mm)"
-	desc = "A large box of police grade 9mm. Has a proper less-than-lethal certification on the label."
+	desc = "A large box of police grade 9mm."
 	matter = list(MATERIAL_STEEL = 15)
 	w_class = ITEM_SIZE_BULKY
 	max_ammo = 200

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -1100,9 +1100,9 @@
 /obj/item/projectile/bullet/crossbow_bolt
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 22)
-	wounding_mult = WOUNDING_SMALL //Relatively small entry wound and straight impale.
-	armor_divisor = 1.5
+	damage_types = list(BRUTE = 25)
+	wounding_mult = WOUNDING_SERIOUS //decent but won't like armor
+	armor_divisor = 1.3
 	knockback = 0 //Bug doups hits
 	supereffective_types = list(/mob/living/carbon/human = FALSE, /mob/living = TRUE)
 	supereffective_mult = 1.5
@@ -1114,8 +1114,8 @@
 /obj/item/projectile/bullet/crossbow_bolt/lethal
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 15)
-	wounding_mult = WOUNDING_NORMAL //slightly bigger
+	damage_types = list(BRUTE = 30)
+	wounding_mult = WOUNDING_WIDE //slightly bigger
 	armor_divisor = 0.5
 	supereffective_types = list(/mob/living/carbon/human = FALSE, /mob/living = TRUE)
 	supereffective_mult = 1.5
@@ -1125,7 +1125,7 @@
 /obj/item/projectile/bullet/crossbow_bolt/hv
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 15)
+	damage_types = list(BRUTE = 20)
 	armor_divisor = 3
 	penetrating = 3
 	hitscan = TRUE


### PR DESCRIPTION
requesting a TM since I'd like to play with these lodge numbers on live and tweak them more. Im still somewhat stuck. supereffectivness on projectile weapons is *still* not working and I don't know why. If anyone has ideas lemme know.

IMPORTANT NOTE: Merge #5561 before TMing this
Changelog:

Fixes the prebuilt guild smelter. It now has space OSHA compliant settings by default and hopefully should reduce the the number of adepts down disposals.
Fixes the desc if 9mm ball boxes. They  no longer declare to be non-lethal

Nerfs mukwah knocking them down to 300 health from 400. (way to chonky on new combat)
Nerfs slepnirs down to 350 from 550. (hypersonic speeds plus crazy health was making them pretty much guaranteed death)

Buffs lodge bolt lance projectiles. generally just higher damage.
