### PR TITLE
fire fighting buff for borgs

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -1,6 +1,6 @@
 /obj/item/extinguisher
 	name = "fire extinguisher"
-	desc = "A traditional red fire extinguisher, its rated for A and B, unless it was refilled with just water..."
+	desc = "A traditional red fire extinguisher, it's rated for A and B, unless it was refilled with just water..."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "fire_extinguisher0"
 	item_state = "fire_extinguisher"
@@ -18,15 +18,28 @@
 	var/spray_particles = 3
 	var/spray_amount = 9	//units of liquid per particle
 	var/max_water = 300
-	var/last_use = 1.0
+	var/last_use = 1
+	var/delay_per_use = 20
 	var/safety = 1
 	var/sprite_name = "fire_extinguisher"
 	var/list/overlaylist = list("fire_extinguisherO1","fire_extinguisherO2","fire_extinguisherO3","fire_extinguisherO4","fire_extinguisherO5","fire_extinguisherO6")
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 
+/obj/item/extinguisher/advanced
+	name = "specialized fire extinguisher"
+	desc = "A specialized fire extinguisher, quicker and holds more reagents than any other. It's rated for A and B, unless it was refilled with just water.."
+	delay_per_use = 10
+	max_water = 900
+	sprite_name = "FEgold"
+	overlaylist = list()
+	extra_bulk = 2
+
+/obj/item/extinguisher/advanced/robotic
+	desc = "A specialized fire extinguisher, quicker and holds more reagents than any other. Well inside a recharger this will slowly refill with A and B class extinguisher."
+
 /obj/item/extinguisher/mini
 	name = "fire extinguisher"
-	desc = "A light and compact fiberglass-framed model fire extinguisher, its rated for A and B, unless it was refilled with just water..."
+	desc = "A light and compact fiberglass-framed model fire extinguisher, it's rated for A and B, unless it was refilled with just water..."
 	icon_state = "miniFE0"
 	item_state = "miniFE"
 	hitsound = null	//it is much lighter, after all.
@@ -45,7 +58,6 @@
 		overlays += temp
 	create_reagents(max_water)
 	reagents.add_reagent("abwater", max_water)
-
 
 /obj/item/extinguisher/attack_self(mob/user as mob)
 	safety = !safety
@@ -94,7 +106,7 @@
 			to_chat(usr, SPAN_NOTICE("\The [src] is empty."))
 			return
 
-		if (world.time < src.last_use + 20)
+		if (world.time < last_use + delay_per_use)
 			return
 
 		src.last_use = world.time

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -303,7 +303,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/device/scanner/price(src)
 	src.modules += new /obj/item/tool/baton/robot(src)
-	src.modules += new /obj/item/extinguisher(src)
+	src.modules += new /obj/item/extinguisher/advanced/robotic(src)
 	src.modules += new /obj/item/tool/robotic_omni/standard(src)
 	src.modules += new /obj/item/tool/tape_roll/fiber/robotic(src) //Window repair
 	src.modules += new /obj/item/tool/weldingtool/robotic/weaker(src) //hardsuits.
@@ -346,6 +346,11 @@ var/global/list/robot_modules = list(
 	var/obj/item/tool/baton/robot/B = locate() in src.modules
 	if(B && B.cell)
 		B.cell.give(amount)
+
+	var/obj/item/extinguisher/advanced/robotic/EX = locate() in src.modules //space cleaner
+	if(B)
+		EX?.reagents?.add_reagent("abwater", 2 * amount)
+
 
 /obj/item/robot_module/medical
 	name = "medical robot module"
@@ -560,7 +565,7 @@ var/global/list/robot_modules = list(
 /obj/item/robot_module/engineering/general/New(var/mob/living/silicon/robot/R)
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/borg/sight/meson(src)
-	src.modules += new /obj/item/extinguisher(src)
+	src.modules += new /obj/item/extinguisher/advanced/robotic(src)
 	src.modules += new /obj/item/tool/weldingtool/robotic(src)
 	src.modules += new /obj/item/tool/multitool/robotic(src)
 	src.modules += new /obj/item/tool/robotic_omni/engi(src)
@@ -657,6 +662,10 @@ var/global/list/robot_modules = list(
 	if(src.modules)
 		var/obj/item/reagent_containers/spray/cleaner/SC = locate() in src.modules //space cleaner
 		SC?.reagents?.add_reagent("cleaner", 2 * amount)
+
+		var/obj/item/extinguisher/advanced/robotic/EX = locate() in src.modules //space cleaner
+		EX?.reagents?.add_reagent("abwater", 2 * amount)
+
 	..()
 
 	if(R.HasTrait(CYBORG_TRAIT_EMAGGED))
@@ -1246,7 +1255,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/reagent_containers/dropper/industrial(src)
 	src.modules += new /obj/item/reagent_containers/glass/beaker/large(src)
 	src.modules += new /obj/item/device/scanner/reagent/adv(src)
-	src.modules += new /obj/item/extinguisher(src)
+	src.modules += new /obj/item/extinguisher/advanced/robotic(src)
 	src.modules += new /obj/item/storage/bag/robotic/produce(src)
 	src.modules += new /obj/item/device/science_tool(src)
 	src.modules += new /obj/item/device/scanner/price(src)
@@ -1284,6 +1293,10 @@ var/global/list/robot_modules = list(
 
 	..(R)
 
+/obj/item/robot_module/research/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
+	if(src.modules)
+		var/obj/item/extinguisher/advanced/robotic/EX = locate() in src.modules //space cleaner
+		EX?.reagents?.add_reagent("abwater", 2 * amount)
 
 /obj/item/robot_module/drone
 	name = "drone module"
@@ -1309,7 +1322,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/gripper/no_use/loader(src)
 	src.modules += new /obj/item/gripper/chemistry(src)// For refilling autolathens with sillicon
 	src.modules += new /obj/item/storage/part_replacer/mini(src)
-	src.modules += new /obj/item/extinguisher(src)
+	src.modules += new /obj/item/extinguisher/advanced/robotic(src)
 	src.modules += new /obj/item/device/pipe_painter(src)
 	src.modules += new /obj/item/device/floor_painter(src)
 	src.modules += new /obj/item/borg/sight/meson(src)
@@ -1390,6 +1403,10 @@ var/global/list/robot_modules = list(
 
 		var/obj/item/device/lightreplacer/LR = locate() in src.modules
 		LR?.Charge(R, amount)
+
+		var/obj/item/extinguisher/advanced/robotic/EX = locate() in src.modules //space cleaner
+		EX?.reagents?.add_reagent("abwater", 2 * amount)
+
 
 	..()
 


### PR DESCRIPTION
Gives borgs a new fire-b-gone that holds 3x the reagents, refills in a recharger and is faster at spraying. - This only applies to borgs that had fire-b-gone present in their kit rather then every borg type