### PR TITLE
better power sink and guilg rig

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -435,8 +435,8 @@
 		drain_complete(H)
 		return
 
-	// Attempts to drain up to 40kW, determines this value from remaining cell capacity to ensure we don't drain too much..
-	var/to_drain = min(40000, ((holder.cell.maxcharge - holder.cell.charge) / CELLRATE))
+	// Attempts to drain up to 100kW, determines this value from remaining cell capacity to ensure we don't drain too much..
+	var/to_drain = min(100000, ((holder.cell.maxcharge - holder.cell.charge) / CELLRATE))
 	var/target_drained = interfaced_with.drain_power(0,0,to_drain)
 	if(target_drained <= 0)
 		to_chat(H, "<span class = 'danger'>Your power sink flashes a red light; there is no power left in [interfaced_with].</span>")

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -168,6 +168,7 @@ Advanced Voidsuit: Guild Master
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/device/rcd,
 		/obj/item/rig_module/vision/meson,
 		/obj/item/rig_module/cargo_clamp,
@@ -187,8 +188,8 @@ Advanced Voidsuit: Guild Master
 Technomancer RIG
 ***************************************/
 /obj/item/rig/techno
-	name = "technomancer suit control module"
-	suit_type = "technomancer RIG suit"
+	name = "Artificers suit control module"
+	suit_type = "Artificers RIG suit"
 	desc = "An advanced RIG suit that protects against hazardous, low pressure and high temperature environments."
 	icon_state = "techno_rig"
 	armor_list = list(
@@ -222,6 +223,7 @@ Technomancer RIG
 /obj/item/rig/techno/equipped
 	initial_modules = list(
 		/obj/item/rig_module/storage/large,
+		/obj/item/rig_module/power_sink,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/cargo_clamp,
 		)


### PR DESCRIPTION
Small PR with some minor changes. addition of power sinks to the suits was at Chefs request and I don't particularly care about it. Buuut I think its fair that the people who make the power get it on tap.

The buffs to the sinks I hold strong on. They fucking suck for how rare of a module they are and now have to compete with cell hot-swapping.

Changes the name of guild RIGs for something more lore correct. We are not Technomancers. _sadly_
Buffs power sinks from 40KW per cycle to a entire 100kw per cycle. Approximately 3 minutes to fully charge a 14000L.
Buffs both the GMs RIG and adepts RIGs to have power sinks round start.