### PR TITLE
Synth buffs for stats

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_synthetic.dm
+++ b/code/datums/setup_option/backgrounds/origin_synthetic.dm
@@ -1,3 +1,6 @@
+//Synths dont have level up or constant atm ways to gain stats so we frountload them so they are good at what they do
+//In general they get about 100 stats, some get less that are higher specilized in it
+
 /datum/category_item/setup_option/background/ethnicity/sot_synth_medical
 	name = "Medical Positronic"
 	desc = "Synthetics are often times built with a specific purpose in mind to augment the qualities most appropriate to the purpose they're intended for. Your specific model was designed with \
@@ -12,9 +15,9 @@
 		STAT_ROB = 0,
 		STAT_TGH = 0,
 		STAT_VIG = 0,
-		STAT_BIO = 30,
-		STAT_MEC = 0,
-		STAT_COG = 0
+		STAT_BIO = 60,
+		STAT_MEC = 15,
+		STAT_COG = 30
 	)
 
 /datum/category_item/setup_option/background/ethnicity/sot_synth_engineer
@@ -30,11 +33,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
-		STAT_TGH = 5,
+		STAT_TGH = 0,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
-		STAT_MEC = 15,
-		STAT_COG = 10
+		STAT_MEC = 65,
+		STAT_COG = 30
 	)
 
 /datum/category_item/setup_option/background/ethnicity/sot_synth_combat
@@ -49,11 +52,11 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 20,
-		STAT_TGH = 5,
-		STAT_VIG = 20,
+		STAT_ROB = 40,
+		STAT_TGH = 20,
+		STAT_VIG = 40,
 		STAT_BIO = 0,
-		STAT_MEC = -5,
+		STAT_MEC = 5,
 		STAT_COG = -5
 	)
 
@@ -73,8 +76,8 @@
 		STAT_TGH = 0,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
-		STAT_MEC = 30,
-		STAT_COG = 0
+		STAT_MEC = 80,
+		STAT_COG = 15
 	)
 
 /datum/category_item/setup_option/background/ethnicity/ag_synth_sturdy
@@ -89,11 +92,11 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
-		STAT_TGH = 0,
-		STAT_VIG = 5,
+		STAT_ROB = 30,
+		STAT_TGH = 25,
+		STAT_VIG = 25,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
+		STAT_MEC = 15,
 		STAT_COG = 20
 	)
 
@@ -110,15 +113,14 @@
 
 //Idea for this is that you were made with being a miner, thus giving you everything you need as one
 //The main boon being you get a bit of evey skill you /need/ to mine out faster and maintain tools / set up the big drills.
-//-0Loss Stats +15Gained Stat
 
 	stat_modifiers = list(
-		STAT_ROB = 25,
-		STAT_TGH = 0,
+		STAT_ROB = 50,
+		STAT_TGH = 10,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
-		STAT_MEC = 15,
-		STAT_COG = 5
+		STAT_MEC = 25,
+		STAT_COG = 15
 	)
 
 /datum/category_item/setup_option/background/ethnicity/blackshield_security
@@ -132,11 +134,11 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 20,
-		STAT_TGH = 5,
-		STAT_VIG = 20,
+		STAT_ROB = 50,
+		STAT_TGH = 25,
+		STAT_VIG = 40,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
+		STAT_MEC = 5,
 		STAT_COG = 0
 	)
 
@@ -152,11 +154,11 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 30,
-		STAT_TGH = 10,
-		STAT_VIG = 5,
+		STAT_ROB = 80,
+		STAT_TGH = 30,
+		STAT_VIG = 15,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
+		STAT_MEC = 5,
 		STAT_COG = 0
 	)
 
@@ -171,11 +173,11 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
-		STAT_TGH = 10,
-		STAT_VIG = 30,
+		STAT_ROB = 20,
+		STAT_TGH = 20,
+		STAT_VIG = 60,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
+		STAT_MEC = 10,
 		STAT_COG = 0
 	)
 
@@ -193,9 +195,9 @@
 		STAT_ROB = 0,
 		STAT_TGH = 0,
 		STAT_VIG = 0,
-		STAT_BIO = 30,
-		STAT_MEC = 0,
-		STAT_COG = 0
+		STAT_BIO = 50,
+		STAT_MEC = 20,
+		STAT_COG = 20
 	)
 
 /datum/category_item/setup_option/background/ethnicity/church_combat
@@ -208,13 +210,12 @@
 	racial_implants = (/obj/item/organ_module/active/simple/armblade/longsword)
 	//restricted_jobs = list(/datum/job/outsider)
 
-	//Compared to the soteria combat model and blackshield synths you get 20 armor across the body vs. 30/35 respectively, so what you lack in natural defense is made up in offense. -Kaz
 	stat_modifiers = list(
-		STAT_ROB = 25,
-		STAT_TGH = 10,
+		STAT_ROB = 45,
+		STAT_TGH = 30,
 		STAT_VIG = 25,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
+		STAT_MEC = 10,
 		STAT_COG = 0
 	)
 
@@ -230,11 +231,11 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
-		STAT_TGH = 0,
+		STAT_ROB = 15,
+		STAT_TGH = 10,
 		STAT_VIG = 10,
-		STAT_BIO = 5, //Given 10 bio racially.
-		STAT_MEC = 10,
+		STAT_BIO = 15,
+		STAT_MEC = 15,
 		STAT_COG = 15
 	)
 
@@ -249,9 +250,9 @@
 	restricted_to_species = list(FORM_FBP, FORM_UNBRANDED)
 
 	stat_modifiers = list(
-		STAT_ROB = 15,
+		STAT_ROB = 20,
 		STAT_TGH = 0,
-		STAT_VIG = 15,
+		STAT_VIG = 20,
 		STAT_BIO = 20,
 		STAT_MEC = 20,
 		STAT_COG = 20
@@ -268,11 +269,11 @@
 	restricted_to_species = list(FORM_FBP, FORM_UNBRANDED)
 
 	stat_modifiers = list(
-		STAT_ROB = 32, // No inbuilt weapons.
+		STAT_ROB = 40, // No inbuilt weapons.
 		STAT_TGH = 10,
-		STAT_VIG = 32,
+		STAT_VIG = 40,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
+		STAT_MEC = 10,
 		STAT_COG = 0
 	)
 
@@ -290,7 +291,7 @@
 		STAT_ROB = 0,
 		STAT_TGH = 0,
 		STAT_VIG = 0,
-		STAT_BIO = 25,
-		STAT_MEC = 25,
-		STAT_COG = 35 // Good on paper, but since you cannot be a psion, at best it helps with hacking and disarming landmines.
+		STAT_BIO = 30,
+		STAT_MEC = 35,
+		STAT_COG = 40 // Good on paper, but since you cannot be a psion, at best it helps with hacking and disarming landmines.
 	)


### PR DESCRIPTION
"Massive" increases synth background stats


A major source of synth stats was the backgrounds, this meant that they would if and only if min maxing to comparable rates that to a simple level up from any other race.
Lets look at one older example
30 bio for SI synth
lets say you are a doctor STAT_BIO = 40
then Wealthy Upbringing 5 bio
and home world of Madinat Yunan for 10
then dump 15 stat points in loadout and what do we get?
100... bio, that's it.... you basically then cant do anything but medical and not even at the skill cap using *every bit of resource you have*
That's lame, this is true for all general background's that force you to min max to get completive ultra single stats, that's not ideal or fun as then your stuck in a lane with no way out or use.


To correct for this every synth backround as they do not currently level up give about 100 stats some more spefic then others but in general should lead to synths being able to become better at their job without costing them every other stat in return