### PR TITLE
fixes gas masks and bridge pipes

### DIFF
--- a/code/modules/cooking_with_jane/recipes/recipe.dm
+++ b/code/modules/cooking_with_jane/recipes/recipe.dm
@@ -315,7 +315,7 @@
 	step_builder = list(
 		list(CWJ_ADD_REAGENT, "cornoil", 2),
 		list(CWJ_ADD_REAGENT, "egg", 3),
-		list(CWJ_ADD_PRODUCE, "sodiumchloride", 1),
+		list(CWJ_ADD_REAGENT, "sodiumchloride", 1),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/meat/pork, qmod=0.5),
 		list(CWJ_ADD_REAGENT, "flour", 5),
 		list(CWJ_USE_STOVE, J_MED, 40 SECONDS)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -151,9 +151,8 @@
 /mob/proc/unEquip(obj/item/I, var/atom/Target = null, force = 0) //Force overrides NODROP for things like wizarditis and admin undress.
 	if(!canUnEquip(I))
 		return
-	//Removed until we have features that need them, so these aren't being rapid-fired needlessly. - Hex
-	//LEGACY_SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, I)
-	//LEGACY_SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
+	LEGACY_SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, I)
+	LEGACY_SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
 	return drop_from_inventory(I,Target)
 
 //Attemps to remove an object on a mob.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -151,8 +151,9 @@
 /mob/proc/unEquip(obj/item/I, var/atom/Target = null, force = 0) //Force overrides NODROP for things like wizarditis and admin undress.
 	if(!canUnEquip(I))
 		return
-	LEGACY_SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, I)
-	LEGACY_SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
+	if(I)
+		LEGACY_SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, I)
+		LEGACY_SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
 	return drop_from_inventory(I,Target)
 
 //Attemps to remove an object on a mob.

--- a/code/modules/psionics/psion_powers/gear_summoning_powers.dm
+++ b/code/modules/psionics/psion_powers/gear_summoning_powers.dm
@@ -145,7 +145,11 @@
 			shield.can_block_proj = TRUE
 			shield.base_block_chance += 10
 			shield.adjustShieldDurability(-10, user)
-		usr.put_in_active_hand(shield)
+		if(usr.put_in_active_hand(shield))
+			return
+		STOP_PROCESSING(SSobj, shield)
+		qdel(shield)
+
 
 /mob/living/carbon/human/proc/psionic_shield_layered()
 	set category = "Psionic powers"
@@ -162,7 +166,10 @@
 			"You feel the rush of electric essence shocking your hand lightly before a psy-shield forms!"
 			)
 		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
-		usr.put_in_active_hand(shield)
+		if(usr.put_in_active_hand(shield))
+			return
+		STOP_PROCESSING(SSobj, shield)
+		qdel(shield)
 
 
 /mob/living/carbon/human/proc/telekinetic_fist()

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -41335,14 +41335,15 @@
 	name = "Bridge";
 	req_access = list(19)
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -45214,6 +45215,16 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
+"iBA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/command/hallway)
 "iBD" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/industrial/bricks,
@@ -54862,6 +54873,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/command/hallway)
 "kuz" = (
@@ -61344,6 +61356,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"lLq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/command/hallway)
 "lLA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders,
@@ -64333,6 +64353,9 @@
 "mny" = (
 /obj/item/modular_computer/console/preset/medical/monitor{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/hallway)
@@ -71452,7 +71475,6 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nDi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/blue,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -71460,6 +71482,7 @@
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
 "nDl" = (
@@ -96190,6 +96213,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"skR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/command/hallway)
 "skU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -101852,6 +101883,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
 "tpN" = (
@@ -101985,6 +102022,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/command/hallway)
 "tra" = (
@@ -109914,6 +109952,19 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"uNU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/command/hallway)
 "uNW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/wood/wild4,
@@ -191151,9 +191202,9 @@ vaK
 jJU
 tPi
 xET
+skR
 kuq
-kuq
-tpH
+iBA
 bix
 cDE
 gku
@@ -191353,9 +191404,9 @@ vaK
 jJU
 hpk
 xET
+lLq
 tqS
-tqS
-tpH
+uNU
 voC
 vWu
 dzS


### PR DESCRIPTION
Gas masks no longer make sanity proof if you rapily take them off and on
fixes a bad pipe in bridge
fixes lack of a room having piping and atmos alarm
fixes psionic shields spawning inside players giving them free endless glowing 
fixes a cooking with jane step error with salt

closes #5732
closes #5692
closes #5672
