### PR TITLE
Removes a *BRUH* unexpanded debuff from SI synths 

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -817,7 +817,6 @@
 	injury_type =  INJURY_TYPE_UNLIVING
 	hunger_factor = 0
 	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN | NO_POISON | NO_MINOR_CUT
-	slowdown = 0.3
 	radiation_mod = 0
 	total_health = 75
 	breath_type = null


### PR DESCRIPTION
Removes a very random 0.3 slowdown stat from SI synths. Not sure what this was..or why this was. But SI synths had a random unexplained debuff. Maybe a mixup meaning to give them a buff?? Regardless. its dumb. Mini PR fixing it. YEARS off my life crawling places....

Changelog: 

Tweak: Removes the very small slowdown debuff SI synths suffer for no reason.