### PR TITLE
splint fix and fpb mercy

### DIFF
--- a/code/game/objects/items/stacks/medical_stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical_stacks/medical.dm
@@ -25,6 +25,7 @@
 	var/bounce_faith_healer_amount = 5
 
 	var/fancy_icon = FALSE //This var is for mulitable icon states that DONT relie on a overlay
+	var/always_useful = FALSE
 
 /obj/item/stack/medical/proc/try_to_save_use(mob/living/user)
 	if(ishuman(user))
@@ -120,11 +121,12 @@
 				M.updatehealth()
 				return TRUE
 
-			to_chat(user, SPAN_WARNING("This isn't useful at all on a robotic limb."))
-			return TRUE
+			if(!always_useful)
+				to_chat(user, SPAN_WARNING("This isn't useful at all on a robotic limb."))
+				return TRUE
 
-		for(var/datum/wound/W in affecting.wounds)
-			if(disinfectant)
+		if(disinfectant)
+			for(var/datum/wound/W in affecting.wounds)
 				W.disinfect()
 
 		H.UpdateDamageIcon()

--- a/code/game/objects/items/stacks/medical_stacks/splint_stacks.dm
+++ b/code/game/objects/items/stacks/medical_stacks/splint_stacks.dm
@@ -6,6 +6,7 @@
 	max_amount = 5
 	fancy_icon = FALSE
 	bio_requirement = -25
+	always_useful = TRUE
 
 /obj/item/stack/medical/splint/improvised
 	name = "improvised bone splint"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -102,7 +102,7 @@
 	// TODO: Rig
 	// if(back && istype(back,/obj/item/rig))
 	// 	var/obj/item/rig/suit = back
-	
+
 	var/chemvessel_efficiency = get_organ_efficiency(OP_CHEMICALS)
 	if(chemvessel_efficiency > 1)
 		. += "Chemical Storage: [carrion_stored_chemicals]/[round(0.5 * chemvessel_efficiency)]"
@@ -993,8 +993,14 @@ var/list/rank_prefix = list(\
 						SPAN_WARNING("Your movement jostles [O] in your [organ.name] painfully."), \
 						SPAN_WARNING("Your movement jostles [O] in your [organ.name] painfully."))
 					to_chat(src, msg)
+
 				var/mob/living/carbon/human/H = organ.owner
 				if(!MOVING_DELIBERATELY(H))
+
+					//Unlike any other race syths main quirk of instantly dieing when battery is damaged is quite bad
+					if(species.reagent_tag == IS_SYNTHETIC && istype(organ, /obj/item/organ/external/chest))
+						continue
+
 					organ.take_damage(3, BRUTE, organ.max_damage, 6.7, TRUE, TRUE)	// When the limb is at 60% of max health, internal organs start taking damage.
 					if(organ.setBleeding())
 						organ.take_damage(2, BRUTE) //Extra 2 damage

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -68,7 +68,7 @@
 	var/cannot_break		// Impossible to fracture.
 	var/joint = "joint"		// Descriptive string used in dislocation.
 	var/amputation_point	// Descriptive string used in amputation.
-	var/nerve_struck = 0		// If you target a joint, you can dislocate the limb, impairing it's usefulness and causing pain
+	var/nerve_struck = 0	// If you target a joint, you can dislocate the limb, impairing it's usefulness and causing pain
 	var/encased				// Needs to be opened with a saw to access certain organs.
 	var/cavity_name = "cavity"				// Name of body part's cavity, displayed during cavity implant surgery
 	var/max_volume = ITEM_SIZE_SMALL	// Max w_class of cavity implanted items


### PR DESCRIPTION
You may now always splint any robot, as splints are always useful - basically fixes a bug

FPBS chest for shrapnel or other imbedded items no longer can be damaged, basically always counted as walking and or splinted for mercy reasons - FPBs **often** in a single step would gain 4 damage on FPB heart and instantly die. This was not deemed fun or engaging content