### PR TITLE
Medical items death grip

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -136,6 +136,10 @@
 		if(E.mob_can_unequip(src))
 			if(E.is_broken() || E.is_nerve_struck() || E.limb_efficiency <= 50)
 
+				if(istype(E, /obj/item/stack/medical))
+					emote("me", 1, "clenches harder onto [E.name]!")
+					return
+
 				drop_from_inventory(E)
 
 				if(E.limb_efficiency <= 50)
@@ -144,6 +148,12 @@
 					emote("me", 1, "[(species.flags & NO_PAIN) ? "" : pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")]drops what they were holding in their [E.name]!")
 
 			else if(E.is_malfunctioning())
+				//many things are welders and holding onto them even with harmed lims means you have a no-drop-risk weapon. So they are excluded - Trilby
+				if(istype(E, /obj/item/stack/cable_coil) || istype(E, /obj/item/stack/nanopaste))
+					emote("me", 1, "clenches harder onto [E.name]!")
+					return
+
+
 				drop_from_inventory(E)
 				emote("pain", 1, "drops what they were holding, their [E.name] malfunctioning!")
 


### PR DESCRIPTION

## About The Pull Request
For normal limbs: Holding any medical item regardless of pain will stay in hand I.e you will no longer drop gauze well trying to self gauze do to pain
For robotic limbs: Holding cable coil or nanopaste will stay in hand regardless of malfunction or lim damage

The above does not applied to stuns, nerve strikes or other interactions that forcedrop items