### PR TITLE
Suits and Boots

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -19,6 +19,7 @@
 	)
 	siemens_coefficient = 0 // DAMN BOI
 	//This armor only applies to legs
+	price_tag = 125
 
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
 	var/obj/item/clothing/shoes/shoes = overslot_contents
@@ -66,3 +67,4 @@
 	mag_slow = 2
 	icon_base = "mercboots"
 	action_button_name = "Toggle Magboots"
+	price_tag = 275

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -185,6 +185,7 @@
 	siemens_coefficient = 0.35
 	species_restricted = list("Human")
 	helmet = /obj/item/clothing/head/helmet/space/void/merc
+	price_tag = 675
 	stiffness = MEDIUM_STIFFNESS
 
 /obj/item/clothing/suit/space/void/merc/equipped

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -71,6 +71,7 @@
 		/obj/item/rcd
 	)
 	helmet = /obj/item/clothing/head/helmet/space/void/engineering
+	price_tag = 250
 
 /obj/item/clothing/suit/space/void/engineering/equipped
 	boots = /obj/item/clothing/shoes/magboots
@@ -188,6 +189,7 @@
 		rad = 75
 	)
 	helmet = /obj/item/clothing/head/helmet/space/void/mining
+	price_tag = 250
 
 //CEO Rig
 /obj/item/clothing/head/helmet/space/void/goldilocks
@@ -272,6 +274,7 @@
 		rad = 75
 	)
 	helmet = /obj/item/clothing/head/helmet/space/void/medical
+	price_tag = 225
 
 /obj/item/clothing/suit/space/void/medical/equipped
 	boots = /obj/item/clothing/shoes/magboots
@@ -316,6 +319,7 @@
 	)
 	siemens_coefficient = 0.7
 	helmet = /obj/item/clothing/head/helmet/space/void/security
+	price_tag = 325
 
 /obj/item/clothing/suit/space/void/security/equipped
 	boots = /obj/item/clothing/shoes/magboots

--- a/code/modules/trade/datums/trade_stations_presets/1-common/botany.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/botany.dm
@@ -96,6 +96,6 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/tool/minihoe = offer_data_mods("modified minihoe (3 upgrades)", 1400, 2, OFFER_MODDED_TOOL, 3),
-		/obj/item/tool/hatchet = offer_data_mods("modified hatchet (3 upgrades)", 1400, 2, OFFER_MODDED_TOOL, 3)
+		/obj/item/tool/minihoe = offer_data_mods("modified minihoe (2 upgrades)", 800, 2, OFFER_MODDED_TOOL, 2),
+		/obj/item/tool/hatchet = offer_data_mods("modified hatchet (3 upgrades)", 1000, 2, OFFER_MODDED_TOOL, 3)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
@@ -34,7 +34,8 @@
 			/obj/item/clothing/suit/space/void/engineering = custom_good_amount_range(list(-5, 3)),
 			/obj/item/clothing/suit/space/void/medical = custom_good_amount_range(list(-5, 3)),
 			/obj/item/clothing/suit/space/void/security = custom_good_amount_range(list(-5, 1)),
-			/obj/item/clothing/suit/space/void/SCAF = custom_good_amount_range(list(-5, 1))
+			/obj/item/clothing/suit/space/void/SCAF = custom_good_amount_range(list(-5, 1)),
+			/obj/item/clothing/shoes/magboots = custom_good_amount_range(list(5, 5))
 		),
 		"RIGs" =  list(
 			/obj/item/rig/eva = custom_good_amount_range(list(1, 5)),

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
@@ -26,7 +26,8 @@
 			/obj/item/noslipmodule,
 			/obj/item/storage/box/syndie_kit/imp_compress,
 			/obj/item/grenade/empgrenade,
-			/obj/item/storage/backpack/military = good_data("MOLLE pack", list(3, 8), 1000)
+			/obj/item/storage/backpack/military = good_data("MOLLE pack", list(3, 8), 1000),
+			/obj/item/clothing/shoes/magboots/merc
 		),
 		"Weapons" = list(
 			/obj/item/melee/energy/sword,


### PR DESCRIPTION
Throws a price onto most voidsuits to make them not have an unpolished "Unset price"  vibe to the suit-up tab.

Adds magboots to suit up, kinda goofy how you couldn't buy relatively vital EVA equipment from the station that specializes in EVA equipment.

Nerfs both modified tool offers on the botany station, makes it so you don't have to use an expansion slot on mini-hoes to actually get enough space to sell them. Payment for the tool adjusted accordingly.

Adds military magboots to Arau, as the station is currently lackluster in epic 'Operative gear', seems fitting to be sold here.



![image](https://github.com/user-attachments/assets/b309ac1f-abff-4e4f-8ad0-e1d8adc4b1aa)
![image](https://github.com/user-attachments/assets/46e950f2-ed11-4874-9d8b-859076ebee63)
![image](https://github.com/user-attachments/assets/bc46bb28-3155-489a-84c8-6e82ede36103)
![image](https://github.com/user-attachments/assets/2474efd4-14bb-474a-9d9d-48eda417c4a9)
![Sprite-0001](https://github.com/user-attachments/assets/046afc4a-5ed9-4c30-af94-cb44724609ab)
