### PR TITLE
Quick botch fix for JTB portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -105,7 +105,7 @@ var/list/portal_cache = list()
 	if (M.anchored && !istype(M, /obj/mecha))
 		return
 	if (!( target ))
-		qdel(src)
+		close()		//SOJOURN EDIT: Prevents edgecases where mobs cross the junk field side before the station side portal is generated properly.
 		return
 	if (istype(M, /atom/movable))
 		if(prob(failchance)) //oh dear a problem, put em in deep space


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A quick one line change that should prevent Junk Field portal duds from happening. Tested locally on two occasions and it seems fine.

## Changelog
:cl: Toriate
fix: JTB portal should stop deleting itself when a mob crosses it before the stationside portal is generated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
