### PR TITLE
Accessory Addition: colorable drop straps

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -124,6 +124,11 @@
 	path = /obj/item/clothing/accessory/waistcoat/color
 	flags = GEAR_HAS_TYPE_SELECTION | GEAR_HAS_COLOR_SELECTION
 
+/datum/gear/accessory/colorablestraps
+	display_name = "colorable drop straps"
+	path = /obj/item/clothing/accessory/dropstraps
+	flags = GEAR_HAS_COLOR_SELECTION
+
 /datum/gear/accessory/blackshieldpatch
 	display_name = "blackshield arm patch"
 	path = /obj/item/clothing/accessory/patches/blackshield


### PR DESCRIPTION
## About The Pull Request

What this PR does is add a colorable drop straps using the drop straps in the code, without taking up a new /accessory/ just mainly a adding in COLORABLE to another drop straps instead of coding in colorable on the regular one as the regular one is a basis for the rest of the accessories. 

## Changelog
:cl:
add: colorable drop straps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
