### PR TITLE
Food descriptor fix

### DIFF
--- a/code/modules/cooking_with_jane/food_overrides.dm
+++ b/code/modules/cooking_with_jane/food_overrides.dm
@@ -15,16 +15,16 @@
 	else
 		switch(food_quality)
 			if(0)
-				food_descriptor = "It looks like an unappetizing a meal."
+				food_descriptor = "It looks like an unappetizing meal."
 			if(1 to 10)
 				food_descriptor = "The food is edible, but frozen dinners have been reheated with more skill."
 			if(11 to 20)
 				food_descriptor = "It looks adequately made."
-			if(21 to 30)
+			if(21 to 40)
 				food_descriptor = "The quality of the food is is pretty good."
-			if(31 to 50)
+			if(41 to 60)
 				food_descriptor = "This food looks very tasty."
-			if(61 to 70)
+			if(61 to 80)
 				food_descriptor = "There's a special spark in this cooking, a measure of love and care unseen by the casual chef."
 			if(81 to 99)
 				food_descriptor = "The quality of this food is legendary. Words fail to describe it further. It must be eaten"


### PR DESCRIPTION
Changed the numbers on the food descriptors to fill in the blanks that caused food to lack any descriptors at all. And changes a single letter in one of the descriptors, too.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
Did some tiny changes for the numbers to make sure there are no blanks. And removed a single letter and a space in one of the descriptors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: Changed the numbers that applied food descriptors to food.
del: " a"
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
