### PR TITLE
Roach Meat Audit + GP station change (And Misc Station tweaks)

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
@@ -122,6 +122,7 @@
 		/datum/reagent/medicine/bicaridine = offer_data("bicard bottle (60u)", 250, 3),
 		/datum/reagent/medicine/kelotane = offer_data("kelotane bottle (60u)", 250, 3),
 		/datum/reagent/medicine/dylovene = offer_data("dylovene bottle (60u)", 250, 3),
+		/obj/item/reagent_containers/food/snacks/meat/spider = offer_data("spider meat", 250, 5),
 		/datum/reagent/nanites/uncapped/control_booster_utility = offer_data("Control Booster Utility bottle (60u)", 30000, 1),
 		/datum/reagent/nanites/uncapped/control_booster_combat = offer_data("Control Booster Combat bottle (60u)", 30000, 1)
 		)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/material_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/material_refine.dm
@@ -76,5 +76,6 @@
 		/obj/item/stack/ore/osmium = offer_data("full stack of raw platinum", 3600, 1),
 		/obj/item/stack/ore/hydrogen = offer_data("full stack of raw hydrogen", 5040, 1),
 		/obj/item/stack/ore/uranium = offer_data("full stack of pitchblende", 3600, 1),
-		/obj/item/stack/ore/plasma = offer_data("full stack of plasma crystals", 1800, 1)
+		/obj/item/stack/ore/plasma = offer_data("full stack of plasma crystals", 1800, 1),
+		/obj/item/reagent_containers/food/snacks/meat/termitemeat = offer_data("termite meat", 125, 10)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
@@ -52,11 +52,11 @@
 	offer_types = list(
 		/obj/item/reagent_containers/food/snacks/meat = offer_data("meat", 100, 10),
 		/obj/item/reagent_containers/food/snacks/meat/corgi = offer_data("corgi meat", 1000, 2),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat = offer_data("roach meat", 300, 0),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/seuche = offer_data("seuche roach meat", 400, 0),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kraftwerk = offer_data("kraftwerk roach meat", 600, 0),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/jager = offer_data("seuche roach meat", 350, 0),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/fuhrer = offer_data("fuhrer roach meat", 450, 5), //Caps it
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat = offer_data("roach meat", 200, 0),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/seuche = offer_data("seuche roach meat", 250, 0),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kraftwerk = offer_data("kraftwerk roach meat", 450, 0),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/jager = offer_data("jager roach meat", 250, 0),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/fuhrer = offer_data("fuhrer roach meat", 350, 5), //Caps it
 		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kaiser = offer_data("kaiser roach meat", 2000, 2)
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/junker.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/junker.dm
@@ -9,8 +9,8 @@
 	spawn_always = TRUE
 	markup = COMMON_GOODS
 	base_income = 3200
-	wealth = -48000		// REALLY good gear so were in det
-	hidden_inv_threshold = 32000
+	wealth = -48000		// REALLY good gear so were in debt
+	hidden_inv_threshold = 8000
 	inventory = list(
 		"Spare Parts" = list(
 			/obj/item/stock_parts/capacitor/adv = custom_good_amount_range(list(1, 3)),

--- a/code/modules/trade/datums/trade_stations_presets/3-rare/monstertrapper.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/monstertrapper.dm
@@ -44,8 +44,8 @@
 	hidden_inventory = list(
 		"High-End Roach Product" = list(
 			/obj/item/reagent_containers/food/snacks/cube/roach/kraftwerk = custom_good_amount_range(list(1, 5)),
-			/obj/item/reagent_containers/glass/bottle/trade/fuhrerole = good_data("fuhrerole bottle", list(1, 1), 900),
-			/obj/item/reagent_containers/glass/bottle/trade/kaiseraurum = good_data("kaiseraurum bottle", list(1, 1), 1000)
+			/obj/item/reagent_containers/glass/bottle/trade/fuhrerole = good_data("fuhrerole bottle", list(1, 1), 900)
+//			/obj/item/reagent_containers/glass/bottle/trade/kaiseraurum = good_data("kaiseraurum bottle", list(1, 1), 1000) Kaiseraurum doesn't exist here, you just get an empty bottle
 		),
 		"Just Spiders" = list(
 			/mob/living/carbon/superior_animal/giant_spider = custom_good_amount_range(list(2, 3)),
@@ -58,5 +58,5 @@
 		/obj/item/mine = offer_data("landmine", 1200, 3),
 		/obj/item/beartrap = offer_data("mechanical trap", 600, 5),
 		/obj/item/device/assembly/mousetrap = offer_data("mousetrap", 200, 10),
-		/datum/reagent/toxin/zombiepowder = offer_data("zombie powder bottle(60u)", 800, 2)
+		/datum/reagent/toxin/zombiepowder = offer_data("zombie powder bottle(60u)", 1200, 2)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
@@ -16,8 +16,8 @@
 	automated. It's a wonder it hasn't been raided, but then again its protected by a massive army of still functioning combat drones. This one specializes in a wide variety of interesting goods.")
 	inventory = list(
 		"Sheji pan" = list(
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar/stockparts = good_data("GP Stockpart Disk", list(30, 50), 1500),
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar = good_data("GP Tool Disk", list(30, 50), 2000)
+			/obj/item/clothing/suit/space/void/greyson = good_data("GP 'Zhengdou' hardsuit", list(5, 5), 25000),
+			/obj/item/tank/onestar_regenerator = good_data("OS Type - 13 'Tiantipenquan'", list(5,10), 2000)
 		),
 		"Gongju" = list(
 			/obj/item/tool/crowbar/onestar = custom_good_nameprice("GP Crowbar", list(-100, -50)),


### PR DESCRIPTION
![Meat and GP](https://github.com/user-attachments/assets/aa0261b2-dc83-43fd-a6f8-5af18a9053a4)

# The big change
Alright, so first and foremost the Dayanji station (Secondary Greyson Station) has had it's tool/part stock replaced with the special Greyson Zhengdou voidsuit (priced at 25k) and the GP Greyson air tank (priced at 2k)
This is because I personally believe it allows LS to stomp on what should be the Guild's and Soteria's toes way too easily, given it's just a matter of nabbing some plat from the mines and using the SOM phone to immediately phone in the station. I'm planning on tossing in more misc. Greyson goodies in the near future, but this is a decent start.

## The less significant changes
The roach meat offers have been audited, generally a 1/3 to 1/2 reduction in value depending on the specific meat. Given Armitage allows players to buy roach cubes obscenely cheaply, this was long overdue. Also fixes jager meat being listed as a repeat seuche offer.

Cad has been given an offer for generic spider meat, under the presumption that antidotes can be procured from the toxins in the meat. 

Recoll has been given an offer for termite meat. They can probably sift out some more ore from the meat.

Together, the last two changes gives more incentive to butcher the total variety of maint bugs to pawn off, rather than just leaving roach meat as the cash king option. Though, I didn't split the meats off into their sub-types because it's annoying having to parse the meat types out so the parent meat-type doesn't gobble up all of the categories of meat at a reduced price.


Armitage has had the Kaiseraurum bottle commented out, because kaiseraurum doesn't exist and you'd just get an empty bottle for a thousand credits. Also, bumps up the price on the offer for zombie powder.

Garbaj has had it's default value of 32k favor (yikes!) reeled back to 8k, also very long overdue.


### Proof that this all works:

![image](https://github.com/user-attachments/assets/d3d0e331-2832-4898-bd3a-77388cb57e0d)
_They can in fact be imported, and the voidsuit does in fact come with a helmet_

![image](https://github.com/user-attachments/assets/d7352dfe-eeac-4957-8aac-899fda0e6c79)
_Still plenty lucrative!_

![image](https://github.com/user-attachments/assets/cfa63147-47f9-4e2e-a3dc-0b4e11efae68)
_Cad was hurting for more means of being favored tbh_

![image](https://github.com/user-attachments/assets/71ef1bcd-8d2c-450b-8c1e-ef523cea4f00)
_Recoll wasn't hurting for more means of being favored, but I don't think anyone would complain_

![image](https://github.com/user-attachments/assets/011df464-0b15-483f-8b50-48941be28f12)
_No more being scammed into buying an empty bottle for a thousand credits_

![image](https://github.com/user-attachments/assets/0dcbb0ba-1c30-4c6b-aead-774d67dc3d51)
_No more bartenders toiling away to make drinks to settle 1.5+ hours of favors to get a single station's  hidden inventory!_

TLDR/Changelog friendly consolidation

- LS can't order GP Tool and stockpart disks anymore
- LS can now order the Zhengdou voidsuit and oxygen generator tank at gouged prices
- Roach meat prices have been audited and cut down, however spider and termite meat are now offers for cad and recoll. Also fixes an error in the roach meat listings.
- Armitage pays a bit more for zombie powder bottles now, can't buy kaiseraurum anymore because it doesn't exist
- Garbaj favor/hidden inventory favor has been significantly reduced to 8k from 32k