### PR TITLE
Buffs Divisors, changes Lemniscates, gives utility litany to prime

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -150,7 +150,7 @@
 		fail("You feel stupid.",user,C,targets)
 		return TRUE //You pay even if you don't actually talk to anyone. Sending shouldn't be a free version of Baptismal Record.
 
-	var/text = input(user, "What message will you send to the target? The message will be recieved telepathically.", "Sending a message") as text|null
+	var/text = input(user, "What message will you send to the target? The message will be recieved by their cruciform and heard in their mind.", "Sending a message") as text|null
 	if (!text)
 		return TRUE //You pay even if you don't actually talk to anyone. Sending shouldn't be a free version of Baptismal Record.
 	to_chat(H, "<span class='notice'><b><font size='3px'><font color='#ffaa00'>[user.real_name]'s voice speaks in your mind: \"[text]\"</font><b></span>")

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -654,8 +654,7 @@
 /datum/ritual/cruciform/divisor/zoom_litany
 	name = "Speed of Battle"
 	phrase = "Festinavit David et cucurrit ad pugnam ex adverso Philisthaei." //"David ran quickly toward the battle line to meet him."
-	desc = "Empowers the speaker with enhanced movement speed, allowing them to run faster for a short time. While useful, the body must rest after exceeding its limits, normally for \
-	only a mere ten minutes."
+	desc = "Empowers the speaker with enhanced movement speed, allowing them to run faster for a short time. To avoid overtaxing the body, this may only be used once every five minutes."
 	cooldown = TRUE
 	cooldown_time = 5 MINUTES
 	effect_time = 1 MINUTES

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -250,6 +250,44 @@
 	phrase = "Dominus, ait, in cujus conspectu ambulo, mittet angelum suum tecum, et diriget viam tuam." //"He replied, ‘The Lord, before whom I have walked faithfully, will send his angel with you and make your journey a success.'"
 	stats_to_boost = list(STAT_ROB = 15, STAT_TGH = 15, STAT_VIG = 15)
 
+/datum/ritual/cruciform/lemniscate/holy_boost
+	name = "Bolster the Fellowship"
+	phrase = "Benedicat tibi Dominus, et custodiat te. Ostendat Dominus faciem suam tibi, et misereatur tui. Convertat Dominus vultum suum ad te, et det tibi pacem." //“The Lord bless you and keep you; the Lord make his face shine on you and be gracious to you; the Lord turn his face toward you and give you peace.”
+	var/stats_to_boost = list(STAT_MEC = 15, STAT_COG = 15, STAT_BIO = 15, STAT_ROB = 15, STAT_TGH = 15, STAT_VIG = 15)
+	desc = "This litany boosts all the stats of all disciples who hear you for thirty minutes, but has no effect on those without cruciforms."
+
+/datum/ritual/cruciform/lemniscate/holy_boost/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
+	var/list/people_around = list()
+	for(var/mob/living/carbon/human/H in view(user))
+		if(H != user && !isdeaf(H) && is_neotheology_disciple(H)) //This one only for the homies
+			people_around.Add(H)
+
+	if(people_around.len > 0)
+		to_chat(user, SPAN_NOTICE("Your feel the air thrum with an inaudible vibration."))
+		playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
+		for(var/mob/living/carbon/human/participant in people_around)
+			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
+			give_boost(participant)
+			add_effect(participant, FILTER_HOLY_GLOW, 25)
+		set_global_cooldown()
+		return TRUE
+	else
+		fail("Your cruciform sings, alone, unto the void.", user, C)
+		return FALSE
+
+/datum/ritual/cruciform/lemniscate/holy_boost/proc/give_boost(mob/living/carbon/human/participant)
+	for(var/stat in stats_to_boost)
+		var/amount = stats_to_boost[stat]
+		participant.stats.addTempStat(stat, amount, effect_time, src.name)
+		addtimer(CALLBACK(src, PROC_REF(take_boost), participant, stat, amount), effect_time)
+	spawn(30)
+		to_chat(participant, SPAN_NOTICE("The power of the Absolute infuses you, and you feel divine will guiding your hand in all that you do."))
+
+
+/datum/ritual/cruciform/lemniscate/holy_boost/proc/take_boost(mob/living/carbon/human/participant, stat, amount)
+	to_chat(participant, SPAN_WARNING("You feel the power that guided you fade away, leaving you with only your own skills."))
+
+
 /datum/ritual/targeted/cruciform/lemniscate/food_for_the_masses
 	name = "Food for the Masses"
 	phrase = "Sive ergo manducatis sive bibitis vel aliud quid facitis omnia in gloriam Dei facite." //"So whether you eat or drink or whatever you do, do it all for the glory of God."
@@ -266,22 +304,7 @@
 	set_personal_cooldown(user)
 	return TRUE
 
-/datum/ritual/cruciform/lemniscate/zoom_litany
-	name = "Infinite Hymn"
-	phrase = "Quam pulchri super montes pedes annuntiantis et praedicantis pacem; annuntiantis bonum, praedicantis salutem, dicentis Sion: Regnabit Deus tuus!" //"How beautiful on the mountains are the feet of those who bring good news, who proclaim peace, who bring good tidings, who proclaim salvation, who say to Zion, “Your God reigns!”"
-	desc = "Empowers the speaker with enhanced movement speed, allowing them to run faster and react quicker for a short time. While useful, the body must rest after exceeding its limits, normally for \
-	only a mere ten minutes."
-	cooldown = TRUE
-	cooldown_time = 15 MINUTES
-	power = 35
-	cooldown_category = "zoom_litany"
 
-/datum/ritual/cruciform/lemniscate/zoom_litany/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/cruciform/C,list/targets)
-	to_chat(H, "<span class='info'>You feel yourself speeding up, your senses and reaction times quickening!</span>")
-	H.reagents.add_reagent("hyperzine", 10)
-	H.updatehealth()
-	set_personal_cooldown(H)
-	return TRUE
 
 //////////////////////////////////////////////////
 /////////         MONOMIAL               /////////
@@ -498,59 +521,152 @@
 /datum/ritual/cruciform/divisor/probability_coefficient
 	name = "Probability Coefficient"
 	phrase = "Parasti in conspectu meo mensam adversus eos qui tribulant me." //"You prepare a table before me in the presence of my enemies."
-	desc = "A highly effective litany designed by divisors to warn them of danger, it will reveal the presence of hostile fauna, traps, and potentially monsters hiding as people. Though \
-	it may warn you of threats nearby, it cannot tell you exactly what or where. Far more reliable than the reveal adversaries litany, offering multiple detection methods and locating a wider \
-	selection of threats."
-	power = 50
+	desc = "A more powerful version of the danger detection litany, developed by Augustine for the Divisors when the threat of carrion first came to the attention of the Church. It can tell a Divisor just how many foes they are facing, their general types, and whether they are within seven meters. It can also detect the presence of the foul carrion, within or without a host."
+	power = 30 //This isn't particularly strong
+	var/longrange = 14 //The actual range of the litany
+	var/closerange = 7 //The range that the litany considers "close"
 
 /datum/ritual/cruciform/divisor/probability_coefficient/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/cruciform/C)
-	var/was_triggired = FALSE
+	var/was_triggered = FALSE
+	var/howfar
+	var/spiders = 0
+	var/spidersclose = 0
+	var/roaches = 0
+	var/roachesclose = 0
+	var/termites = 0
+	var/termitesclose = 0
+	var/ameridian = 0
+	var/ameridianclose = 0
+	var/psionic = 0
+	var/psionicclose = 0
+	var/other = 0
+	var/otherclose = 0
+	var/simples = 0
+	var/simplesclose = 0
+	var/traps
+	var/carrion
 	log_and_message_admins("performed empowered reveal litany")
-	for(var/mob/living/carbon/superior_animal/S in range(14, H))
+	for(var/mob/living/carbon/superior_animal/S in range(longrange, H))
 		if (S.stat != DEAD)
-			to_chat(H, SPAN_WARNING("Vermin are near. You can feel something nasty and hostile."))
-			was_triggired = TRUE
+			if(!S.friendly_to_colony) //if something's friendly to the colony e.g. the Commander's beacon roach we don't care
+				was_triggered = TRUE
+				howfar = get_dist(H.loc, S.loc)
+				switch(S.faction)
+					if("roach")
+						roaches += 1
+						if(howfar <= closerange)
+							roachesclose += 1
+					if("spiders")
+						spiders += 1
+						if(howfar <= closerange)
+							roachesclose += 1
+					if("ameridian")
+						ameridian += 1
+						if(howfar <= closerange)
+							ameridianclose += 1
+					if("wurm")
+						termites += 1
+						if(howfar <= closerange)
+							termitesclose += 1
+					if("psi_monster")
+						psionic += 1
+						if(howfar <= closerange)
+							S.alpha = 254 //Reveals cloaked psi creatures within the close radius! 254 because if you set it to 255 the cloaking code just executes again
+							psionicclose += 1
+					else
+						other += 1
+						if(howfar <= closerange)
+							otherclose += 1
 
-	for (var/mob/living/simple_animal/hostile/S in range(14, H))
+	for (var/mob/living/simple_animal/hostile/S in range(longrange, H))
 		if (S.stat != DEAD)
-			to_chat(H, SPAN_WARNING("A simple hostile brute is nearby, nasty and stupid."))
-			was_triggired = TRUE
+			if(!S.friendly_to_colony) //if something's friendly to the colony e.g. the Commander's beacon roach we don't care
+				howfar = get_dist(H.loc, S.loc)
+				if(istype(S, /mob/living/simple_animal/spider_core) && howfar >= closerange) //Carrions get detected separately
+					was_triggered = TRUE
+					carrion = TRUE
+				else
+					was_triggered = TRUE
+					simples += 1
+					if(howfar <= closerange)
+						simplesclose += 1
 
-	if(locate(/obj/structure/wire_splicing || /obj/item/mine || /obj/item/mine_old || /obj/item/spider_shadow_trap || /obj/item/beartrap || /obj/item/emp_mine) in view(7, H))
-		to_chat(H, SPAN_WARNING("Something is wrong with this area. Tread carefully, someone has laid a trap nearby."))
-		was_triggired = TRUE
+	if(locate(/obj/structure/wire_splicing || /obj/item/mine || /obj/item/mine_old || /obj/item/spider_shadow_trap || /obj/item/beartrap || /obj/item/emp_mine) in view(closerange, H))
+		traps = TRUE
+		was_triggered = TRUE
 
-	for(var/mob/living/carbon/human/target in range(14, H))
+	for(var/mob/living/carbon/human/target in range(closerange, H))
 		for(var/organ in target.organs)
 			if (organ in subtypesof(/obj/item/organ/internal/carrion))
-				to_chat(H, SPAN_DANGER("A black terrible evil brushes against your mind suddenly, a horrible monstrous entity who's mere glancing ire is enough to leave you in a breathless cold sweat. You know there is a carrion nearby."))
-				was_triggired = TRUE
+				carrion = TRUE
+				was_triggered = TRUE
 
-	if(!was_triggired)
+	if(!was_triggered) //Nothing to see here!
 		to_chat(H, SPAN_NOTICE("There is nothing here. You feel safe."))
-
+	else //Bad things around
+		if(roaches)
+			to_chat(H, SPAN_NOTICE("There are [roaches] giant roaches nearby, [roachesclose] of them are close!"))
+		if(spiders)
+			to_chat(H, SPAN_NOTICE("There are [spiders] giant spiders nearby, [spidersclose] of them are close!"))
+		if(termites)
+			to_chat(H, SPAN_NOTICE("There are [termites] giant termites nearby, [termitesclose] of them are close!"))
+		if(ameridian)
+			to_chat(H, SPAN_NOTICE("There are [ameridian] ameridian golems nearby, [ameridianclose] of them are close!"))
+		if(psionic)
+			to_chat(H, SPAN_NOTICE("There are [psionic] psionic abominations nearby, [psionicclose] of them are close!"))
+		if(simples)
+			to_chat(H, SPAN_NOTICE("There are [simples] dumb beasts nearby, [simplesclose] of them are close!"))
+		if(traps)
+			to_chat(H, SPAN_NOTICE("There are potential traps close, but the number of them cannot be determined!"))
+		if(other)
+			to_chat(H, SPAN_NOTICE("There are [other] unidentifiable threats nearby, [otherclose] of them are close!"))
+		if(carrion)
+			to_chat(H, SPAN_DANGER("A black terrible evil brushes against your mind suddenly, a horrible monstrous entity whose views intelligent beings as prey. You know there is a carrion close."))
 	return TRUE
 
 /datum/ritual/cruciform/divisor/divisor_smite
 	name = "Divine Smite"
 	phrase = "In maxilla asini, in mandibula pulli asinarum, delevi eos, et percussi mille viros." //"With a donkey’s jawbone, I have made donkeys of them. With a donkey’s jawbone, I have killed a thousand men"
-	desc = "A short litany spoken in the middle of battle. Considered tricky to use, as it only lasts 30 seconds, but gives the speaker additional power and strength when swinging a melee weapon. Takes five minutes to recharge."
+	desc = "A short litany spoken in the middle of battle. Gives the speaker additional power and strength when swinging a melee weapon for two minutes. Takes five minutes to recharge."
 	cooldown = TRUE
 	cooldown_time = 5 MINUTES
 	cooldown_category = "divisor_smite"
-	effect_time = 30 SECONDS
-	power = 30
+	effect_time = 90 SECONDS
+	power = 25
 	var/wrath_damage = 0.2
 
 /datum/ritual/cruciform/divisor/divisor_smite/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
 	user.damage_multiplier += wrath_damage
 	to_chat(user, SPAN_NOTICE("You feel divine wrath empowering you with immense but fleeting strength!"))
 	set_personal_cooldown(user)
-	addtimer(CALLBACK(src, PROC_REF(discard_effect), user), src.cooldown_time)
+	addtimer(CALLBACK(src, PROC_REF(discard_effect), user), src.effect_time)
 	return TRUE
 
 /datum/ritual/cruciform/divisor/divisor_smite/proc/discard_effect(mob/living/carbon/human/user, amount)
+	to_chat(user, SPAN_NOTICE("You feel the divine wrath fade, leaving you with only your own strength."))
 	user.damage_multiplier -= wrath_damage
+
+/datum/ritual/cruciform/divisor/zoom_litany
+	name = "Infinite Hymn"
+	phrase = "Quam pulchri super montes pedes annuntiantis et praedicantis pacem; annuntiantis bonum, praedicantis salutem, dicentis Sion: Regnabit Deus tuus!" //"How beautiful on the mountains are the feet of those who bring good news, who proclaim peace, who bring good tidings, who proclaim salvation, who say to Zion, “Your God reigns!”"
+	desc = "Empowers the speaker with enhanced movement speed, allowing them to run faster for a short time. While useful, the body must rest after exceeding its limits, normally for \
+	only a mere ten minutes."
+	cooldown = TRUE
+	cooldown_time = 5 MINUTES
+	effect_time = 1 MINUTES
+	power = 25
+	cooldown_category = "zoom_litany"
+
+/datum/ritual/cruciform/divisor/zoom_litany/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C,list/targets)
+	to_chat(user, "<span class='info'>You feel yourself speeding up, the Absolute speeding you on your way!</span>")
+	user.added_movedelay -= 0.5
+	set_personal_cooldown(user)
+	addtimer(CALLBACK(src, PROC_REF(discard_effect), user), src.effect_time)
+	return TRUE
+
+/datum/ritual/cruciform/divisor/zoom_litany/proc/discard_effect(mob/living/carbon/human/user)
+	to_chat(user, "You feel yourself slowing down once more.")
+	user.added_movedelay += 0.5
 
 //////////////////////////////////////////////////
 /////////         FACTORIAL              /////////

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -613,7 +613,7 @@
 		if(spiders)
 			return_message +="There are [spiders] giant spiders nearby, [spidersclose] of them are close!.\n"
 		if(termites)
-			return_message +=There are [termites] giant termites nearby, [termitesclose] of them are close!\n"
+			return_message += "There are [termites] giant termites nearby, [termitesclose] of them are close!\n"
 		if(ameridian)
 			return_message += "There are [ameridian] ameridian golems nearby, [ameridianclose] of them are close!\n"
 		if(psionic)

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -254,6 +254,9 @@
 	name = "Bolster the Fellowship"
 	phrase = "Benedicat tibi Dominus, et custodiat te. Ostendat Dominus faciem suam tibi, et misereatur tui. Convertat Dominus vultum suum ad te, et det tibi pacem." //“The Lord bless you and keep you; the Lord make his face shine on you and be gracious to you; the Lord turn his face toward you and give you peace.”
 	var/stats_to_boost = list(STAT_MEC = 15, STAT_COG = 15, STAT_BIO = 15, STAT_ROB = 15, STAT_TGH = 15, STAT_VIG = 15)
+	cooldown = TRUE
+	cooldown_time = 2 MINUTES
+	effect_time = 30 MINUTES
 	desc = "This litany boosts all the stats of all disciples who hear you for thirty minutes, but has no effect on those without cruciforms."
 
 /datum/ritual/cruciform/lemniscate/holy_boost/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -253,7 +253,7 @@
 /datum/ritual/cruciform/lemniscate/holy_boost
 	name = "Bolster the Fellowship"
 	phrase = "Benedicat tibi Dominus, et custodiat te. Ostendat Dominus faciem suam tibi, et misereatur tui. Convertat Dominus vultum suum ad te, et det tibi pacem." //“The Lord bless you and keep you; the Lord make his face shine on you and be gracious to you; the Lord turn his face toward you and give you peace.”
-	var/stats_to_boost = list(STAT_MEC = 15, STAT_COG = 15, STAT_BIO = 15, STAT_ROB = 15, STAT_TGH = 15, STAT_VIG = 15)
+	var/stats_to_boost = list(STAT_MEC = 10, STAT_COG = 10, STAT_BIO = 10, STAT_ROB = 10, STAT_TGH = 10, STAT_VIG = 10)
 	cooldown = TRUE
 	cooldown_time = 2 MINUTES
 	effect_time = 30 MINUTES

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -632,7 +632,7 @@
 /datum/ritual/cruciform/divisor/divisor_smite
 	name = "Divine Smite"
 	phrase = "In maxilla asini, in mandibula pulli asinarum, delevi eos, et percussi mille viros." //"With a donkey’s jawbone, I have made donkeys of them. With a donkey’s jawbone, I have killed a thousand men"
-	desc = "A short litany spoken in the middle of battle. Gives the speaker additional power and strength when swinging a melee weapon for two minutes. Takes five minutes to recharge."
+	desc = "A short litany spoken in the middle of battle. Gives the speaker additional power and strength when swinging a melee weapon for ninety seconds. Takes five minutes to recharge."
 	cooldown = TRUE
 	cooldown_time = 5 MINUTES
 	cooldown_category = "divisor_smite"
@@ -652,8 +652,8 @@
 	user.damage_multiplier -= wrath_damage
 
 /datum/ritual/cruciform/divisor/zoom_litany
-	name = "Infinite Hymn"
-	phrase = "Quam pulchri super montes pedes annuntiantis et praedicantis pacem; annuntiantis bonum, praedicantis salutem, dicentis Sion: Regnabit Deus tuus!" //"How beautiful on the mountains are the feet of those who bring good news, who proclaim peace, who bring good tidings, who proclaim salvation, who say to Zion, “Your God reigns!”"
+	name = "Speed of Battle"
+	phrase = "Festinavit David et cucurrit ad pugnam ex adverso Philisthaei." //"David ran quickly toward the battle line to meet him."
 	desc = "Empowers the speaker with enhanced movement speed, allowing them to run faster for a short time. While useful, the body must rest after exceeding its limits, normally for \
 	only a mere ten minutes."
 	cooldown = TRUE

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -227,7 +227,7 @@
 	if(!C.get_module(CRUCIFORM_PRIME) && !C.get_module(CRUCIFORM_INQUISITOR) && !C.get_module(CRUCIFORM_CRUSADER))
 		fail("Only Primes and Crusaders have the authority to address the flock.", user, C)
 		return FALSE
-	var/text = input(user, "What message will you speak to the Church? The message will be recieved telepathically.", "Sending a message") as text|null
+	var/text = input(user, "What message will you speak to the Church? The message will be recieved by their cruciforms and heard in their mind.", "Sending a message") as text|null
 	if (!text)
 		return FALSE //Unlike Sending, this doesn't give you a list of everyone, so we can refund if you decide not to say anything
 	for(var/mob/living/H in disciples)

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -218,7 +218,7 @@
 
 /datum/ritual/cruciform/priest/announcement
 	name = "Address the Flock"
-	phrase = "Cum autem magna conquisitio fieret, surgens Petrus dixit ad eos." //"After much discussion, Peter got up and addressed them"
+	phrase = "Et dixit ad me: Fili hominis, vade ad domum Israel, et loqueris verba mea ad eos." //"And he said to me, “Son of man, eat what is before you, eat this scroll; then go and speak to the people of Israel.”
 	desc = "This litany acts as a mass Sending, addressing all disciples."
 	category = "Episcopal"
 	power = 30

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -216,6 +216,30 @@
 		if(target.wearer && target.wearer.stat != DEAD)
 			return target
 
+/datum/ritual/cruciform/priest/announcement
+	name = "Address the Flock"
+	phrase = "Cum autem magna conquisitio fieret, surgens Petrus dixit ad eos." //"After much discussion, Peter got up and addressed them"
+	desc = "This litany acts as a mass Sending, addressing all disciples."
+	category = "Episcopal"
+	power = 30
+
+/datum/ritual/cruciform/priest/announcement/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
+	var/text = input(user, "What message will you speak to the Church? The message will be recieved telepathically.", "Sending a message") as text|null
+	if (!text)
+		return FALSE //Unlike Sending, this doesn't give you a list of everyone, so we can refund if you decide not to say anything
+	for(var/mob/living/H in disciples)
+		if(H != user) //Don't send it to ourselves
+			to_chat(H, "<span class='notice'><b><font size='3px'><font color='#ffaa00'>[user.real_name]'s voice speaks in your mind: \"[text]\"</font><b></span>")
+			playsound(H, 'sound/machines/signal.ogg', 50, 1)
+	to_chat(user, "<span class='info'><font color='#ffaa00'>You say to the Church: \"[text]\"</font></span>")
+	log_and_message_admins("[user.real_name] made an announcement to all other disciples with text \"[text]\"")
+	playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
+	for(var/mob/observer/ghost/G in world)
+		if(G.get_preference_value(/datum/client_preference/ghost_ears_plus) == GLOB.PREF_YES)
+			G.show_message("<i>Cruciform announcement from <b>[user]</b>: [text]</i>")
+
+	return TRUE
+
 /datum/ritual/cruciform/priest/install
 	name = "Commitment"
 	phrase = "Iter tuum para." //"Prepare for your journey."*

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -232,7 +232,7 @@
 		return FALSE //Unlike Sending, this doesn't give you a list of everyone, so we can refund if you decide not to say anything
 	for(var/mob/living/H in disciples)
 		if(H != user) //Don't send it to ourselves
-			to_chat(H, "<span class='notice'><b><font size='3px'><font color='#ffaa00'>[user.real_name]'s voice speaks in your mind: \"[text]\"</font><b></span>")
+			to_chat(H, "<span class='notice'><b><font size='3px'><font color='#ffaa00'>[user.real_name]'s voice speaks to the Church: \"[text]\"</font><b></span>")
 			playsound(H, 'sound/machines/signal.ogg', 50, 1)
 	to_chat(user, "<span class='info'><font color='#ffaa00'>You say to the Church: \"[text]\"</font></span>")
 	log_and_message_admins("[user.real_name] made an announcement to all other disciples with text \"[text]\"")

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -224,6 +224,9 @@
 	power = 30
 
 /datum/ritual/cruciform/priest/announcement/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
+	if(!C.get_module(CRUCIFORM_PRIME) && !C.get_module(CRUCIFORM_INQUISITOR) && !C.get_module(CRUCIFORM_CRUSADER))
+		fail("Only Primes and Crusaders have the authority to address the flock.", user, C)
+		return FALSE
 	var/text = input(user, "What message will you speak to the Church? The message will be recieved telepathically.", "Sending a message") as text|null
 	if (!text)
 		return FALSE //Unlike Sending, this doesn't give you a list of everyone, so we can refund if you decide not to say anything


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Improves the Divisor's enemy detection litany, fixes and buffs their divine smite, and gives them the speed boost litany that Lemniscates used to have. Gives Lemniscates a "holy boost" litany that only affects disciples, but boosts all stats rather than just half. Gives Primes/Crusaders a litany to send a Sending to all disciples.
</summary>
<hr>

Divisor enemy detection litany now tells the user the general "type" of enemy for each detection, as well as how many are within a "close" range of 7 tiles. It also now reveals cloaked deep-maint monsters within 7 tiles. The carrion detection will now actually trigger for a carrion that's outside a person.

Divisor's Divine Smite was fixed to not last a full 5 minutes, but the intended duration was buffed to 90 seconds from 30, so it's more useful.

Divisors received the Infinite Hymn litany that used to be given to Lemniscates. It was reworked to directly boost speed rather than just inject hyperzine into the user. This is intended to help a Divisor close to melee range, where most of their kit is designed to work.

Lemniscates received a specialized long boost litany to go with their other long boosts that boosts all stats on only disciples, rather than half the stats on everyone around.

Primes (and Crusaders) received a litany that just acts as a mass Sending to everyone, useful for coordinating the Church.
	
<hr>
</details>

## Changelog
:cl:
tweak: Probability Coefficient buffed to give more useful information
tweak: Divine smite fixed and changed to last 90 second
tweak: Speed boost litany moved from Lemniscate to Divisor, changed to directly boost speed rather than inject meth
add: Lemniscates get a new litany that boosts all stats, but only for disciples.
add: Primes and Crusaders get a litany that acts as Sending but to all other disciples rather than just one.
tweak: Sending no longer says the message will be received "telepathically", as that word usually indicates psionics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
