### PR TITLE
Area issues Corrections

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -22,6 +22,7 @@
 	var/static_equip
 	var/static_light = 0
 	var/static_environ
+	var/prevent_ship_area = FALSE //Used to make sure even if this area is in a station map level, that it will not be turned into a ship area.
 
 /**
  * Called when an area loads
@@ -404,7 +405,7 @@ var/list/mob/living/forced_ambiance_list = new
 
 
 /area/proc/set_ship_area()
-	if (!ship_area)
+	if (!ship_area && !prevent_ship_area)
 		ship_area = TRUE
 		ship_areas[src] = TRUE
 

--- a/code/game/area/asteroid_areas.dm
+++ b/code/game/area/asteroid_areas.dm
@@ -8,27 +8,35 @@
 
 /area/mine/prep
 	name = "Lonestar Mining Prep"
+	ship_area = TRUE
 
 /area/mine/processing
 	name = "Lonestar Ore Processing"
+	ship_area = TRUE
 
 /area/mine/hallway
 	name = "Lonestar General"
+	ship_area = TRUE
 
 /area/mine/medical
 	name = "Lonestar Triage"
+	ship_area = TRUE
 
 /area/mine/livingarea
 	name = "Lonestar Quarters"
+	ship_area = TRUE
 
 /area/mine/atmos
 	name = "Lonestar Atmos"
+	ship_area = TRUE
 
 /area/mine/power
 	name = "Lonestar Machine Room"
+	ship_area = TRUE
 
 /area/mine/lockers
 	name = "Lonestar Locker Room"
+	ship_area = TRUE
 
 /area/mine/explored
 	name = "Mine"

--- a/maps/__Nadezhda/area/_Nadezhda_areas.dm
+++ b/maps/__Nadezhda/area/_Nadezhda_areas.dm
@@ -1560,10 +1560,12 @@ area/nadezhda/medical/medbaymeeting
 /area/nadezhda/quartermaster/mining_outside_doc
 	name = "\improper Cargo Mining Area"
 	icon_state = "mining"
+	ship_area = FALSE
 
 /area/nadezhda/quartermaster/mining_dreg
 	name = "Slate Mining Pad MEH A" //Mining Excation Head
 	icon_state = "erisblue"
+	ship_area = FALSE
 
 /area/nadezhda/quartermaster/disposaldrop
 	name = "Disposal and Delivery"

--- a/maps/__Nadezhda/area/_Nadezhda_areas.dm
+++ b/maps/__Nadezhda/area/_Nadezhda_areas.dm
@@ -5,6 +5,7 @@
 
 /area/colony
 	base_turf = /turf/simulated/floor/asteroid
+	prevent_ship_area = TRUE
 
 /area/colony/exposedsun
 	ship_area = FALSE
@@ -302,6 +303,7 @@
 	flags = null
 	is_dungeon_lootable = TRUE
 	ship_area = FALSE
+	prevent_ship_area = TRUE
 
 /area/nadezhda/outside/one_star
 	name = "Greyson Positronic Base"


### PR DESCRIPTION
Fixes hivemind spawning in the mines, unknown areas and in the forest
Corrects many areas being wrongly counted as "ship area"