### PR TITLE
runtimes food and fix for ians

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -241,3 +241,11 @@
 	preloaded_reagents = list("protein" = 8, "polystem" = 5, "quickclot" = 5)
 	slice_path = /obj/item/reagent_containers/food/snacks/chickenbreast
 	slices_num = 4
+
+/obj/item/reagent_containers/food/snacks/meat/runtimes_dinner
+	name = "Runtime's Dinner"
+	desc = "A plate of wet catfood, it smells."
+	icon_state = "soydope"
+	filling_color = "#3B8529"
+	preloaded_reagents = list("protein" = 8, "nutriment" = 15, "polystem" = 1)
+	slices_num = 0

--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -677,9 +677,6 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "dx" = (
 /obj/structure/table/rack/shelf,
-/obj/item/reagent_containers/cooking_with_jane/cooking_container/plate,
-/obj/item/reagent_containers/cooking_with_jane/cooking_container/plate,
-/obj/item/reagent_containers/cooking_with_jane/cooking_container/plate,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "dz" = (

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -14682,6 +14682,9 @@
 	dir = 8;
 	pixel_x = 32
 	},
+/obj/item/reagent_containers/food/snacks/meatsteak{
+	name = "ian's dinner"
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain)
 "cVZ" = (
@@ -22310,9 +22313,6 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "esf" = (
-/obj/item/reagent_containers/food/snacks/meatsteak{
-	name = "ian's dinner"
-	},
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = -32
 	},
@@ -33331,7 +33331,6 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "gzo" = (
-/obj/effect/floor_decal/industrial/warningred,
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
@@ -89026,6 +89025,7 @@
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
+/obj/item/reagent_containers/food/snacks/meat/runtimes_dinner,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "rny" = (


### PR DESCRIPTION
Gives back runtime their food
Moves ians steak outside the fire locker
Removes debug CWJ debug plates from hunters