### PR TITLE
Soteria Buff one out of one hundred.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/onestarboss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/onestarboss.dm
@@ -38,6 +38,8 @@
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(3, 1, src)
 		s.start()
+		if(prob(10))
+			new /obj/item/gun_upgrade/mechanism/greyson_master_catalyst(src.loc)
 		..()
 
 

--- a/code/modules/research/designs/greyson.dm
+++ b/code/modules/research/designs/greyson.dm
@@ -99,10 +99,10 @@
 	build_path = /obj/item/gun_upgrade/mechanism/glass_widow
 	category = CAT_GUNMODS
 
-/datum/design/research/item/greyson/unmaker
-	name = "GP \"Master Unmaker\" infuser"
-	build_path = /obj/item/gun_upgrade/mechanism/greyson_master_catalyst
-	category = CAT_GUNMODS
+//datum/design/research/item/greyson/unmaker
+//	name = "GP \"Master Unmaker\" infuser"
+//	build_path = /obj/item/gun_upgrade/mechanism/greyson_master_catalyst
+//	category = CAT_GUNMODS
 
 /datum/design/research/item/powercell/large/grayson
 	name = "GP-SI \"Posi-cell 16000L\""

--- a/code/modules/research/nodes/greyson.dm
+++ b/code/modules/research/nodes/greyson.dm
@@ -68,7 +68,7 @@
 
 /datum/technology/GP_window
 	name = "Greyson Positronic Glass-Widow Infuser"
-	desc = "The GP Glass Widow Infuser design and manufacturing."
+	desc = "The GP Glass Widow Infuser design and portable self charging combat shields."
 	tech_type = RESEARCH_GREYSON
 
 	x = 0.3 //Bottom left
@@ -79,23 +79,23 @@
 								 /datum/technology/exotic_gunmods)
 	required_tech_levels = list(RESEARCH_COMBAT = 10)
 	cost = 11250
-	unlocks_designs = list(/datum/design/research/item/greyson/glass_widow)
+	unlocks_designs = list(/datum/design/research/item/greyson/glass_widow,
+			/datum/design/research/item/greyson/combat_shield)
 
-/datum/technology/GP_unmaker
-	name = "Greyson Positronic Tyrant Destroyers"
-	desc = "The rare and highly valueable GP Master Unmaker Infuser gun mod and portable self charging combat shields."
-	tech_type = RESEARCH_GREYSON
+//datum/technology/GP_unmaker
+//	name = "Greyson Positronic Tyrant Destroyers"
+//	desc = "The rare and highly valueable GP Master Unmaker Infuser gun mod."
+//	tech_type = RESEARCH_GREYSON
 
-	x = 0.5 //Bottom middle
-	y = 0.3
-	icon = "mastermind"
+//	x = 0.5 //Bottom middle
+//	y = 0.3
+//	icon = "mastermind"
 
-	required_technologies = list(/datum/technology/GP_window)
-	required_tech_levels = list(RESEARCH_COMBAT = 13)
-	cost = 37500
+//	required_technologies = list(/datum/technology/GP_window)
+//	required_tech_levels = list(RESEARCH_COMBAT = 13)
+//	cost = 37500
 
-	unlocks_designs = list(/datum/design/research/item/greyson/unmaker,
-			       /datum/design/research/item/greyson/combat_shield)
+//	unlocks_designs = list(/datum/design/research/item/greyson/unmaker)
 
 /datum/technology/GP_cells
 	name = "Greyson Positronic Cells"


### PR DESCRIPTION
It's been a long time coming, This PR was meant to be done months ago. It reduces the research points needed by 37500 because it removes the research tree for the unmaker. The Greyson portable shield was moved to the glass widow branch. Unmakers can still be purchased from cargo, Found at the end of the gauntlet and now are a rare drop from the Greyson Titan robots that can be found at the end of the gauntlet or the boss rooms in the Greyson's outpost.


The node was left untouched as things will be added too it later for a replacement, but spiriting needs to be done. Greyson oxygen tank will most likely added to this tree as well in the future.