### PR TITLE
Use role's alt title instead of assigned role when cryoing

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -420,7 +420,7 @@
 	log_and_message_admins("[key_name(occupant)]" + "[occupant.mind ? " ([occupant.mind.assigned_role])" : ""]" + " entered cryostorage.")
 
 	if(cryo_announcement)
-		announce.autosay("[occupant.real_name]" + "[occupant.mind ? ", [occupant.mind.assigned_role]" : ""]" + ", [on_store_message]", "[on_store_name]")
+		announce.autosay("[occupant.real_name]" + "[occupant.mind ? ", [occupant.mind.role_alt_title]" : ""]" + ", [on_store_message]", "[on_store_name]")
 
 	visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [occupant.real_name] into storage.</span>")
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -420,7 +420,7 @@
 	log_and_message_admins("[key_name(occupant)]" + "[occupant.mind ? " ([occupant.mind.assigned_role])" : ""]" + " entered cryostorage.")
 
 	if(cryo_announcement)
-		announce.autosay("[occupant.real_name]" + "[occupant.mind ? ", [occupant.mind.role_alt_title]" : ""]" + ", [on_store_message]", "[on_store_name]")
+		announce.autosay("[occupant.real_name]" + "[occupant.mind ? ", [occupant.mind.role_alt_title ? occupant.mind.role_alt_title : occupant.mind.assigned_role]" : ""]" + ", [on_store_message]", "[on_store_name]")
 
 	visible_message("<span class='notice'>\The [initial(name)] hums and hisses as it moves [occupant.real_name] into storage.</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Use role's alt title instead of assigned role when cryoing
</summary>
<hr>
This way the titles used in the announcement are the same in joining and leaving. So I won't join as nurse and leave as doctor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: Use role's alt title instead of assigned role when cryoing
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
