### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v3
       # If we ever add more artifacts, this is going to break, but it'll be obvious.
       - name: Download screenshot tests
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
       - name: ls -R


### PR DESCRIPTION
Reverts sojourn-13/sojourn-station#5658