### PR TITLE
fixes tally issues + fixes some kegs + buffs herme shoes

### DIFF
--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -293,15 +293,15 @@
 
 /proc/statPointsToLevel(var/points)
 	switch(points)
-		if (-1000 to -100)
+		if (-100 to -1000)
 			return "Hopeless"
-		if (-100 to -50)
+		if (-50 to -100)
 			return "Blundering"
-		if (-50 to -20)
+		if (-20 to -50)
 			return "Incompetent"
-		if (-20 to -15)
-			return "Inept"
 		if (-15 to -1)
+			return "Inept"
+		if (-1 to -15)
 			return "Misinformed"
 		if (STAT_LEVEL_NONE to STAT_LEVEL_BASIC)
 			return "Untrained"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -117,12 +117,12 @@
 
 /obj/item/clothing/shoes/hermes_shoes
 	name = "Hermes Boots"
-	desc = "Boots used by the faithful to spread the word of God more quickly by small hidden wheels under the heels. Sadly not all that good at protecting your feet as other more robust boots."
+	desc = "Boots used by the faithful to spread the word of God more affectively with bulky items by small hidden wheels under the heels. Sadly not all that good at protecting your feet as other more robust boots."
 	armor_list = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GOLD = 2)
 	icon_state = "hermes"
 	item_state = "hermes"
-	slowdown = SHOES_SLOWDOWN - 0.1 //10% speed buff
+	slowdown = SHOES_SLOWDOWN - 0.3 //Less of a speed buff more of an off-set to slowdown
 	can_hold_knife = 1//Still boots
 	price_tag = 120
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -26,7 +26,7 @@
 	if(stats.getPerk(PERK_SCUTTLEBUG))
 		tally -= 0.3
 	if(stats.getPerk(PERK_REZ_SICKNESS))
-		tally -= 0.5
+		tally += 0.5
 	if(blocking)
 		tally += 1
 

--- a/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
@@ -109,18 +109,21 @@
 	price_tag = 1000
 
 /obj/structure/reagent_dispensers/beerkeg/cargo/New()
+	..()
 	price_tag = 100
 
 /obj/structure/reagent_dispensers/meadkeg/cargo
 	price_tag = 3800
 
 /obj/structure/reagent_dispensers/meadkeg/cargo/New()
+	..()
 	price_tag = 900
 
 /obj/structure/reagent_dispensers/premiumwhiskey/cargo
 	price_tag = 5000
 
 /obj/structure/reagent_dispensers/premiumwhiskey/cargo/New()
+	..()
 	price_tag = 500
 
 

--- a/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
@@ -157,10 +157,12 @@
 	price_tag = 600
 
 /obj/item/reagent_containers/food/drinks/cans/cahors/cargo/New()
+	..()
 	price_tag = 60
 
 /obj/item/reagent_containers/food/drinks/bottle/ntcahors/cargo
 	price_tag = 1200
 
 /obj/item/reagent_containers/food/drinks/bottle/ntcahors/cargo/New()
+	..()
 	price_tag = 100


### PR DESCRIPTION
Herme shoes do to how slowdown works now no longer seemed to give you a speed boost even if you ran 10+ tiles 
It has been buffed accordingly to help off-set inhand item slowdown
Fixes negative stats not properly showing
Rez Sickness now slows you down rather then speeds you up
Fixes some cargo kegs spawning wrong