### PR TITLE
Tweaks spawn rates of ore in slab + psion fix

### DIFF
--- a/code/modules/mining/drilling/slab_mining.dm
+++ b/code/modules/mining/drilling/slab_mining.dm
@@ -118,14 +118,14 @@
 		stored_points = 0
 
 	//Quite bad at statistics so grain of salt ya? - Trilby
-	//20 out of 450 so 14ish% chance of nothing (refills soil digging)
-	//250 out of 450 so 56ish% chance of normal rockwalls basically useless
-	//139 out of 450 so 30ish% to be mineral wall could be any materal - as of commiting the weights are 100% to spawn with
+	//60 out of 450 so 8ish% chance of nothing (refills soil digging)
+	//250 out of 450 so 71ish% chance of normal rockwalls basically useless
+	//139 out of 450 so 19ish% to be mineral wall could be any materal - as of commiting the weights are 100% to spawn with
 	//list(ORE_URANIUM = 5, ORE_PLATINUM = 5, ORE_IRON = 35, ORE_CARBON = 35, ORE_DIAMOND = 1, ORE_GOLD = 5, ORE_SILVER = 5, ORE_PLASMA = 10, ORE_HYDROGEN = 1)
 
 	//And then a 1 out of 300 or about 0.3% chance of a rocky friend :3c
 	for(var/turf/simulated/floor/asteroid/MS in work_area.contents)
-		switch (pickweight(list("nothing" = 60,"rockwall" = 250, "mineral_wall" = 139, "ameridian_crystal" = 1)))
+		switch (pickweight(list("nothing" = 60, "rockwall" = 499, "mineral_wall" = 139, "ameridian_crystal" = 1)))
 			if("nothing")
 				if(MS.dug)
 					MS.dug = FALSE

--- a/code/modules/mining/drilling/slab_mining.dm
+++ b/code/modules/mining/drilling/slab_mining.dm
@@ -11,7 +11,7 @@
 	circuit = /obj/item/circuitboard/slab_consol
 	dir = NORTH
 	var/all_cleared = FALSE
-	var/point_reward = 300
+	var/point_reward = 100
 	var/first_time = TRUE //So we dont give a free 1k on first spawn
 
 /obj/item/circuitboard/slab_consol

--- a/code/modules/mining/drilling/slab_mining.dm
+++ b/code/modules/mining/drilling/slab_mining.dm
@@ -118,14 +118,14 @@
 		stored_points = 0
 
 	//Quite bad at statistics so grain of salt ya? - Trilby
-	//20 out of 300 so 6% chance of nothing (refills soil digging)
-	//140 out of 300 so 46ish% chance of normal rockwalls basically useless
-	//139 out of 300 so 45ish% to be mineral wall could be any materal - as of commiting the weights are 100% to spawn with
+	//20 out of 450 so 14ish% chance of nothing (refills soil digging)
+	//250 out of 450 so 56ish% chance of normal rockwalls basically useless
+	//139 out of 450 so 30ish% to be mineral wall could be any materal - as of commiting the weights are 100% to spawn with
 	//list(ORE_URANIUM = 5, ORE_PLATINUM = 5, ORE_IRON = 35, ORE_CARBON = 35, ORE_DIAMOND = 1, ORE_GOLD = 5, ORE_SILVER = 5, ORE_PLASMA = 10, ORE_HYDROGEN = 1)
 
 	//And then a 1 out of 300 or about 0.3% chance of a rocky friend :3c
 	for(var/turf/simulated/floor/asteroid/MS in work_area.contents)
-		switch (pickweight(list("nothing" = 20,"rockwall" = 140, "mineral_wall" = 139, "ameridian_crystal" = 1)))
+		switch (pickweight(list("nothing" = 60,"rockwall" = 250, "mineral_wall" = 139, "ameridian_crystal" = 1)))
 			if("nothing")
 				if(MS.dug)
 					MS.dug = FALSE

--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -37,8 +37,8 @@
 	var/cognitive_potential = 0
 	//The maxium amount are cog can lower cooldown
 	var/cognitive_potential_max = 3
-
-
+	//Used for things outside of when we gather it in regen
+	var/psi_max_other_sources = 0
 
 	owner_verbs = list(
 		/mob/living/carbon/human/proc/psionic_healing,

--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -67,8 +67,6 @@
 
 		//Now we do are math to under are point cap and regen
 		psi_max_bonus = 0 + psi_max_other_sources
-		cognitive_potential_max += psionic_equipment_check("cognitive_potential_max_bonus")
-
 
 		if(!owner.stats.getPerk(PERK_PSION))
 			owner.stats.addPerk(PERK_PSION)
@@ -83,7 +81,7 @@
 
 		max_psi_points = round(clamp((owner.stats.getStat(STAT_COG) * 0.1), 1, 30)) + psi_max_bonus
 
-		cognitive_potential = round(clamp((owner.stats.getStat(STAT_COG) * 0.1), 0, cognitive_potential_max), 0.1)
+		cognitive_potential = round(clamp((owner.stats.getStat(STAT_COG) * 0.1), 0, (cognitive_potential_max+psionic_equipment_check("cognitive_potential_max_bonus"))), 0.1)
 
 		var/regen_points_timer = (5 MINUTES - cognitive_potential MINUTES)
 

--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -66,6 +66,7 @@
 		remove_synthetics()
 
 		//Now we do are math to under are point cap and regen
+		psi_max_bonus = 0 + psi_max_other_sources
 		cognitive_potential_max += psionic_equipment_check("cognitive_potential_max_bonus")
 
 


### PR DESCRIPTION
Reduces the spawns of ore nodes to about 30% for spawns for the slab
Makes it so psionic bounce gets reset to 0 rather then endlessly added