### PR TITLE
Marshal Vest has LOWER_TORSO tag

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1102,7 +1102,6 @@
 		bio = 0,
 		rad = 0
 	)
-	body_parts_covered = UPPER_TORSO //we get the same armor as a regular marshal vest with limited coverage.
 
 //Provides the protection of a merc voidsuit, but only covers the chest/groin, and also takes up a suit slot. In exchange it has no slowdown and provides storage.
 /obj/item/clothing/suit/storage/vest/merc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Gives the Marshal's default webbing vest lower body protection. This vest, when upgraded into a full-body vest, loses its webbing anyway.

Removing the webbed armor's slowdown was never going to make the full-body vest obsolete; the full-body vest still is more useful overall but webbed armor is able to hold a 4 extra small items for those willing to risk their limbs. Webbed Operator Armor can be upgraded into a full-body vest, but it **loses** the webbing if you do this. 

There was no need to remove half of its protective region; the point is for the player to choose between a bit of extra storage space, or limb protection when choosing between the webbed armor or tactical unit armor. Making the webbed vest even less usable as armor is overcorrecting for an issue no one brought up.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: The LOWER_TORSO tag has been added back to the Marshal webbing vest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
