### PR TITLE
Makes both foreman melee options more equivalent

### DIFF
--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -560,6 +560,7 @@
 	force = WEAPON_FORCE_BRUTAL + 2 // 35 damage
 	slot_flags = SLOT_BELT|SLOT_BACK
 	armor_divisor = ARMOR_PEN_MASSIVE // Sharp edge
+	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	effective_faction = list("deathclaw") // Called like this for a reason
 	damage_mult = 2
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_STEEL = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Both the renderslayer and the foreman's sledge tend to be pretty equal in stats (~5 hits to kill a nightmare stalker, for one example). This gives the renderslayer the ability to break secure doors like the sledge, intending to make both options more of a visual/stylistic (or in technicalities, minor combat) choices rather than a choice between two good weapons with one having a clear utility bonus
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Lets renderslayer sword break secure doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
