### PR TITLE
Gun parts fixes

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
@@ -48,7 +48,7 @@
 	desc = "A Grease Gun SMG frame. Cheap? Yes, but also effective."
 	icon_state = "frame_grease"
 	result = /obj/item/gun/projectile/automatic/greasegun
-	gripvars = list(/obj/item/part/gun/grip/black)
+	gripvars = list(/obj/item/part/gun/grip/wood, /obj/item/part/gun/grip/black)
 	resultvars = list(/obj/item/gun/projectile/automatic/greasegun)
 	mechanismvar = /obj/item/part/gun/mechanism/smg
 	barrelvars = list(/obj/item/part/gun/barrel/pistol)

--- a/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
@@ -49,6 +49,6 @@
 	icon_state = "frame_grease"
 	result = /obj/item/gun/projectile/automatic/greasegun
 	gripvars = list(/obj/item/part/gun/grip/wood, /obj/item/part/gun/grip/black)
-	resultvars = list(/obj/item/gun/projectile/automatic/greasegun)
 	mechanismvar = /obj/item/part/gun/mechanism/smg
 	barrelvars = list(/obj/item/part/gun/barrel/pistol)
+	resultvars = list(/obj/item/gun/projectile/automatic/greasegun, /obj/item/gun/projectile/automatic/texan)

--- a/code/modules/projectiles/guns/projectile/automatic/sts.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts.dm
@@ -117,7 +117,7 @@
 		)
 	wield_delay = 0.8 SECOND
 	wield_delay_factor = 0.2 // 20 vig for insta wield
-	gun_parts = list(/obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/stack/material/plasteel = 2)
+	gun_parts = list(/obj/item/part/gun/grip/wood = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/stack/material/plasteel = 2)
 
 /obj/item/gun/projectile/automatic/sts/rifle/heavy
 	name = "\"STS\" heavy rifle"


### PR DESCRIPTION
Adds wooden grip to the list of accepted grips on the greasegun frame and texan to the resultvars so texan SMGs can be disassembled and reassembled properly.
Changes the bakelite grip on sawn down STS rifles to wood in order to match the current version of the full rifle.