### PR TITLE
Turrets projectile lim ammo fix

### DIFF
--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -4,7 +4,7 @@
 
 // Mutable appearances are children of images, just so you know.
 
-/mutable_appearance/New()
+/mutable_appearance/proc/New()
 	..()
 	plane = FLOAT_PLANE // No clue why this is 0 by default yet images are on FLOAT_PLANE
 						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -107,8 +107,7 @@
 	if(get_dist(src, L) > 7)
 		return TURRET_NOT_TARGET
 
-	//if(!check_trajectory(L, src))
-		//return TURRET_NOT_TARGET
+	
 
 	if(emagged)		// If emagged not even the dead get a rest
 		return L.stat ? TURRET_SECONDARY_TARGET : TURRET_PRIORITY_TARGET
@@ -505,3 +504,6 @@
 #undef TURRET_PRIORITY_TARGET
 #undef TURRET_SECONDARY_TARGET
 #undef TURRET_NOT_TARGET
+
+/*if(!check_trajectory(L, src)) 
+	return TURRET_NOT_TARGET

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -107,8 +107,8 @@
 	if(get_dist(src, L) > 7)
 		return TURRET_NOT_TARGET
 
-	if(!check_trajectory(L, src))
-		return TURRET_NOT_TARGET
+	//if(!check_trajectory(L, src))
+		//return TURRET_NOT_TARGET
 
 	if(emagged)		// If emagged not even the dead get a rest
 		return L.stat ? TURRET_SECONDARY_TARGET : TURRET_PRIORITY_TARGET
@@ -343,8 +343,8 @@
 	if(get_dist(src, L) > 7)
 		return TURRET_NOT_TARGET
 
-	if(!check_trajectory(L, src))
-		return TURRET_NOT_TARGET
+	//if(!check_trajectory(L, src))
+		//return TURRET_NOT_TARGET
 
 	if(L.stat == DEAD)
 		return TURRET_NOT_TARGET

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -342,9 +342,6 @@
 	if(get_dist(src, L) > 7)
 		return TURRET_NOT_TARGET
 
-	//if(!check_trajectory(L, src))
-		//return TURRET_NOT_TARGET
-
 	if(L.stat == DEAD)
 		return TURRET_NOT_TARGET
 
@@ -505,5 +502,5 @@
 #undef TURRET_SECONDARY_TARGET
 #undef TURRET_NOT_TARGET
 
-/*if(!check_trajectory(L, src)) 
+/*if(!check_trajectory(L, src))    unknown function. Was used in both settings lists
 	return TURRET_NOT_TARGET

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -504,3 +504,4 @@
 
 /*if(!check_trajectory(L, src))    unknown function. Was used in both settings lists
 	return TURRET_NOT_TARGET
+*/


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Tested Limited ammo projectile turrets on the main server. They are barely shooting and ignoring some mobs include half or more of the roach faction. Which is most frequent enemy in colony. Now they shoot everything according their settings which is described in code and can't be changed in game by players. Also. Downloaded Master branch and had troubles to compile it due error in mutable_appearance.dm. Fixed that too.

</summary>
<hr>

https://github.com/user-attachments/assets/e5091e52-677a-4440-9b88-0b6ab1e65a29


<hr>
</details>

## Changelog


:cl:
Fix: All projectile turrets (3) with limited ammo now shoots mobs properly 
Fix: Unknown proc trouble on compile from master branch in mutable_appearance.dm file
/:cl:


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
