### PR TITLE
Maybe fixes dropped phatom guns

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1068,6 +1068,12 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 		var/datum/firemode/new_mode = firemodes[sel_mode]
 		new_mode.update(force_state)
 
+/obj/item/gun/proc/force_firemode_deselect(mob/user)
+	if (sel_mode && firemodes && firemodes.len)
+		var/datum/firemode/new_mode = firemodes[sel_mode]
+		new_mode.force_deselect(user)
+
+
 /obj/item/gun/AltClick(mob/user)
 	if(user.incapacitated())
 		to_chat(user, SPAN_WARNING("You can't do that right now!"))
@@ -1114,14 +1120,15 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	update_firemode()
 
 /obj/item/gun/dropped(mob/user)
+	update_firemode(FALSE)
 	// I really fucking hate this but this is how this is going to work.
 	var/mob/living/carbon/human/H = user
 	if(wielded)
 		unwield(H)
 	if (istype(H) && H.using_scope)
 		toggle_scope(H)
-	update_firemode(FALSE)
 	.=..()
+	force_firemode_deselect(H)
 
 /obj/item/gun/swapped_from()
 	.=..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1120,13 +1120,13 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	update_firemode()
 
 /obj/item/gun/dropped(mob/user)
-	update_firemode(FALSE)
 	// I really fucking hate this but this is how this is going to work.
 	var/mob/living/carbon/human/H = user
 	if(wielded)
 		unwield(H)
 	if (istype(H) && H.using_scope)
 		toggle_scope(H)
+	update_firemode(FALSE)
 	.=..()
 	force_firemode_deselect(H)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1116,6 +1116,8 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 /obj/item/gun/dropped(mob/user)
 	// I really fucking hate this but this is how this is going to work.
 	var/mob/living/carbon/human/H = user
+	if(wielded)
+		unwield(H)
 	if (istype(H) && H.using_scope)
 		toggle_scope(H)
 	update_firemode(FALSE)

--- a/code/modules/projectiles/gun_firemode.dm
+++ b/code/modules/projectiles/gun_firemode.dm
@@ -60,7 +60,7 @@
 		if(propname == "damage_mult_add")
 			gun.damage_multiplier += settings[propname]
 			continue
-		
+
 		try
 			gun.vars[propname] = settings[propname]
 
@@ -83,4 +83,7 @@
 
 //Called whenever the firemode is switched to, or the gun is picked up while its active
 /datum/firemode/proc/update()
+	return
+
+/datum/firemode/proc/force_deselect(mob/user)
 	return

--- a/code/modules/projectiles/guns/energy/charge.dm
+++ b/code/modules/projectiles/guns/energy/charge.dm
@@ -78,6 +78,13 @@
 		L.client.CH = CH //Put it on the client
 		CH.owner = L.client //And tell it where it is
 
+/datum/firemode/automatic/force_deselect(mob/user)
+	if(!CH)
+		return
+	if(CH.owner) //Remove our handler from the client
+		CH.owner.CH = null //wew
+		QDEL_NULL(CH) //And delete it
+
 /****************************
 	Charge gun click handler
 *****************************/

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -96,3 +96,13 @@
 		CH.receiver = gun //receiver is the gun that gets the fire events
 		L.client.CH = CH //Put it on the client
 		CH.owner = L.client //And tell it where it is
+
+/datum/firemode/automatic/force_deselect(mob/user)
+	if(CH)
+		if(CH.owner) //Remove our handler from the client
+			CH.owner.CH = null //wew
+			QDEL_NULL(CH) //And delete it
+	if(user.client)
+		if(user.client.CH)
+			user.client.CH = null
+			QDEL_NULL(user.client.CH)


### PR DESCRIPTION
## About The Pull Request
When dropping a gun it now will first thing unwield if wielded
When dropping a gun it now should forcefully delete the click checkers for firing said gun
This in theory should fix dropping guns and having them stick to you and fire from distance