### PR TITLE
Fixes an icon error

### DIFF
--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -347,6 +347,8 @@
 
 /obj/item/stack/material/wood
 	name = "wooden plank"
+	icon_state = "sheet-wood"
+	icon = 'icons/obj/stack/material.dmi'
 	default_type = MATERIAL_WOOD
 	price_tag = 1 //Way to easy to get on mass.
 


### PR DESCRIPTION
Wood planks now should have the icon back