### PR TITLE
some combat PR balance tweaks

### DIFF
--- a/code/game/objects/random/rig.dm
+++ b/code/game/objects/random/rig.dm
@@ -6,31 +6,31 @@
 /obj/random/rig/item_to_spawn()
 	return pickweight(list(
 	//Uncommon/civilian ones. These should make up most of the rig spawns
-	/obj/item/rig/eva = 20,
+	/obj/item/rig/eva = 40,
 	/obj/item/rig/eva/equipped = 10,
-	/obj/item/rig/medical = 20,
+	/obj/item/rig/medical = 30,
 	/obj/item/rig/medical/equipped = 10,
-	/obj/item/rig/light = 20,
-	/obj/item/rig/industrial = 20,
-	/obj/item/rig/industrial/equipped = 10,
-	/obj/item/rig/light/hacker = 20,
+	/obj/item/rig/light = 10,
+	/obj/item/rig/industrial = 10,
+	/obj/item/rig/industrial/equipped = 5,
+	/obj/item/rig/light/hacker = 10,
 	/obj/item/rig/light/hacker/equipped = 1, //has numerous rare modules including power sink and omni hud rare treat
 
 	//Head of staff
 	//obj/item/rig/ce = 10,
 	//obj/item/rig/ce/equipped = 5,
-	/obj/item/rig/hazmat = 5,
-	/obj/item/rig/hazmat/equipped = 2,
+	/obj/item/rig/hazmat = 2,
+	/obj/item/rig/hazmat/equipped = 1,
 
 	//Heavy armor
 	//obj/item/rig/combat = 10,
 	//obj/item/rig/combat/ironhammer = 10,
-	/obj/item/rig/hazard = 5,
+	/obj/item/rig/hazard = 2,
 
 	//The ones below here come with built in weapons
 	//obj/item/rig/combat/equipped = 4,
 	//obj/item/rig/combat/ironhammer/equipped = 4,
-	/obj/item/rig/hazard/equipped = 2,
+	/obj/item/rig/hazard/equipped = 1,
 	))
 
 /obj/random/rig/always_spawn

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -21,7 +21,7 @@
 	req_access = null
 	w_class = ITEM_SIZE_BULKY
 	item_flags = DRAG_AND_DROP_UNEQUIP|EQUIP_SOUNDS
-	price_tag = 600
+	price_tag = 1500
 
 	// These values are passed on to all component pieces.
 	armor = list(
@@ -42,7 +42,7 @@
 	obscuration = LIGHT_OBSCURATION
 	var/ablative_armor = 0
 	var/ablative_max = 0
-	var/ablation = ABLATION_STANDARD
+	var/ablation = ABLATION_SOFT
 	tool_qualities = list(QUALITY_ARMOR = 100)
 	max_upgrades = 1
 	blacklist_upgrades = list(

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -14,7 +14,7 @@
 		bio = 100,
 		rad = 100
 	)
-	price_tag = 1500
+	price_tag = 3500
 	slowdown = 0.3
 	drain = 4
 	offline_slowdown = 3

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -17,6 +17,7 @@
 	slowdown = 0
 	obscuration = 0
 	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | DRAG_AND_DROP_UNEQUIP | EQUIP_SOUNDS
+	price_tag = 1000
 	offline_slowdown = 0
 	offline_vision_restriction = 0
 	drain = 2
@@ -51,8 +52,6 @@
 		bio = 100,
 		rad = 45
 	)
-	ablative_max = 12
-	ablation = ABLATION_SOFT
 	airtight = 0
 	seal_delay = 5
 	slowdown = -0.2 //We speed up the user at cost of horrable armor
@@ -80,7 +79,7 @@
 	desc = "A Soteria Institute modification of the traditional light rig built for equal parts utility and defense."
 	suit_type = "SI 'retainer"
 	armor_list = list(
-		melee =7,
+		melee = 7,
 		bullet = 6,
 		energy = 7,
 		bomb = 30,
@@ -88,10 +87,13 @@
 		rad = 80
 	)
 	emp_protection = 20
+	ablative_armor = ABLATION_STANDARD //high quality armor
+	ablative_max = 6 //but not a lot of it.
 	seal_delay = 5
 	airtight = 0
 	icon_state = "hacker_rig"
 	req_access = list(access_hop)
+	price_tag = 2000
 
 	initial_modules = list(
 		/obj/item/rig_module/mounted/taser,

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -24,7 +24,7 @@
 	offline_vision_restriction = 1
 	stiffness = 0
 	obscuration = 0
-	price_tag = 2000
+	price_tag = 4000
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/merc
 

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -42,13 +42,14 @@
 		bio = 100,
 		rad = 100
 	)
-	ablative_max = 8
-	ablation = ABLATION_SOFT
+	ablative_max = 14 //heavy ass suit, big ass armor.
+	ablation = ABLATION_STANDARD
 	slowdown = 0.3
 	drain = 3
 	offline_slowdown = 10
 	offline_vision_restriction = 2
 	emp_protection = -20
+	price_tag = 1500
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/industrial
 
@@ -91,6 +92,7 @@
 		rad = 100
 	)
 	seal_delay = 20
+	ablative_max = 5 //common suit, not really much in the way of room for armor.
 	slowdown = 0
 	offline_slowdown = 1
 	offline_vision_restriction = 1
@@ -135,7 +137,7 @@ Advanced Voidsuit: Guild Master
 		rad = 100
 	)
 	ablative_max = 10
-	ablation = ABLATION_RESILIENT
+	ablation = ABLATION_STANDARD
 	seal_delay = 15
 	slowdown = 0
 	stiffness = 0
@@ -190,7 +192,7 @@ Technomancer RIG
 	desc = "An advanced RIG suit that protects against hazardous, low pressure and high temperature environments."
 	icon_state = "techno_rig"
 	armor_list = list(
-		melee =7,
+		melee = 7,
 		bullet = 7,
 		energy = 7,
 		bomb = 50,
@@ -198,7 +200,6 @@ Technomancer RIG
 		rad = 100
 	)
 	ablative_max = 10
-	ablation = ABLATION_DURABLE
 	drain = 3
 	offline_slowdown = 3
 	offline_vision_restriction = 0
@@ -244,7 +245,7 @@ Technomancer RIG
 	desc = "An Anomalous Material Interaction hardsuit that protects against the strangest energies the universe can throw at it."
 	icon_state = "science_rig"
 	armor_list = list(
-		melee =7,
+		melee = 7,
 		bullet = 5,
 		energy = 10,
 		bomb = 90,
@@ -297,7 +298,7 @@ Technomancer RIG
 	This advanced verson is made with speed in mind as well better armor plates at the cost of power."
 	icon_state = "science_ami_rig"
 	armor_list = list(
-		melee =8,
+		melee = 8,
 		bullet = 7,
 		energy = 10,
 		bomb = 90,
@@ -356,7 +357,7 @@ Technomancer RIG
 		bio = 100,
 		rad = 100
 	)
-	ablative_max = 10
+	ablative_max = 50
 	ablation = ABLATION_CERAMIC
 	slowdown = 0
 	offline_vision_restriction = 1
@@ -438,6 +439,8 @@ Technomancer RIG
 	req_access = list(access_cmo)
 	seal_delay = 4 //built for speed
 	slowdown = -0.3 //we get a bit more speed than the baseline recovery rig as this is a unique item with exactly 0 armor. This is for zipping around medical, rather than getting in the weeds
+	ablative_armor = 0
+	ablative_max = 0 //no armor, none.
 	helm_type = /obj/item/clothing/head/helmet/space/rig/cmo
 	max_upgrades = 1
 	initial_modules = list(
@@ -465,7 +468,7 @@ Technomancer RIG
 		bio = 100,
 		rad = 100
 	)
-	price_tag = 1500
+	price_tag = 3000
 	ablative_max = 8
 	ablation = ABLATION_DURABLE // Lasts longer than most rigs
 	slowdown = 0.3

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -23,7 +23,7 @@
 		dmg_types[damagetype] += damage
 
 	if(armor_divisor <= 0)
-		armor_divisor = 1
+		armor_divisor = 0.001
 		log_debug("[used_weapon] applied damage to [name] with a nonpositive armor divisor")
 
 	var/total_dmg = 0

--- a/code/modules/projectiles/guns/projectile/shotgun/buffalo.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/buffalo.dm
@@ -22,7 +22,7 @@
 	bulletinsert_sound 	= 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 10)
 	price_tag = 800
-	penetration_multiplier = 0.8
+	penetration_multiplier = 1.5
 	pierce_multiplier = 2
 	damage_multiplier = 0.8
 	init_recoil = RIFLE_RECOIL(1.4)

--- a/code/modules/projectiles/guns/projectile/shotgun/swat.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/swat.dm
@@ -19,6 +19,7 @@
 	init_recoil = RIFLE_RECOIL(0.6)
 	saw_off = FALSE //No
 	folding_stock = TRUE //we can fold are stocks
+	gun_parts = null //no deconstructing
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,


### PR DESCRIPTION
Buffalo has 1.5 AP mod up from 0.8

specialized RIG modules are generally rarer and more expensive, the standard level of ablative armor has gone from 10 to 5(that is to say, they now provide an extra 5 destroyable armor instead of 10, as this was maybe a bit much. combat suits retain their high ablation value.)

Industrial RIG has retained high ablation and gained a bit of max ablative, given that it's slow and kinda rare. makes it good for miners, but maybe not ideal for combat.

SWAT may no longer be disassembled.

if your armor divisor somehow becomes negative, instead of returning a 1 it return a 0.001, meanuing it is no longer a good idea to accept a negative armor divisor as it will unironically be unable to penetrate even jackboot tier armor.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
