### PR TITLE
Human layering button

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1707,3 +1707,16 @@ var/list/rank_prefix = list(\
 
 
 #undef SLIME_TRANSPARENCY
+
+//Typically works to set yourself on the top of same layers
+/mob/living/carbon/human/verb/move_to_top()
+	set name = "Move Self To Top"
+	set desc = "Try to move yourself on the tile to be ontop of everything."
+	set category = "IC"
+
+	if(!istype(loc, /turf) || usr.stat || usr.restrained() )
+		return
+
+	var/turf/T = loc
+	loc = null
+	loc = T


### PR DESCRIPTION
Allows humans (players) that are stack on other mobs or objects to be able to use a new verb "Move to top". Requested by chef doggo 