### PR TITLE
antibluecross cheats

### DIFF
--- a/code/game/objects/items/weapons/storage/vendor_loot_boxes.dm
+++ b/code/game/objects/items/weapons/storage/vendor_loot_boxes.dm
@@ -178,7 +178,7 @@
 
 /obj/item/storage/box/vendor_lootbox/oddity_low/populate_contents()
 	if(prob(1)) //Lucky!
-		new /obj/random/oddity_guns(src)
+		new /obj/random/oddity_guns/propis_box(src)
 	else
 		new /obj/random/common_oddities/always_spawn(src)
 
@@ -189,7 +189,7 @@
 
 /obj/item/storage/box/vendor_lootbox/oddity_moderate/populate_contents()
 	if(prob(5)) //Lucky!
-		new /obj/random/oddity_guns(src)
+		new /obj/random/oddity_guns/propis_box(src)
 	else
 		new /obj/random/common_oddities/always_spawn(src)
 		new /obj/random/common_oddities/always_spawn(src)
@@ -201,7 +201,7 @@
 
 /obj/item/storage/box/vendor_lootbox/oddity_high/populate_contents()
 	if(prob(10)) //Lucky!
-		new /obj/random/oddity_guns(src)
+		new /obj/random/oddity_guns/propis_box(src)
 	else
 		new /obj/random/common_oddities/always_spawn(src)
 		new /obj/random/common_oddities/always_spawn(src)

--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -58,17 +58,16 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "wormhole_unstable"
 	has_postspawn = TRUE
-	late_handling = TRUE //Only used in GP moon base
+	late_handling = TRUE
 	anchored = TRUE
 	var/anticheat = TRUE
 	alpha = 255
 	invisibility = 0
-
 	layer = SIGN_LAYER
 
 /obj/random/oddity_guns/propis_box
 	has_postspawn = TRUE
-	late_handling = FALSE //Only used in GP moon base
+	late_handling = FALSE
 
 /obj/random/oddity_guns/attack_hand(mob/user as mob)
 	if(anticheat)

--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -53,9 +53,26 @@
 	spawn_nothing_percentage = 60
 
 /obj/random/oddity_guns
-	name = "random oddities weapons spawn"
-	icon_state = "techloot-grey"
+	name = "Unstable cross rift"
+	desc = "A rift that has eaten a cross weapon. The rift seems to be only able to reseave rather then send."
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "wormhole_unstable"
 	has_postspawn = TRUE
+	late_handling = TRUE //Only used in GP moon base
+	anchored = TRUE
+	var/anticheat = TRUE
+	alpha = 255
+	invisibility = 0
+
+	layer = SIGN_LAYER
+
+/obj/random/oddity_guns/attack_hand(mob/user as mob)
+	if(anticheat)
+		to_chat(user, SPAN_NOTICE("The rift drops a rare cross item before you even lift a hand to it."))
+		late_handling()
+		anticheat = FALSE
+		qdel(src)
+	to_chat(user, SPAN_NOTICE("The rift is eating itself far to much to get any more out of it."))
 
 /obj/random/oddity_guns/item_to_spawn()
 	var/item_to_spawn = random_grabber()

--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -66,6 +66,10 @@
 
 	layer = SIGN_LAYER
 
+/obj/random/oddity_guns/propis_box
+	has_postspawn = TRUE
+	late_handling = FALSE //Only used in GP moon base
+
 /obj/random/oddity_guns/attack_hand(mob/user as mob)
 	if(anticheat)
 		to_chat(user, SPAN_NOTICE("The rift drops a rare cross item before you even lift a hand to it."))


### PR DESCRIPTION
Bluecrosses now need to be mannaully spawned in via clicking a portal to drop the item
This is to stop ghosts and meta-gaming of what spawned where