### PR TITLE
big stat buffs for synths

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_synthetic.dm
+++ b/code/datums/setup_option/backgrounds/origin_synthetic.dm
@@ -1,3 +1,5 @@
+//FPBs do not level up so we juice the stats at round start so they are comparable to folks that do mid-round
+
 /datum/category_item/setup_option/background/ethnicity/sot_synth_medical
 	name = "Medical Positronic"
 	desc = "Synthetics are often times built with a specific purpose in mind to augment the qualities most appropriate to the purpose they're intended for. Your specific model was designed with \
@@ -13,9 +15,9 @@
 		STAT_ROB = 0,
 		STAT_TGH = 0,
 		STAT_VIG = 0,
-		STAT_BIO = 30,
-		STAT_MEC = 0,
-		STAT_COG = 0
+		STAT_BIO = 65,
+		STAT_MEC = 10,
+		STAT_COG = 25
 	)
 
 /datum/category_item/setup_option/background/ethnicity/sot_synth_engineer
@@ -32,11 +34,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
-		STAT_TGH = 5,
+		STAT_TGH = 15,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
-		STAT_MEC = 15,
-		STAT_COG = 10
+		STAT_MEC = 45,
+		STAT_COG = 30
 	)
 
 /datum/category_item/setup_option/background/ethnicity/sot_synth_combat
@@ -52,9 +54,9 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 20,
-		STAT_TGH = 5,
-		STAT_VIG = 20,
+		STAT_ROB = 40,
+		STAT_TGH = 35,
+		STAT_VIG = 35,
 		STAT_BIO = 0,
 		STAT_MEC = -5,
 		STAT_COG = -5
@@ -74,11 +76,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
-		STAT_TGH = 0,
+		STAT_TGH = 10,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
-		STAT_MEC = 30,
-		STAT_COG = 0
+		STAT_MEC = 80,
+		STAT_COG = 10
 	)
 
 /datum/category_item/setup_option/background/ethnicity/ag_synth_sturdy
@@ -91,15 +93,15 @@
 	restricted_to_species = list(FORM_AGSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/engineer)
 	racial_implants_l = (/obj/item/organ_module/active/multitool/engineering)
-	//restricted_jobs = list(/datum/job/outsider)
+	restricted_jobs = list(/datum/job/outsider) //You are colony designed, makes no sence outsiders could have it
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
-		STAT_TGH = 0,
-		STAT_VIG = 5,
+		STAT_ROB = 40,
+		STAT_TGH = 15,
+		STAT_VIG = 10,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
-		STAT_COG = 20
+		STAT_COG = 35
 	)
 
 /datum/category_item/setup_option/background/ethnicity/ag_synth_mine
@@ -114,17 +116,13 @@
 	racial_implants_l = (/obj/item/organ_module/active/multitool/lighting)
 	//restricted_jobs = list(/datum/job/outsider)
 
-//Idea for this is that you were made with being a miner, thus giving you everything you need as one
-//The main boon being you get a bit of evey skill you /need/ to mine out faster and maintain tools / set up the big drills.
-//-0Loss Stats +35Gained Stat
-
 	stat_modifiers = list(
-		STAT_ROB = 25,
-		STAT_TGH = 0,
+		STAT_ROB = 45,
+		STAT_TGH = 15,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
-		STAT_MEC = 15,
-		STAT_COG = 5
+		STAT_MEC = 25,
+		STAT_COG = 15
 	)
 
 /datum/category_item/setup_option/background/ethnicity/blackshield_security
@@ -139,9 +137,9 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 20,
-		STAT_TGH = 5,
-		STAT_VIG = 20,
+		STAT_ROB = 40,
+		STAT_TGH = 20,
+		STAT_VIG = 40,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0
@@ -159,9 +157,9 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 30,
-		STAT_TGH = 10,
-		STAT_VIG = 5,
+		STAT_ROB = 40,
+		STAT_TGH = 50,
+		STAT_VIG = 10,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0
@@ -179,9 +177,9 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
-		STAT_TGH = 10,
-		STAT_VIG = 30,
+		STAT_ROB = 20,
+		STAT_TGH = 20,
+		STAT_VIG = 60,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0
@@ -201,10 +199,10 @@
 	stat_modifiers = list(
 		STAT_ROB = 0,
 		STAT_TGH = 0,
-		STAT_VIG = 0,
-		STAT_BIO = 30,
-		STAT_MEC = 0,
-		STAT_COG = 0
+		STAT_VIG = 15,
+		STAT_BIO = 35,
+		STAT_MEC = 10,
+		STAT_COG = 35
 	)
 
 /datum/category_item/setup_option/background/ethnicity/church_combat
@@ -218,14 +216,13 @@
 	racial_implants_l = (/obj/item/organ_module/active/multitool/lighting)
 	//restricted_jobs = list(/datum/job/outsider)
 
-	//Compared to the soteria combat model and blackshield synths you get 20 armor across the body vs. 30/35 respectively, so what you lack in natural defense is made up in offense. -Kaz
 	stat_modifiers = list(
 		STAT_ROB = 25,
-		STAT_TGH = 10,
+		STAT_TGH = 25,
 		STAT_VIG = 25,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
-		STAT_COG = 0
+		STAT_MEC = 5,
+		STAT_COG = 20
 	)
 
 /datum/category_item/setup_option/background/ethnicity/church_religion
@@ -240,12 +237,12 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 10,
+		STAT_ROB = 20,
 		STAT_TGH = 0,
-		STAT_VIG = 10,
-		STAT_BIO = 5, //Given 10 bio racially.
-		STAT_MEC = 10,
-		STAT_COG = 15
+		STAT_VIG = 20,
+		STAT_BIO = 15,
+		STAT_MEC = 20,
+		STAT_COG = 25
 	)
 
 // FBP's lack a base racial bonus, what you see here is all they get.
@@ -261,11 +258,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 15,
-		STAT_TGH = 0,
+		STAT_TGH = 15,
 		STAT_VIG = 15,
 		STAT_BIO = 20,
 		STAT_MEC = 20,
-		STAT_COG = 20
+		STAT_COG = 15
 	)
 
 /datum/category_item/setup_option/background/ethnicity/full_body_prosthetic_fighter
@@ -280,11 +277,11 @@
 	racial_implants_l = (/obj/item/organ_module/active/multitool/lighting)
 
 	stat_modifiers = list(
-		STAT_ROB = 32, // No inbuilt weapons.
-		STAT_TGH = 10,
-		STAT_VIG = 32,
+		STAT_ROB = 35,
+		STAT_TGH = 15,
+		STAT_VIG = 35,
 		STAT_BIO = 0,
-		STAT_MEC = 0,
+		STAT_MEC = 15,
 		STAT_COG = 0
 	)
 
@@ -302,7 +299,7 @@
 	stat_modifiers = list(
 		STAT_ROB = 0,
 		STAT_TGH = 0,
-		STAT_VIG = 0,
+		STAT_VIG = 15,
 		STAT_BIO = 25,
 		STAT_MEC = 25,
 		STAT_COG = 35 // Good on paper, but since you cannot be a psion, at best it helps with hacking and disarming landmines.

--- a/code/datums/setup_option/backgrounds/origin_synthetic.dm
+++ b/code/datums/setup_option/backgrounds/origin_synthetic.dm
@@ -93,7 +93,7 @@
 	restricted_to_species = list(FORM_AGSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/engineer)
 	racial_implants_l = (/obj/item/organ_module/active/multitool/engineering)
-	restricted_jobs = list(/datum/job/outsider) //You are colony designed, makes no sence outsiders could have it
+	restricted_jobs = list(/datum/job/outsider) //You are colony designed, makes no sense outsiders could have it
 
 	stat_modifiers = list(
 		STAT_ROB = 40,


### PR DESCRIPTION
Makes all synth backrounds more robust in giving stats to help minimize minmaxing 
Blacklists "\"Long-Haul\" Body Chassis" from outsider do to being one of O'Conners designs