### PR TITLE
fixes some materal weapons and xenoarch weapons

### DIFF
--- a/code/game/objects/items/weapons/material/material_weapons.dm
+++ b/code/game/objects/items/weapons/material/material_weapons.dm
@@ -20,6 +20,21 @@
 	var/drops_debris = 1
 	var/furniture_icon  //icon states for non-material colorable overlay, i.e. handles
 
+	max_upgrades = 0 //Its upgrade is its materal type.
+
+/obj/item/material/refresh_upgrades()
+	name = "[material.display_name] [initial(name)]"
+
+	update_force()
+	if(wielded)
+		if(force_wielded_multiplier)
+			force = force * force_wielded_multiplier
+		else //This will give items wielded 30% more damage. This is balanced by the fact you cannot use your other hand.
+			force = (force * 1.3) //Items that do 0 damage will still do 0 damage though.
+		name = "[name] (Wielded)"
+	return
+
+
 /obj/item/material/New(var/newloc, var/material_key)
 	..(newloc)
 	if(!material_key)

--- a/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
@@ -9,6 +9,7 @@
 	self_recharge = TRUE
 	projectile_type = /obj/item/projectile/beam/tesla/shotgun // thats right. Its a shotgun cog.
 	allow_greyson_mods = FALSE
+	max_upgrades = 0
 
 /obj/item/gun/energy/cog/xenoarch/refresh_upgrades()
 	force = initial(force)
@@ -30,6 +31,7 @@
 	item_state_slots = null
 	icon_contained = FALSE
 	self_recharge = TRUE
+	max_upgrades = 0
 
 /obj/item/gun/energy/xray/xenoarch/refresh_upgrades()
 	force = initial(force)
@@ -51,6 +53,7 @@
 	item_state_slots = null
 	icon_contained = FALSE
 	allow_greyson_mods = FALSE
+	max_upgrades = 0
 
 /obj/item/gun/energy/captain/xenoarch/refresh_upgrades()
 	force = initial(force)
@@ -71,6 +74,7 @@
 	name = "Fossilised Gun"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	max_shells = 12
+	max_upgrades = 0
 
 /obj/item/gun/projectile/revolver/xenoarch/refresh_upgrades()
 	force = initial(force)
@@ -92,6 +96,7 @@
 	max_shells = 4
 	damage_multiplier = 1.2
 	saw_off = FALSE
+	max_upgrades = 0
 
 /obj/item/gun/projectile/revolver/sixshot/xenoarch/refresh_upgrades()
 	force = initial(force)
@@ -111,6 +116,7 @@
 	name = "Fossilized Gun"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	damage_multiplier = 1.5
+	max_upgrades = 0
 
 /obj/item/gun/projectile/boltgun/heavysniper/xenoarch/refresh_upgrades()
 	force = initial(force)


### PR DESCRIPTION
Materal weapons such as katana's claymores and swords now shouldnt randomly reset themselfs to 0 damage
Fixes being able to add gunmods uselessly to xenoarch weapons