### PR TITLE
Map Addition: New Vector Room and Chiken Coop Moved

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -3919,10 +3919,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"aNq" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "aNy" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -4246,14 +4242,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm2)
-"aRw" = (
-/obj/item/contraband/poster/placed/generic/no_erp{
-	desc = "This poster reminds the crew that Eroticism, unsanctioned Rituals and Pornography are bad and shouldnt be film or done.";
-	pixel_y = 32
-	},
-/obj/structure/closet/acolyte,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "aRD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -9367,6 +9355,13 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
+"bPP" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "bPX" = (
 /obj/structure/sink{
 	density = 1;
@@ -11605,11 +11600,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"cmY" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "cne" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -12322,6 +12312,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"cuS" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "cuV" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Marshals Brig";
@@ -12750,6 +12746,14 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
+"cyS" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "cyW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -17837,13 +17841,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/server)
-"dwT" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "dwU" = (
 /obj/structure/girder,
 /obj/effect/spider/stickyweb,
@@ -19318,9 +19315,12 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "dKl" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dKy" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/effect/decal/cleanable/dirt,
@@ -20445,14 +20445,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
-"dWr" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/browndouble,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "dWs" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -24033,6 +24025,13 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/rocinante_shuttle_area)
+"eDL" = (
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	desc = "A wooden door weighted to always fall closed if left open.";
+	name = "Chicken Coop"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "eDM" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -24605,14 +24604,6 @@
 	},
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"eKv" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "eKF" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Waste to Custom"
@@ -25789,13 +25780,6 @@
 /obj/structure/closet/secure_closet/personal/doctor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/medical/sleeper)
-"eVe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "eVm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -29063,13 +29047,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
 /area/colony)
-"fAB" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/sink/puddle,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "fAK" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -33607,10 +33584,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"gsK" = (
-/mob/living/simple_animal/chicken,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "gsN" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/grass,
@@ -36766,13 +36739,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
-"gYz" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "gYB" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -36826,9 +36792,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
 "gZv" = (
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/railing{
-	dir = 8
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -37183,6 +37150,12 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"hcL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hcO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
@@ -41819,6 +41792,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
+"hVx" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "hVz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/frog{
@@ -44999,13 +44976,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/surface/section1)
-"izy" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "izD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -48421,12 +48391,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"jiI" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jiQ" = (
 /obj/structure/sign/warning/caution/small{
 	dir = 1
@@ -50088,13 +50052,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/checker_large,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"jyB" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	desc = "A wooden door weighted to always fall closed if left open.";
-	name = "Chicken Coop"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jyH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -50248,6 +50205,13 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
+"jAo" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jAr" = (
 /obj/structure/sign/warningnew/danger{
 	pixel_y = -32
@@ -57559,6 +57523,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kWz" = (
+/obj/structure/table/woodentable,
+/obj/item/pen,
+/obj/item/paper_bin,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kWE" = (
 /obj/machinery/light/floor,
 /obj/structure/cable/green{
@@ -59384,14 +59354,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"lrN" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lrQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -59812,12 +59774,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
-"lvM" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lvQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60261,6 +60217,11 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
+"lBm" = (
+/obj/machinery/newscaster/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "lBn" = (
 /obj/machinery/power/emitter,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -61198,16 +61159,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"lJJ" = (
-/obj/structure/table/woodentable,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "lJZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -61305,13 +61256,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"lKN" = (
-/obj/random/flora/small_jungle_tree,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lKS" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "7,21"
@@ -62181,13 +62125,6 @@
 	light_color = "#0892d0"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/outside/inside_colony)
-"lTO" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "lTS" = (
 /obj/effect/decal/cleanable/rubble,
@@ -63187,12 +63124,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"mdH" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/small/rock3,
-/obj/structure/flora/tree/jungle_small/variant2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "mdJ" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/mineral,
@@ -63275,6 +63206,14 @@
 	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
+"meA" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "meB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/meter,
@@ -63764,6 +63703,13 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"mht" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mhv" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -66783,11 +66729,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
-"mLD" = (
-/obj/machinery/newscaster/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "mLG" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/firealarm{
@@ -66796,6 +66737,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/lab)
+"mLI" = (
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mLJ" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light,
@@ -67661,6 +67606,13 @@
 	icon_state = "6,3"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"mUQ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sink/puddle,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mVc" = (
 /obj/structure/closet/secure_closet/personal/salvager,
 /obj/item/device/radio/intercom{
@@ -73963,11 +73915,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"obi" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie_onlysquid,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "obk" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -82976,6 +82923,11 @@
 /obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"pKI" = (
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie_onlysquid,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "pKS" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -83128,6 +83080,12 @@
 "pMx" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"pMD" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/tree/jungle_small/variant2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "pMM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -84987,6 +84945,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"qcA" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/browndouble,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qcQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -85807,6 +85773,14 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"qla" = (
+/obj/item/contraband/poster/placed/generic/no_erp{
+	desc = "This poster reminds the crew that Eroticism, unsanctioned Rituals and Pornography are bad and shouldnt be film or done.";
+	pixel_y = 32
+	},
+/obj/structure/closet/acolyte,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qlg" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "1,8"
@@ -93109,6 +93083,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"rHl" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "rHw" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -94394,6 +94374,13 @@
 /obj/machinery/pile_ripper,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
+"rTN" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "rTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -94919,12 +94906,6 @@
 /obj/random/credits/low_chance,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"rYE" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "rYI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap_cube,
@@ -97143,10 +97124,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"stk" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "stI" = (
 /obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
@@ -98328,14 +98305,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/absolutism/chapel)
-"sDX" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "sEh" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -99180,6 +99149,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/cafe_large,
 /area/nadezhda/maintenance/surfaceeast)
+"sNv" = (
+/obj/random/flora/small_jungle_tree,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "sNx" = (
 /obj/structure/railing/grey{
 	pixel_y = -4
@@ -101160,6 +101136,11 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
+"tik" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "til" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -109298,6 +109279,10 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"uJl" = (
+/mob/living/simple_animal/chicken,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "uJn" = (
 /obj/machinery/door/unpowered/simple/wood{
 	color = "#9a977b"
@@ -110213,7 +110198,9 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "uQv" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "uQy" = (
@@ -110775,6 +110762,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"uVd" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "uVj" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -121845,12 +121836,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"wXf" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "wXo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -122026,6 +122011,14 @@
 /obj/random/material_resources,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"wZh" = (
+/obj/structure/table/woodentable,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "wZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -122182,13 +122175,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
-"xaW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "xaZ" = (
 /obj/machinery/door/airlock/security{
 	name = "Ranger Office";
@@ -123682,6 +123668,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters)
+"xra" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xrd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -124063,6 +124056,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"xuf" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xuh" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -126101,6 +126098,13 @@
 	},
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"xMY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xNb" = (
 /obj/machinery/light{
 	dir = 1
@@ -234580,9 +234584,9 @@ mvt
 sOP
 pFV
 pFV
-lrN
-gYz
-lrN
+gZv
+dKl
+gZv
 pFV
 vtx
 bXS
@@ -234782,9 +234786,9 @@ mvt
 sOP
 pFV
 uIj
-dwT
-izy
-dwT
+jAo
+bPP
+jAo
 uIj
 rIK
 bXS
@@ -234983,12 +234987,12 @@ sOP
 mvt
 sOP
 gMK
-fAB
+mUQ
 pFV
-gsK
+uJl
 rIK
-uQv
-sDX
+uVd
+cyS
 bXS
 bXS
 fFO
@@ -235189,8 +235193,8 @@ dGV
 tyN
 rIK
 myK
-cmY
-lKN
+tik
+sNv
 bXS
 bXS
 fFO
@@ -235387,12 +235391,12 @@ sOP
 mvt
 sOP
 gMK
-jiI
+hcL
 igM
-mdH
+pMD
 rIK
-cmY
-rYE
+tik
+rHl
 bXS
 bXS
 fFO
@@ -235589,12 +235593,12 @@ sOP
 mvt
 sOP
 gMK
-jiI
+hcL
 rIK
 rIK
 rIK
-uQv
-lTO
+uVd
+xra
 bXS
 bXS
 bXS
@@ -235791,12 +235795,12 @@ wEa
 wAY
 wEa
 pFV
-jyB
+eDL
 rIK
 pFV
-gsK
-aNq
-rYE
+uJl
+hVx
+rHl
 bXS
 bXS
 bXS
@@ -235975,9 +235979,9 @@ xja
 xja
 aBx
 nba
-xaW
-lJJ
-tXh
+xMY
+wZh
+kWz
 aBx
 veQ
 byG
@@ -235994,9 +235998,9 @@ wAY
 wEa
 rDN
 uIj
-eKv
-lvM
-lvM
+meA
+uQv
+uQv
 uIj
 pFV
 pFV
@@ -236176,10 +236180,10 @@ ajI
 xja
 xja
 aBx
-aRw
+qla
 rvy
-eVe
-obi
+mht
+pKI
 aBx
 hWN
 lik
@@ -236196,9 +236200,9 @@ pwk
 wEa
 pFV
 hcX
-wXf
-gZv
-wXf
+cuS
+rTN
+cuS
 pFV
 pFV
 fLu
@@ -236381,7 +236385,7 @@ aBx
 lVu
 rvy
 rvy
-dKl
+mLI
 aBx
 okJ
 xQA
@@ -236580,10 +236584,10 @@ wmS
 qjE
 xja
 aBx
-dWr
-mLD
+qcA
+lBm
 rvy
-stk
+xuf
 aBx
 bOv
 byG

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -371,6 +371,14 @@
 /obj/structure/railing,
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
+"aee" = (
+/obj/item/contraband/poster/placed/generic/no_erp{
+	desc = "This poster reminds the crew that Eroticism, unsanctioned Rituals and Pornography are bad and shouldnt be film or done.";
+	pixel_y = 32
+	},
+/obj/structure/closet/acolyte,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "aef" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/dirt,
@@ -5207,6 +5215,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/hallway)
+"bbv" = (
+/obj/random/flora/small_jungle_tree,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "bbA" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -9355,13 +9370,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
-"bPP" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "bPX" = (
 /obj/structure/sink{
 	density = 1;
@@ -10219,6 +10227,11 @@
 /obj/machinery/microwave/burnbarrel,
 /turf/simulated/floor/industrial/green_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"bYw" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bYF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -12312,12 +12325,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"cuS" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "cuV" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Marshals Brig";
@@ -12601,6 +12608,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
+"cxv" = (
+/obj/random/furniture/pottedplant,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "cxw" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/dirt,
@@ -12746,14 +12758,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
-"cyS" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "cyW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -19315,6 +19319,7 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "dKl" = (
+/obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/railing{
 	dir = 4;
 	tag = "icon-railing0 (EAST)"
@@ -24025,13 +24030,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/rocinante_shuttle_area)
-"eDL" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	desc = "A wooden door weighted to always fall closed if left open.";
-	name = "Chicken Coop"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "eDM" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -27787,6 +27785,11 @@
 /obj/structure/flora/small/grassa1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"fnr" = (
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie_onlysquid,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "fnu" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/small/grassb2,
@@ -36792,13 +36795,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
 "gZv" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/railing{
+/obj/structure/table/woodentable,
+/obj/machinery/alarm{
 	dir = 4;
-	tag = "icon-railing0 (EAST)"
+	pixel_x = -32
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "gZA" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/spider/stickyweb,
@@ -37150,12 +37153,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"hcL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "hcO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
@@ -38958,6 +38955,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/nuke_storage)
+"hvr" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hvy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -41269,6 +41273,12 @@
 	icon_state = "5,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"hQc" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hQf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -41792,10 +41802,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
-"hVx" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "hVz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/frog{
@@ -42148,6 +42154,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/foyer)
+"hYt" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sink/puddle,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hYu" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -43191,6 +43204,14 @@
 /obj/item/spider_shadow_trap,
 /turf/simulated/floor/industrial/blue_slates,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"iil" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/browndouble,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "iip" = (
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/armory)
@@ -45358,6 +45379,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"iDg" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "iDm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -48738,6 +48767,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"jmi" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jmk" = (
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
@@ -50205,13 +50241,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
-"jAo" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jAr" = (
 /obj/structure/sign/warningnew/danger{
 	pixel_y = -32
@@ -50270,6 +50299,10 @@
 /mob/living/simple_animal/soteria_roomba/medical,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"jBx" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "jBC" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
@@ -56983,6 +57016,13 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"kQP" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "kQT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -57523,12 +57563,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kWz" = (
-/obj/structure/table/woodentable,
-/obj/item/pen,
-/obj/item/paper_bin,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "kWE" = (
 /obj/machinery/light/floor,
 /obj/structure/cable/green{
@@ -59807,6 +59841,12 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"lwk" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lwq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -60217,11 +60257,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
-"lBm" = (
-/obj/machinery/newscaster/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "lBn" = (
 /obj/machinery/power/emitter,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -63206,14 +63241,6 @@
 	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
-"meA" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "meB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/meter,
@@ -63703,13 +63730,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"mht" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "mhv" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -65787,6 +65807,13 @@
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/rnd/robotics)
+"mCF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mCJ" = (
 /obj/machinery/microscope,
 /obj/structure/table/standard,
@@ -66737,10 +66764,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/lab)
-"mLI" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "mLJ" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light,
@@ -67315,6 +67338,12 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"mRD" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mRL" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "1,17"
@@ -67606,13 +67635,6 @@
 	icon_state = "6,3"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"mUQ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/sink/puddle,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "mVc" = (
 /obj/structure/closet/secure_closet/personal/salvager,
 /obj/item/device/radio/intercom{
@@ -80878,6 +80900,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"pqt" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "pqC" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/fueltank/huge,
@@ -82923,11 +82950,6 @@
 /obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
-"pKI" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie_onlysquid,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "pKS" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -83080,12 +83102,6 @@
 "pMx" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
-"pMD" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/small/rock3,
-/obj/structure/flora/tree/jungle_small/variant2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "pMM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -84945,14 +84961,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"qcA" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/browndouble,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "qcQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -85123,6 +85131,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"qeG" = (
+/obj/machinery/newscaster/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qeH" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /obj/machinery/light/small{
@@ -85773,14 +85786,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"qla" = (
-/obj/item/contraband/poster/placed/generic/no_erp{
-	desc = "This poster reminds the crew that Eroticism, unsanctioned Rituals and Pornography are bad and shouldnt be film or done.";
-	pixel_y = 32
-	},
-/obj/structure/closet/acolyte,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "qlg" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "1,8"
@@ -91735,6 +91740,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"rtC" = (
+/obj/structure/table/woodentable,
+/obj/item/pen,
+/obj/item/paper_bin,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "rtE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -93083,12 +93094,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"rHl" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "rHw" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -94374,13 +94379,6 @@
 /obj/machinery/pile_ripper,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
-"rTN" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "rTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -99149,13 +99147,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/cafe_large,
 /area/nadezhda/maintenance/surfaceeast)
-"sNv" = (
-/obj/random/flora/small_jungle_tree,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "sNx" = (
 /obj/structure/railing/grey{
 	pixel_y = -4
@@ -101136,11 +101127,6 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
-"tik" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "til" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -103472,6 +103458,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfaceeast)
+"tFr" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "tFu" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -109279,10 +109273,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
-"uJl" = (
-/mob/living/simple_animal/chicken,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "uJn" = (
 /obj/machinery/door/unpowered/simple/wood{
 	color = "#9a977b"
@@ -110198,8 +110188,9 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "uQv" = (
+/obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -110762,10 +110753,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"uVd" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "uVj" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -111715,6 +111702,10 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"vfc" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vff" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -111881,6 +111872,12 @@
 	icon_state = "12,7"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"vgF" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/tree/jungle_small/variant2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vgL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -113380,6 +113377,10 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"vur" = (
+/mob/living/simple_animal/chicken,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vus" = (
 /obj/machinery/camera/network/security{
 	dir = 1
@@ -115363,6 +115364,13 @@
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
+"vNI" = (
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	desc = "A wooden door weighted to always fall closed if left open.";
+	name = "Chicken Coop"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vNK" = (
 /obj/structure/closet/coffin,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -121042,6 +121050,12 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"wPt" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -122011,14 +122025,6 @@
 /obj/random/material_resources,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"wZh" = (
-/obj/structure/table/woodentable,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "wZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -123668,13 +123674,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters)
-"xra" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "xrd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -124056,10 +124055,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"xuf" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "xuh" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -126098,13 +126093,6 @@
 	},
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"xMY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "xNb" = (
 /obj/machinery/light{
 	dir = 1
@@ -126729,6 +126717,13 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"xTf" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xTl" = (
 /obj/machinery/light,
 /obj/effect/spider/stickyweb,
@@ -234584,9 +234579,9 @@ mvt
 sOP
 pFV
 pFV
-gZv
 dKl
-gZv
+kQP
+dKl
 pFV
 vtx
 bXS
@@ -234786,9 +234781,9 @@ mvt
 sOP
 pFV
 uIj
-jAo
-bPP
-jAo
+jmi
+uQv
+jmi
 uIj
 rIK
 bXS
@@ -234987,12 +234982,12 @@ sOP
 mvt
 sOP
 gMK
-mUQ
+hYt
 pFV
-uJl
+vur
 rIK
-uVd
-cyS
+vfc
+tFr
 bXS
 bXS
 fFO
@@ -235193,8 +235188,8 @@ dGV
 tyN
 rIK
 myK
-tik
-sNv
+pqt
+bbv
 bXS
 bXS
 fFO
@@ -235391,12 +235386,12 @@ sOP
 mvt
 sOP
 gMK
-hcL
+hQc
 igM
-pMD
+vgF
 rIK
-tik
-rHl
+pqt
+mRD
 bXS
 bXS
 fFO
@@ -235593,12 +235588,12 @@ sOP
 mvt
 sOP
 gMK
-hcL
+hQc
 rIK
 rIK
 rIK
-uVd
-xra
+vfc
+hvr
 bXS
 bXS
 bXS
@@ -235795,12 +235790,12 @@ wEa
 wAY
 wEa
 pFV
-eDL
+vNI
 rIK
 pFV
-uJl
-hVx
-rHl
+vur
+jBx
+mRD
 bXS
 bXS
 bXS
@@ -235979,9 +235974,9 @@ xja
 xja
 aBx
 nba
-xMY
-wZh
-kWz
+mCF
+gZv
+rtC
 aBx
 veQ
 byG
@@ -235998,9 +235993,9 @@ wAY
 wEa
 rDN
 uIj
-meA
-uQv
-uQv
+iDg
+wPt
+wPt
 uIj
 pFV
 pFV
@@ -236180,10 +236175,10 @@ ajI
 xja
 xja
 aBx
-qla
+aee
 rvy
-mht
-pKI
+gUm
+fnr
 aBx
 hWN
 lik
@@ -236200,9 +236195,9 @@ pwk
 wEa
 pFV
 hcX
-cuS
-rTN
-cuS
+lwk
+xTf
+lwk
 pFV
 pFV
 fLu
@@ -236385,7 +236380,7 @@ aBx
 lVu
 rvy
 rvy
-mLI
+bYw
 aBx
 okJ
 xQA
@@ -236584,10 +236579,10 @@ wmS
 qjE
 xja
 aBx
-qcA
-lBm
+iil
+qeG
 rvy
-xuf
+cxv
 aBx
 bOv
 byG

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -3919,6 +3919,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"aNq" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "aNy" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -4242,6 +4246,14 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm2)
+"aRw" = (
+/obj/item/contraband/poster/placed/generic/no_erp{
+	desc = "This poster reminds the crew that Eroticism, unsanctioned Rituals and Pornography are bad and shouldnt be film or done.";
+	pixel_y = 32
+	},
+/obj/structure/closet/acolyte,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "aRD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -11593,6 +11605,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"cmY" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "cne" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -17820,6 +17837,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/server)
+"dwT" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dwU" = (
 /obj/structure/girder,
 /obj/effect/spider/stickyweb,
@@ -18949,7 +18973,9 @@
 /area/nadezhda/outside/inside_colony)
 "dGV" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/obj/random/flora/jungle_tree,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "dHa" = (
@@ -19292,13 +19318,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "dKl" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "dKy" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/effect/decal/cleanable/dirt,
@@ -20423,6 +20445,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"dWr" = (
+/obj/structure/bed/double/padded,
+/obj/item/bedsheet/browndouble,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "dWs" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -23358,7 +23388,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/west,
+/obj/machinery/camera/network/church{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "exj" = (
@@ -24573,6 +24605,14 @@
 	},
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"eKv" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "eKF" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Waste to Custom"
@@ -25749,6 +25789,13 @@
 /obj/structure/closet/secure_closet/personal/doctor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/medical/sleeper)
+"eVe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eVm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -29016,6 +29063,13 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
 /area/colony)
+"fAB" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sink/puddle,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "fAK" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -29685,6 +29739,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "fHr" = (
@@ -33552,6 +33607,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"gsK" = (
+/mob/living/simple_animal/chicken,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "gsN" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/grass,
@@ -36707,6 +36766,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
+"gYz" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "gYB" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -36760,11 +36826,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
 "gZv" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	desc = "A wooden door weighted to always fall closed if left open.";
-	name = "Chicken Coop"
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "gZA" = (
 /obj/random/scrap/dense_weighted,
@@ -44933,6 +44999,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/surface/section1)
+"izy" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "izD" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -48348,6 +48421,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jiI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jiQ" = (
 /obj/structure/sign/warning/caution/small{
 	dir = 1
@@ -50009,6 +50088,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/checker_large,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jyB" = (
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	desc = "A wooden door weighted to always fall closed if left open.";
+	name = "Chicken Coop"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jyH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -59298,6 +59384,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"lrN" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lrQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -59718,6 +59812,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
+"lvM" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lvQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61098,6 +61198,16 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"lJJ" = (
+/obj/structure/table/woodentable,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "lJZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -61195,6 +61305,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"lKN" = (
+/obj/random/flora/small_jungle_tree,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lKS" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "7,21"
@@ -62064,6 +62181,13 @@
 	light_color = "#0892d0"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/outside/inside_colony)
+"lTO" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "lTS" = (
 /obj/effect/decal/cleanable/rubble,
@@ -63063,6 +63187,12 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"mdH" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/tree/jungle_small/variant2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mdJ" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/mineral,
@@ -66653,6 +66783,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
+"mLD" = (
+/obj/machinery/newscaster/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mLG" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/firealarm{
@@ -68241,10 +68376,17 @@
 /turf/simulated/floor/industrial/blue_slates,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "nba" = (
-/obj/structure/sink/puddle,
-/mob/living/simple_animal/chicken,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/inside_colony)
+/obj/structure/bed/double/padded{
+	dir = 4
+	},
+/obj/item/bedsheet/browndouble{
+	dir = 1
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nbd" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -69730,9 +69872,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/machinery/camera/network/church{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -73824,6 +73963,11 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"obi" = (
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie_onlysquid,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "obk" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -94775,6 +94919,12 @@
 /obj/random/credits/low_chance,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"rYE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "rYI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap_cube,
@@ -96993,6 +97143,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"stk" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "stI" = (
 /obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
@@ -98174,6 +98328,14 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/absolutism/chapel)
+"sDX" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "sEh" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -110051,9 +110213,7 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "uQv" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/mob/living/simple_animal/chicken,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "uQy" = (
@@ -121685,6 +121845,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"wXf" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wXo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -122016,6 +122182,13 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
+"xaW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xaZ" = (
 /obj/machinery/door/airlock/security{
 	name = "Ranger Office";
@@ -234407,9 +234580,9 @@ mvt
 sOP
 pFV
 pFV
-igM
-pFV
-igM
+lrN
+gYz
+lrN
 pFV
 vtx
 bXS
@@ -234608,11 +234781,11 @@ sOP
 mvt
 sOP
 pFV
-dHz
-vbq
-dHz
-vbq
-rIK
+uIj
+dwT
+izy
+dwT
+uIj
 rIK
 bXS
 bXS
@@ -234796,7 +234969,7 @@ pFV
 rIK
 ckO
 kvx
-kvx
+ckO
 kvx
 kvx
 kvx
@@ -234809,13 +234982,13 @@ rIK
 sOP
 mvt
 sOP
+gMK
+fAB
 pFV
-pFV
-fLu
-pFV
+gsK
 rIK
-pFV
-uoM
+uQv
+sDX
 bXS
 bXS
 fFO
@@ -235011,13 +235184,13 @@ pFV
 sOP
 mvt
 sOP
-pFV
+gMK
 dGV
 tyN
 rIK
 myK
-rIK
-pvI
+cmY
+lKN
 bXS
 bXS
 fFO
@@ -235197,7 +235370,7 @@ lMy
 vdT
 dyh
 cwC
-csA
+pFV
 ckO
 ckO
 pFV
@@ -235213,13 +235386,13 @@ pFV
 sOP
 mvt
 sOP
-pFV
-pFV
+gMK
+jiI
 igM
-myK
+mdH
 rIK
-rIK
-pFV
+cmY
+rYE
 bXS
 bXS
 fFO
@@ -235398,9 +235571,9 @@ xii
 gfG
 rpo
 pDs
-uIj
-dKl
-gZv
+aBx
+aBx
+aBx
 aBx
 aBx
 aBx
@@ -235415,13 +235588,13 @@ pFV
 sOP
 mvt
 sOP
-pFV
-pFV
+gMK
+jiI
 rIK
 rIK
 rIK
-pFV
-pfy
+uQv
+lTO
 bXS
 bXS
 bXS
@@ -235599,10 +235772,10 @@ mmz
 pDs
 pDs
 pDs
-uIj
-ckO
-pFV
-pFV
+aBx
+aBx
+aBx
+aBx
 aBx
 xBi
 qmW
@@ -235618,12 +235791,12 @@ wEa
 wAY
 wEa
 pFV
+jyB
 rIK
-rIK
 pFV
-pFV
-fFO
-pFV
+gsK
+aNq
+rYE
 bXS
 bXS
 bXS
@@ -235800,11 +235973,11 @@ kKk
 lzf
 xja
 xja
-uIj
+aBx
 nba
-pFV
-hcX
-hcX
+xaW
+lJJ
+tXh
 aBx
 veQ
 byG
@@ -235820,11 +235993,11 @@ wEa
 wAY
 wEa
 rDN
-rDN
-uoM
-pFV
-pFV
-mGO
+uIj
+eKv
+lvM
+lvM
+uIj
 pFV
 pFV
 pFV
@@ -236002,11 +236175,11 @@ ajI
 ajI
 xja
 xja
-uIj
-pFV
-pFV
-hTC
-pfy
+aBx
+aRw
+rvy
+eVe
+obi
 aBx
 hWN
 lik
@@ -236023,9 +236196,9 @@ pwk
 wEa
 pFV
 hcX
-pFV
-mGO
-pFV
+wXf
+gZv
+wXf
 pFV
 pFV
 fLu
@@ -236204,11 +236377,11 @@ gTv
 gTv
 vvI
 xja
-uIj
-pFV
-pFV
-pFV
-fFO
+aBx
+lVu
+rvy
+rvy
+dKl
 aBx
 okJ
 xQA
@@ -236406,11 +236579,11 @@ wmS
 wmS
 qjE
 xja
-uIj
-fFO
-fFO
-uQv
-pFV
+aBx
+dWr
+mLD
+rvy
+stk
 aBx
 bOv
 byG
@@ -236611,7 +236784,7 @@ xja
 aBx
 aBx
 aBx
-aBx
+tWL
 aBx
 aBx
 aBx


### PR DESCRIPTION
## About The Pull Request
This PR adds in two more lockers to the church and moves the chiken coop into a more viewable area instead of tucked away by the church
![image](https://github.com/user-attachments/assets/2fdbd465-17df-436f-ba9d-a9be8fdcba36)

## Changelog
:cl:
add: new vector room and new chicken coop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
