### PR TITLE
We Dig It

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/junker.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/junker.dm
@@ -79,6 +79,7 @@
 */
 	// TODO: Better offers
 	offer_types = list(
+		/obj/item/tool/shovel/combat/turbo = offer_data("Artificer Power Crovel", 1750, 2),
 		/datum/reagent/ethanol/changelingsting = offer_data("Changeling Sting bottle (60u)", 1500, 1),
 		/datum/reagent/ethanol/longislandicedtea = offer_data("Long Island Iced Tea bottle (60u)", 1500, 1),
 		/datum/reagent/ethanol/neurotoxin = offer_data("Neurotoxin bottle (60u)", 2500, 1),


### PR DESCRIPTION
Adds the gas powered crovel favor to the Garbaj station. 1750 credits each, up to 2 at a time.

![image](https://github.com/user-attachments/assets/158f2241-b6d8-457b-833a-7dd1bd171a41)
it works


![WeDigIt](https://github.com/user-attachments/assets/27268d0b-ea28-4d7a-9cd1-d3597eee3560)
a quick doodle for a quick PR