### PR TITLE
More specific hog desc

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -354,7 +354,7 @@ var/global/chicken_count = 0
 
 /mob/living/simple_animal/pig/hog
 	name = "Amerethi hog"
-	desc = "The result of crossing genetics between the colony's aging sow and cerberi from the Lodge, this is a docile species with asexual reproduction when fed mushrooms, raised chiefly for its meat without the otherwise ugly connotations of raising for slaughter what should have been a valued hunting companion."
+	desc = "The result of crossing genetics between the colony's aging sow and cerberi from the Lodge, this is a docile species with asexual reproduction when fed plump helmets, raised chiefly for its meat without the otherwise ugly connotations of raising for slaughter what should have been a valued hunting companion."
 	icon_state = "pighog"
 
 /mob/living/simple_animal/pig/hog/attackby(var/obj/item/O as obj, var/mob/user as mob)


### PR DESCRIPTION
switches a mushrooms to a plump helmets. Seems like a skill issue to me but Trilby asked. ¯\_(ツ)_/¯

Changelog:

Slight adjustment to the Amerethi hog desc to be more specific on mushroom type.