### PR TITLE
Balance rigtele, fix energy nets

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -74,6 +74,7 @@
 	playsound(get_turf(H), 'sound/effects/stealthoff.ogg', 75, 1)
 
 
+
 /obj/item/rig_module/teleporter
 
 	name = "teleportation module"
@@ -98,28 +99,35 @@
 	if(!M || !T)
 		return
 
+
 	holder.spark_system.start()
 	playsound(T, 'sound/effects/phasein.ogg', 25, 1)
 	playsound(T, 'sound/effects/sparks2.ogg', 50, 1)
 	anim(T,M,'icons/mob/mob.dmi',,"phasein",,M.dir)
+
+	new /obj/item/bluespace_dust(T)
 
 /obj/item/rig_module/teleporter/proc/phase_out(var/mob/M,var/turf/T)
 
 	if(!M || !T)
 		return
 
-	playsound(T, "sparks", 50, 1)
-	anim(T,M,'icons/mob/mob.dmi',,"phaseout",,M.dir)
+	if (do_after(M, 10, src))
+		visible_message(SPAN_WARNING("\the [src] begins to spool up!"))
+		playsound(T, "sparks", 50, 1)
+		anim(T,M,'icons/mob/mob.dmi',,"phaseout",,M.dir)
+
+		new /obj/item/bluespace_dust(T)
 
 /obj/item/rig_module/teleporter/engage(atom/target, notify_ai)
 
-	if(!..()) return 0
+	if(!..()) return FALSE
 
 	var/mob/living/carbon/human/H = holder.wearer
 
 	if(!istype(H.loc, /turf))
 		to_chat(H, SPAN_WARNING("You cannot teleport out of your current location."))
-		return 0
+		return FALSE
 
 	var/turf/T
 	var/misalignment = round((realign_time - world.time)/90)
@@ -141,19 +149,19 @@
 
 	if(!T || T.density)
 		to_chat(H, SPAN_WARNING("You cannot teleport into solid walls."))
-		return 0
+		return FALSE
 
 	if(isAdminLevel(T.z))
 		to_chat(H, SPAN_WARNING("You cannot use your teleporter on this Z-level."))
-		return 0
+		return FALSE
 
 	if(T.contains_dense_objects())
 		to_chat(H, SPAN_WARNING("You cannot teleport to a location with solid objects."))
-		return 0
+		return FALSE
 
 	if(T.z != H.z || get_dist(T, get_turf(H)) > world.view)
 		to_chat(H, SPAN_WARNING("You cannot teleport to such a distant object."))
-		return 0
+		return FALSE
 
 	phase_out(H,get_turf(H))
 	H.forceMove(T)
@@ -166,7 +174,7 @@
 			phase_in(G.affecting,get_turf(G.affecting))
 
 	realign_time = max(world.time, realign_time) + 30
-	return 1
+	return TRUE
 
 /obj/item/rig_module/fabricator/energy_net
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -152,7 +152,6 @@ While it would be entirely possible to check the mob's move handlers list for th
 	var/voice_name = "unidentifiable voice"
 
 	var/faction = "neutral" //Used for checking whether hostile simple animals will attack you, possibly more stuff later
-	var/captured = 0 //Functionally, should give the same effect as being buckled into a chair when true.
 
 	var/blinded = null
 	var/ear_deaf = null		//Carbon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Rig-based teleporters now leave bluespace dust where they jump from, and where they jump to. Also takes a few seconds to spool up before jump. Can reduce it if its too large of a timer. Let me know if its a big nerf, because the intent is to make it to be an access tool rather than a `use annoyingly in combat` tool.

E-nets now actually buckle and lock-down mobs.

This is part 1 of 2. Part 2'll be out when the invisibility module stops kicking me in the nuts
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Rig-Tele leaves behind bluespace dust. Also takes a few seconds to spool up before phase.
fix: E-nets now buckle people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
