### PR TITLE
G.P. Revolution (Lets wallets holds G.P. Yuan.)

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -12,6 +12,7 @@
 	can_hold = list(
 		/obj/item/spacecash,
 		/obj/item/card,
+		/obj/item/stack/os_cash,
 		/obj/item/clothing/mask/smokable/cigarette/,
 		/obj/item/device/lighting/toggleable/flashlight/pen,
 		/obj/item/seeds,


### PR DESCRIPTION
Kinda goofy how a currency, albeit archaic, doesn't fit in a wallet. Remedies that.

![image](https://github.com/user-attachments/assets/c235d665-d0d0-48cd-9ef8-83eeb750b7d2)
