### PR TITLE
Make BS-BDU selectable in loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
@@ -73,7 +73,7 @@
 	allowed_roles = list("Corpsman")
 	slot = slot_wear_suit
 
-/datum/gear/factionsecurity/bdu
+/datum/gear/factionblackshield/bdu
 	display_name = "blackshield battle dress uniform"
 	path = /obj/item/clothing/under/rank/bdu/trooper
 	slot = slot_w_uniform


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Blackshield can once again use the BDU.
	Who put the gear datum path as the same as the marshal one 😭 
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: allow the BS BDU to be loadout selectable again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
