### PR TITLE
Allow items in storage slots to not hassle body cover checks

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -293,7 +293,7 @@ Proc for attack log creation, because really why not
 	)
 
 	for(var/obj/item/clothing/C in src)
-		if(l_hand == C || r_hand == C)
+		if(l_hand == C || r_hand == C || slot_l_store == C || slot_r_store == C || slot_s_store == C)
 			continue
 		if(C.body_parts_covered & bodyparts[bodypart])
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Fixes the bug about head covers in storage slots stopping implanters. though i don't think this is the best solution, because headwear (and some other gear) may be able to be placed in empty belt slots as well, which can prove an issue. would be good to overhaul how body-part checks are done in the future
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: Storage slots don't strike bodypart cover checks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
