### PR TITLE
More love for borgs.

### DIFF
--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -185,3 +185,16 @@
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_STEEL = 3)
 	price_tag = 70
+
+/obj/item/tool/pickaxe/borgonly
+	name = "Cyborg Mining Tool"
+	desc = "A dedicated mining tool. Essentially just a hunk of plasteel backed up by a small canister of inexpensive nanites that keep it from falling apart or dulling. \
+	Due to the reinforcement it's very heavy which makes it great at pacifying natives, but not so much at precise excavation. There is little space for tool mods due to it's dedicated nature."
+	force = WEAPON_FORCE_DANGEROUS * 1.5
+	tool_qualities = list(QUALITY_PRYING = 20)
+	toggleable = TRUE
+	workspeed = 0.75 // way faster than it appears. Normal pickaxe qualities make mining cyborgs with default skillset go lightning fast.
+	max_upgrades = 2
+	degradation = 0
+	switched_off_qualities = list(QUALITY_EXCAVATION = 5, QUALITY_PRYING = 20)
+	switched_on_qualities = list(QUALITY_DIGGING = 25, QUALITY_PRYING = 20)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -204,12 +204,12 @@ var/list/ai_verbs_default = list(
 	..()
 
 	//Stats
-	//The AI gets 100 in all three knowledge stats.
+	//The AI gets 100 in all stats except cognition for use in some RnD machinery
 	//These are only ever used to operate machinery and software
 	//It doesnt get any physical stats, like robustness, since its a disembodied mind
 	stats.changeStat(STAT_BIO, 100)
 	stats.changeStat(STAT_MEC, 100)
-	stats.changeStat(STAT_COG, 100)
+	stats.changeStat(STAT_COG, 150)
 
 /mob/living/silicon/ai/proc/on_mob_init()
 	to_chat(src, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -928,7 +928,8 @@ var/global/list/robot_modules = list(
 	power_efficiency = 0.8 //Poor
 
 	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,
-							  /obj/item/borg/upgrade/satchel_of_holding_for_borgs)
+							  /obj/item/borg/upgrade/satchel_of_holding_for_borgs,
+							  /obj/item/borg/upgrade/arc_welder)
 
 	robot_traits = CYBORG_TRAIT_CLEANING_WALK
 	stat_modifiers = list(
@@ -1155,11 +1156,10 @@ var/global/list/robot_modules = list(
 
 /obj/item/robot_module/miner/New(var/mob/living/silicon/robot/R)
 	src.modules += new /obj/item/tool/robotic_omni/miner(src)
-	src.modules += new /obj/item/tool/pickaxe(src)
+	src.modules += new /obj/item/tool/pickaxe/borgonly(src)
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/borg/sight/material(src)
 	src.modules += new /obj/item/storage/bag/robotic/ore(src)
-	src.modules += new /obj/item/tool/pickaxe/diamonddrill(src)
 	src.modules += new /obj/item/storage/bag/robotic/sheetsnatcher(src)
 	src.modules += new /obj/item/gripper/miner(src)
 	src.modules += new /obj/item/gripper/no_use/loader(src) //They have to sell materials over desks at times.
@@ -1222,12 +1222,12 @@ var/global/list/robot_modules = list(
 	desc = "Built for working in a well-equipped lab, and designed to handle a wide variety of research \
 	duties, this module prioritises flexibility over efficiency. Capable of working in R&D, Toxins, \
 	chemistry, xenobiology and robotics."
-	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs,/obj/item/borg/upgrade/arc_welder)
 
 	stat_modifiers = list(
 		STAT_BIO = 40,
 		STAT_COG = 120,
-		STAT_MEC = 30
+		STAT_MEC = 60 //So a cyborg that is meant to work in robotics can work robotics.
 	)
 
 /obj/item/robot_module/research/New(var/mob/living/silicon/robot/R)
@@ -1262,13 +1262,19 @@ var/global/list/robot_modules = list(
 	src.emag += new /obj/item/melee/energy/sword(src)
 
 	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)
+	var/datum/matter_synth/wire = new /datum/matter_synth/wire(30)
 	synths += nanite
+	synths += wire
 
 	var/obj/item/stack/nanopaste/N = new /obj/item/stack/nanopaste(src)
 	N.uses_charge = 1
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)
 	src.modules += N
+
+	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
+	C.synths = list(wire)
+	src.modules += C
 
 	//We know medical and robotics, were a mix.
 	R?.stats?.addPerk(PERK_MEDICAL_EXPERT)


### PR DESCRIPTION
Mining cyborg can now do it's main function. Gives Janiborgs and Research borgs the ability to get the Arc welder.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Gives the mining cyborgs a dedicated tool for mining which doesn't break and mines decently well. Also gives Janitor cyborgs and Research cyborgs the ability to get an Arc Welder Upgrade to do their jobs a little better. Reasoning for research borgs is that their nanopaste is finite and can't be used to repair borgs/FBP's en-masse. Additionally if they're repairing an exosuit their starting welding tool will quickly run out of fuel. As for janiborgs it's purely for sealing burrows, as the failrate of the omnitool is purposefully low and the need to refill the small welder coupled with the already low power efficiency make this a pure QOL upgrade. Not doing this on Security and Defense models, though, otherwise they will just repair each other infinitely.
	(edit): After some testing i found out that Nanopaste cannot repair limbs and science cyborgs have too little mechanical to diagnose robotic limbs on example. As such i gave them extra mechanical skill, as well as a cable synthesizer to better perform their job. Also, AI now has slightly more cognition to better operate some things like MetaDataAnalyzer (It also makes sense, as they are supposed to be an intelligence vastly superior to an average person.)
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: Adds 'Cyborg Mining Tool' - a new cyborg mining pickaxe that doesn't break, works decently fast and deals decent damage.
del: Deletes Mining borg's old Default pickaxe and diamond mining drill from their 'loadout'
tweak: Research Cyborgs and Custodial cyborgs now have the ability to receive an Arc Welder.
tweak: Research Cyborg gets a cable coil synthesizer.
tweak: Research Cyborg gets a slight boost of Mechanical skill
tweak: AI gets a slight boost of Cognition.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
