### PR TITLE
Fixes RIG ablative armor readout, nerfs AMI rig.

### DIFF
--- a/code/game/objects/random/rig.dm
+++ b/code/game/objects/random/rig.dm
@@ -19,8 +19,8 @@
 	//Head of staff
 	//obj/item/rig/ce = 10,
 	//obj/item/rig/ce/equipped = 5,
-	/obj/item/rig/hazmat = 1,
-	/obj/item/rig/hazmat/equipped = 1,
+	/obj/item/rig/hazmat = 5,
+	/obj/item/rig/hazmat/equipped = 2,
 
 	//Heavy armor
 	//obj/item/rig/combat = 10,

--- a/code/game/objects/random/rig.dm
+++ b/code/game/objects/random/rig.dm
@@ -19,8 +19,8 @@
 	//Head of staff
 	//obj/item/rig/ce = 10,
 	//obj/item/rig/ce/equipped = 5,
-	/obj/item/rig/hazmat = 5,
-	/obj/item/rig/hazmat/equipped = 2,
+	/obj/item/rig/hazmat = 1,
+	/obj/item/rig/hazmat/equipped = 1,
 
 	//Heavy armor
 	//obj/item/rig/combat = 10,

--- a/code/game/objects/random/science.dm
+++ b/code/game/objects/random/science.dm
@@ -18,8 +18,8 @@
 	/obj/item/stock_parts/micro_laser/high = 2,
 	/obj/item/computer_hardware/hard_drive/portable/research_points = 5,
 	/obj/item/computer_hardware/hard_drive/portable/research_points/rare = 1,
-	/obj/item/rig/hazmat = 2,
-	/obj/item/rig/hazmat/equipped = 1,
+	/obj/item/rig/hazmat = 0.5,
+	/obj/item/rig/hazmat/equipped = 0.25,
 	/obj/item/tool/multitool/uplink = 0.001, //REALLY RARE
 	/obj/item/device/radio/headset/uplink = 0.001,
 	/obj/item/hydrogen_fuel_cell = 0.1,

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -169,7 +169,7 @@
 				to_chat(usr, "The armor system reports critical failure! Repairs mandatory.")
 			if(0.5 to 0.8)
 				to_chat(usr, "The armor system reports heavy damage. Repairs required.")
-			if(0.8 to 1)
+			if(0.8 to 0.99)
 				to_chat(usr, "The armor system reports insignificant damage. Repairs advised.")
 
 /obj/item/rig/Initialize()

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -252,10 +252,11 @@ Technomancer RIG
 		rad = 100
 	)
 	ablative_max = 12
-	ablation = ABLATION_EVERLASTING
+	ablation = ABLATION_DURABLE
 	slowdown = 0.3
 	drain = 3
 	offline_vision_restriction = 1
+	price_tag = 3000 //same as hazard suit, it is arguably better than that one because it has hella bomb armor.
 
 	helm_type = /obj/item/clothing/head/helmet/space/rig/hazmat
 


### PR DESCRIPTION
AMI rig no longer has the same ablation value as the other insanely powerful suits.

ablative armor 'need fixing or not' readout now properly says when it's fully fixed.

AMI rig is no longer cheaper than the hazard suit while having comparable if not better performance. this suit will very likely get hit with the nerf stick in the future but for now this works.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
