### PR TITLE
Autodoc Bugfix / Church Jobs Tweak

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -30,6 +30,7 @@
 		STAT_COG = 10,
 		STAT_VIG = 15,
 		STAT_TGH = 10,
+		STAT_ROB = 15,
 	)
 
 	perks = list(PERK_NEAT, PERK_GREENTHUMB, PERK_CHANNELING)
@@ -83,6 +84,7 @@
 	STAT_BIO = 10,
 	STAT_VIG = 10,
 	STAT_TGH = 5,
+	STAT_ROB = 10,
 	)
 	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 

--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -168,7 +168,7 @@
 			patchnote.surgery_operations &= ~AUTODOC_INTERNAL_WOUNDS
 
 /datum/autodoc/Process()
-	if(!patient || picked_patchnotes.len <= current_step)
+	if(!patient || picked_patchnotes.len <= current_step - 1)
 		stop()
 		return
 


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
Vectors and Primes now have strength training (+10 ROB for Vectors, +15 for Primes, to match their VIG stat buff and help them be more well-rounded statwise).

Autodocs are now (almost) fully operational. They will now complete all operations that are selected. Mapped-in autodocs will (probably) still need to be rebuilt before they operate.
<hr>
</details>

## Changelog
:cl:
bugfix: Autodocs now properly finish all selected operations. Mapped autodocs will likely still need rebuilding before they work.
/:cl:
