### PR TITLE
Cube+Pouch+Rig

### DIFF
--- a/code/game/objects/items/devices/organ_module/active/pouch.dm
+++ b/code/game/objects/items/devices/organ_module/active/pouch.dm
@@ -37,3 +37,4 @@
 	verb_name = "Deploy ammo pouch"
 	icon_state = "small_implanted"
 	completely_hide_from_scanners = FALSE
+	allowed_organs = list(BP_R_ARM, BP_L_ARM)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -171,6 +171,9 @@
 				to_chat(usr, "The armor system reports heavy damage. Repairs required.")
 			if(0.8 to 0.99)
 				to_chat(usr, "The armor system reports insignificant damage. Repairs advised.")
+		to_chat(usr, "The armor system has [ablative_max] ablative armor.")
+	else
+		to_chat(usr, "This RIG unit does not provide additional support armor plates.")
 
 /obj/item/rig/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/cubes.dm
+++ b/code/modules/reagents/reagent_containers/food/cubes.dm
@@ -12,8 +12,7 @@
 	matter = list(MATERIAL_BIOMATTER = 20)
 	var/wrapped = FALSE
 	var/monkey_type = "Monkey"
-	 //Well this looks like a pill but better, but its required do to roach cubes do to how many reagents get added to the cube on microwaving
-	volume = 200
+	volume = 500
 	preloaded_reagents = list("protein" = 10)
 
 /obj/item/reagent_containers/food/snacks/monkeycube/attack_self(mob/user as mob)
@@ -89,7 +88,7 @@
 	preloaded_reagents = list("protein" = 10)
 	grow_into = /mob/living/carbon/superior_animal/roach
 	taste_tag = list(MEAT_FOOD,BLAND_FOOD)
-
+	volume = 500
 
 /obj/item/reagent_containers/food/snacks/cube/roach/on_reagent_change()
 	if(reagents.has_reagent("blood"))


### PR DESCRIPTION
Fixes embedded ammo pouches being not in arms
Fixes Roach Cubes being unable expand do to lack of volume
Allows players to see the ablative armor of RIGs when examined 