### PR TITLE
Updates synth buffs.

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_synthetic.dm
+++ b/code/datums/setup_option/backgrounds/origin_synthetic.dm
@@ -217,12 +217,12 @@
 	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 25,
+		STAT_ROB = 35,
 		STAT_TGH = 25,
-		STAT_VIG = 25,
+		STAT_VIG = 35,
 		STAT_BIO = 0,
 		STAT_MEC = 5,
-		STAT_COG = 20
+		STAT_COG = 0
 	)
 
 /datum/category_item/setup_option/background/ethnicity/church_religion


### PR DESCRIPTION
Related to triliby PR that was uploaded earlier this week. Edits the church's combat model to not have a dump stat bringing it in line with other models because currently there is no way to even get COG high enough with other stats to get it to be a bypass stat correctly. Moves the twenty COG to ROB and VIG putting it in line with the unbranded veteran model and weaker then the Standard combat synth models.

