### PR TITLE
map reduction and locker post spawning

### DIFF
--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -97,6 +97,10 @@
 		/*if(istype(O, /obj/structure/scrap_cube))
 			current_item = O
 			return*/
+		if(istype(O, /obj/structure/closet))
+			var/obj/structure/closet/C = O
+			C.populate_contents()
+
 		var/list/materials = result_materials(O)
 		if(!materials?.len || !are_valid_materials(materials))
 			eject(O, refuse_output_side)
@@ -200,6 +204,7 @@
 	if(T.density)
 		return
 	O.loc = T
+	O.reset_plane_and_layer()
 
 /obj/machinery/smelter/proc/eject_material_stack(material)
 	var/obj/item/stack/material/stack_type = material_stack_type(material)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -46,6 +46,7 @@
 	var/has_mobs_to_spawn = FALSE
 	var/chance_old_mobs = 20
 	var/mobs_to_spawn = /obj/random/cluster/roaches
+	var/populated_contents = FALSE
 
 /obj/structure/closet/can_prevent_fall()
 	return TRUE
@@ -53,7 +54,6 @@
 /obj/structure/closet/Initialize(mapload)
 	..()
 
-	populate_contents()
 	update_icon()
 	hack_require = rand(6,8)
 
@@ -95,6 +95,7 @@
 			storage_capacity = content_size + 5
 
 /obj/structure/closet/Destroy()
+	populate_contents()
 	dump_contents()
 	. = ..()
 
@@ -106,16 +107,19 @@
 		for(var/obj/item/I in src.contents)
 			if(!I.anchored)
 				content_size += CEILING(I.w_class * 0.5, 1)
-		if(!content_size)
-			to_chat(user, "It is empty.")
-		else if(storage_capacity > content_size*4)
-			to_chat(user, "It is barely filled.")
-		else if(storage_capacity > content_size*2)
-			to_chat(user, "It is less than half full.")
-		else if(storage_capacity > content_size)
-			to_chat(user, "There is still some free space.")
+		if(populated_contents)
+			if(!content_size)
+				to_chat(user, "It is empty.")
+			else if(storage_capacity > content_size*4)
+				to_chat(user, "It is barely filled.")
+			else if(storage_capacity > content_size*2)
+				to_chat(user, "It is less than half full.")
+			else if(storage_capacity > content_size)
+				to_chat(user, "There is still some free space.")
+			else
+				to_chat(user, "It is full.")
 		else
-			to_chat(user, "It is full.")
+			to_chat(user, "Its hard to tell how full [src] is.")
 
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0 || wall_mounted)) return 1
@@ -203,6 +207,8 @@
 /obj/structure/closet/proc/open(mob/living/user)
 	if(opened || !can_open(user))
 		return FALSE
+
+	populate_contents()
 
 	if(rigged && (locate(/obj/item/device/radio/electropack) in src) && istype(user))
 		if(user.electrocute_act(20, src))
@@ -336,6 +342,7 @@
 
 // this should probably use dump_contents()
 /obj/structure/closet/ex_act(severity)
+	populate_contents()
 	switch(severity)
 		if(1)
 			for(var/atom/movable/A as mob|obj in src)//pulls everything out of the locker and hits it with an explosion
@@ -355,10 +362,13 @@
 				health -= 50
 
 /obj/structure/closet/proc/populate_contents()
-	return
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 
 /obj/structure/closet/proc/damage(var/damage)
 	health -= damage
+	populate_contents()
 	if(health <= 0)
 		qdel(src)
 
@@ -563,6 +573,7 @@
 // tk grab then use on self
 /obj/structure/closet/attack_self_tk(mob/user as mob)
 	src.add_fingerprint(user)
+	populate_contents()
 	if(!src.toggle())
 		to_chat(usr, SPAN_NOTICE("It won't budge!"))
 
@@ -571,6 +582,7 @@
 		locked = FALSE
 		broken = TRUE
 		update_icon()
+		populate_contents()
 		playsound(src.loc, "sparks", 60, 1)
 		to_chat(user, SPAN_NOTICE("You unlock \the [src]."))
 		return TRUE
@@ -586,6 +598,7 @@
 			playsound(src.loc, 'sound/effects/sparks4.ogg', 75, 1)
 		broken = TRUE
 	update_icon()
+	populate_contents()
 	..()
 
 /obj/structure/closet/verb/verb_toggleopen()
@@ -705,6 +718,7 @@
 /obj/structure/closet/proc/break_open()
 	welded = 0
 	update_icon()
+	populate_contents()
 	//Do this to prevent contents from being opened into nullspace (read: bluespace)
 	if(istype(loc, /obj/structure/bigDelivery))
 		var/obj/structure/bigDelivery/BD = loc

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -119,7 +119,7 @@
 			else
 				to_chat(user, "It is full.")
 		else
-			to_chat(user, "Its hard to tell how full [src] is.")
+			to_chat(user, "It's hard to tell how full [src] is.")
 
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0 || wall_mounted)) return 1

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -362,9 +362,9 @@
 				health -= 50
 
 /obj/structure/closet/proc/populate_contents()
-	if(populated_contents)
-		return
 	populated_contents = TRUE
+	if(populated_contents)
+		return FALSE
 
 /obj/structure/closet/proc/damage(var/damage)
 	health -= damage

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -4,7 +4,9 @@
 	icon_door = "mixed"
 
 /obj/structure/closet/athletic_mixed/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/shorts/athleticgrey(src)
 	new /obj/item/clothing/under/shorts/athleticblack(src)
 	new /obj/item/clothing/under/shorts(src)
@@ -28,7 +30,9 @@
 	desc = "It's a storage unit for gloves for use in the boxing ring."
 
 /obj/structure/closet/boxinggloves/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/gloves/boxing/blue(src)
 	new /obj/item/clothing/gloves/boxing/green(src)
 	new /obj/item/clothing/gloves/boxing/yellow(src)
@@ -39,7 +43,9 @@
 	desc = "IT'S A STORAGE UNIT FOR FIGHTER MASKS OLE!"
 
 /obj/structure/closet/masks/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/mask/costume/job/luchador(src)
 	new /obj/item/clothing/mask/costume/job/luchador/rudos(src)
 	new /obj/item/clothing/mask/costume/job/luchador/tecnicos(src)
@@ -50,7 +56,9 @@
 	icon_door = "red"
 
 /obj/structure/closet/lasertag/red/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/gun/energy/lasertag/red(src)
 	new /obj/item/gun/energy/lasertag/red(src)
 	new /obj/item/gun/energy/lasertag/red(src)
@@ -82,7 +90,9 @@
 	icon_door = "blue"
 
 /obj/structure/closet/lasertag/blue/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/gun/energy/lasertag/blue(src)
 	new /obj/item/gun/energy/lasertag/blue(src)
 	new /obj/item/gun/energy/lasertag/blue(src)
@@ -114,7 +124,9 @@
 	icon_door = "green"
 
 /obj/structure/closet/lasertag/green/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/gun/energy/lasertag/green(src)
 	new /obj/item/gun/energy/lasertag/green(src)
 	new /obj/item/gun/energy/lasertag/green(src)
@@ -146,7 +158,9 @@
 	icon_door = "yellow"
 
 /obj/structure/closet/lasertag/yellow/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/gun/energy/lasertag/yellow(src)
 	new /obj/item/gun/energy/lasertag/yellow(src)
 	new /obj/item/gun/energy/lasertag/yellow(src)

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -4,6 +4,7 @@
 	icon_door = "mixed"
 
 /obj/structure/closet/athletic_mixed/populate_contents()
+	..()
 	new /obj/item/clothing/under/shorts/athleticgrey(src)
 	new /obj/item/clothing/under/shorts/athleticblack(src)
 	new /obj/item/clothing/under/shorts(src)
@@ -27,6 +28,7 @@
 	desc = "It's a storage unit for gloves for use in the boxing ring."
 
 /obj/structure/closet/boxinggloves/populate_contents()
+	..()
 	new /obj/item/clothing/gloves/boxing/blue(src)
 	new /obj/item/clothing/gloves/boxing/green(src)
 	new /obj/item/clothing/gloves/boxing/yellow(src)
@@ -37,6 +39,7 @@
 	desc = "IT'S A STORAGE UNIT FOR FIGHTER MASKS OLE!"
 
 /obj/structure/closet/masks/populate_contents()
+	..()
 	new /obj/item/clothing/mask/costume/job/luchador(src)
 	new /obj/item/clothing/mask/costume/job/luchador/rudos(src)
 	new /obj/item/clothing/mask/costume/job/luchador/tecnicos(src)
@@ -47,6 +50,7 @@
 	icon_door = "red"
 
 /obj/structure/closet/lasertag/red/populate_contents()
+	..()
 	new /obj/item/gun/energy/lasertag/red(src)
 	new /obj/item/gun/energy/lasertag/red(src)
 	new /obj/item/gun/energy/lasertag/red(src)
@@ -78,6 +82,7 @@
 	icon_door = "blue"
 
 /obj/structure/closet/lasertag/blue/populate_contents()
+	..()
 	new /obj/item/gun/energy/lasertag/blue(src)
 	new /obj/item/gun/energy/lasertag/blue(src)
 	new /obj/item/gun/energy/lasertag/blue(src)
@@ -109,6 +114,7 @@
 	icon_door = "green"
 
 /obj/structure/closet/lasertag/green/populate_contents()
+	..()
 	new /obj/item/gun/energy/lasertag/green(src)
 	new /obj/item/gun/energy/lasertag/green(src)
 	new /obj/item/gun/energy/lasertag/green(src)
@@ -140,6 +146,7 @@
 	icon_door = "yellow"
 
 /obj/structure/closet/lasertag/yellow/populate_contents()
+	..()
 	new /obj/item/gun/energy/lasertag/yellow(src)
 	new /obj/item/gun/energy/lasertag/yellow(src)
 	new /obj/item/gun/energy/lasertag/yellow(src)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -15,6 +15,7 @@
 	icon_state = "syndicate"
 
 /obj/structure/closet/gimmick/russian/populate_contents()
+	..()
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
@@ -40,6 +41,7 @@
 	name = "red-team Thunderdome closet"
 
 /obj/structure/closet/thunderdome/tdred/populate_contents()
+	..()
 	new /obj/item/clothing/suit/armor/heavy/red(src)
 	new /obj/item/clothing/suit/armor/heavy/red(src)
 	new /obj/item/clothing/suit/armor/heavy/red(src)
@@ -64,6 +66,7 @@
 	icon_state = "syndicate"
 
 /obj/structure/closet/thunderdome/tdgreen/populate_contents()
+	..()
 	new /obj/item/clothing/suit/armor/heavy/green(src)
 	new /obj/item/clothing/suit/armor/heavy/green(src)
 	new /obj/item/clothing/suit/armor/heavy/green(src)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -15,7 +15,9 @@
 	icon_state = "syndicate"
 
 /obj/structure/closet/gimmick/russian/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
@@ -35,13 +37,17 @@
 	anchored = 1
 
 /obj/structure/closet/thunderdome/New()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 
 /obj/structure/closet/thunderdome/tdred
 	name = "red-team Thunderdome closet"
 
 /obj/structure/closet/thunderdome/tdred/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/armor/heavy/red(src)
 	new /obj/item/clothing/suit/armor/heavy/red(src)
 	new /obj/item/clothing/suit/armor/heavy/red(src)
@@ -66,7 +72,9 @@
 	icon_state = "syndicate"
 
 /obj/structure/closet/thunderdome/tdgreen/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/armor/heavy/green(src)
 	new /obj/item/clothing/suit/armor/heavy/green(src)
 	new /obj/item/clothing/suit/armor/heavy/green(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -15,6 +15,7 @@
 	icon_door = "black"
 
 /obj/structure/closet/gmcloset/populate_contents()
+	..()
 	new /obj/item/clothing/head/tophat(src)
 	new /obj/item/clothing/head/tophat(src)
 	new /obj/item/device/radio/headset/headset_service(src)
@@ -37,6 +38,7 @@
 	icon_door = "black"
 
 /obj/structure/closet/chefcloset/populate_contents()
+	..()
 	new /obj/item/clothing/under/costume/job/waiter(src)
 	new /obj/item/clothing/under/costume/job/waiter(src)
 	new /obj/item/clothing/under/rank/bartender(src)
@@ -62,6 +64,7 @@
 	icon_door = "mixed"
 
 /obj/structure/closet/jcloset/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/sport/purple(src)
 	else
@@ -94,6 +97,7 @@
 	icon_state = "custodian"
 
 /obj/structure/closet/custodial/populate_contents()
+	..()
 	new /obj/item/storage/belt/utility/neotheology(src)
 	new /obj/item/device/lighting/toggleable/flashlight(src)
 	new /obj/item/gun/matter/launcher/nt_sprayer(src)
@@ -118,6 +122,7 @@
 	icon_state = "acolyte"
 
 /obj/structure/closet/acolyte/populate_contents()
+	..()
 	if(prob(25))
 		new /obj/item/storage/backpack/neotheology(src)
 	else if(prob(25))

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -15,7 +15,9 @@
 	icon_door = "black"
 
 /obj/structure/closet/gmcloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/head/tophat(src)
 	new /obj/item/clothing/head/tophat(src)
 	new /obj/item/device/radio/headset/headset_service(src)
@@ -38,7 +40,9 @@
 	icon_door = "black"
 
 /obj/structure/closet/chefcloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/costume/job/waiter(src)
 	new /obj/item/clothing/under/costume/job/waiter(src)
 	new /obj/item/clothing/under/rank/bartender(src)
@@ -64,7 +68,9 @@
 	icon_door = "mixed"
 
 /obj/structure/closet/jcloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/sport/purple(src)
 	else
@@ -97,7 +103,9 @@
 	icon_state = "custodian"
 
 /obj/structure/closet/custodial/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/belt/utility/neotheology(src)
 	new /obj/item/device/lighting/toggleable/flashlight(src)
 	new /obj/item/gun/matter/launcher/nt_sprayer(src)
@@ -122,7 +130,9 @@
 	icon_state = "acolyte"
 
 /obj/structure/closet/acolyte/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(25))
 		new /obj/item/storage/backpack/neotheology(src)
 	else if(prob(25))

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -4,14 +4,18 @@
 	icon_state = "bio"
 
 /obj/structure/closet/l3closet/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/bio_suit/general(src)
 	new /obj/item/clothing/head/bio_hood/general(src)
 
 /obj/structure/closet/l3closet/general
 
 /obj/structure/closet/l3closet/general/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/bio_suit/general(src)
 	new /obj/item/clothing/head/bio_hood/general(src)
 	new /obj/item/reagent_containers/spray/sterilizine(src)
@@ -20,7 +24,9 @@
 	icon_door = "bio_viro"
 
 /obj/structure/closet/l3closet/virology/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/bio_suit/virology(src)
 	new /obj/item/clothing/head/bio_hood/virology(src)
 	new /obj/item/clothing/mask/breath(src)
@@ -31,7 +37,9 @@
 	icon_door = "bio_sec"
 
 /obj/structure/closet/l3closet/security/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/bio_suit/security(src)
 	new /obj/item/clothing/head/bio_hood/security(src)
 
@@ -39,13 +47,17 @@
 	icon_door = "bio_jan"
 
 /obj/structure/closet/l3closet/janitor/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/bio_suit/janitor(src)
 	new /obj/item/clothing/head/bio_hood/janitor(src)
 
 /obj/structure/closet/l3closet/scientist
 
 /obj/structure/closet/l3closet/scientist/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/bio_suit/scientist(src)
 	new /obj/item/clothing/head/bio_hood/scientist(src)

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -4,12 +4,14 @@
 	icon_state = "bio"
 
 /obj/structure/closet/l3closet/populate_contents()
+	..()
 	new /obj/item/clothing/suit/bio_suit/general(src)
 	new /obj/item/clothing/head/bio_hood/general(src)
 
 /obj/structure/closet/l3closet/general
 
 /obj/structure/closet/l3closet/general/populate_contents()
+	..()
 	new /obj/item/clothing/suit/bio_suit/general(src)
 	new /obj/item/clothing/head/bio_hood/general(src)
 	new /obj/item/reagent_containers/spray/sterilizine(src)
@@ -18,6 +20,7 @@
 	icon_door = "bio_viro"
 
 /obj/structure/closet/l3closet/virology/populate_contents()
+	..()
 	new /obj/item/clothing/suit/bio_suit/virology(src)
 	new /obj/item/clothing/head/bio_hood/virology(src)
 	new /obj/item/clothing/mask/breath(src)
@@ -28,6 +31,7 @@
 	icon_door = "bio_sec"
 
 /obj/structure/closet/l3closet/security/populate_contents()
+	..()
 	new /obj/item/clothing/suit/bio_suit/security(src)
 	new /obj/item/clothing/head/bio_hood/security(src)
 
@@ -35,11 +39,13 @@
 	icon_door = "bio_jan"
 
 /obj/structure/closet/l3closet/janitor/populate_contents()
+	..()
 	new /obj/item/clothing/suit/bio_suit/janitor(src)
 	new /obj/item/clothing/head/bio_hood/janitor(src)
 
 /obj/structure/closet/l3closet/scientist
 
 /obj/structure/closet/l3closet/scientist/populate_contents()
+	..()
 	new /obj/item/clothing/suit/bio_suit/scientist(src)
 	new /obj/item/clothing/head/bio_hood/scientist(src)

--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -8,7 +8,9 @@
 	chance_old_mobs = 50
 
 /obj/structure/closet/random_miscellaneous/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
@@ -37,7 +39,9 @@
 	chance_old_mobs = 25
 
 /obj/structure/closet/random_tech/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -61,7 +65,9 @@
 	chance_old_mobs = 25
 
 /obj/structure/closet/random_tech/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -91,7 +97,9 @@
 	chance_old_mobs = 75
 
 /obj/structure/closet/random_milsupply/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -128,7 +136,9 @@
 	chance_old_mobs = 15
 
 /obj/structure/closet/random_medsupply/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -152,7 +162,9 @@
 	chance_old_mobs = 75
 
 /obj/structure/closet/secure_closet/rare_loot/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/pack/rare(src)
 	new /obj/random/pack/rare(src)
 	new /obj/random/pack/rare(src)
@@ -182,7 +194,9 @@
 	chance_old_mobs = 95
 
 /obj/structure/closet/random_hostilemobs/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/pack/rare(src) //To reward players for fighting this bullshit
 	new /obj/random/pack/rare(src)
 	new /obj/random/gun_parts/low(src)
@@ -204,7 +218,9 @@
 	has_mobs_to_spawn = TRUE //These always have roaches
 
 /obj/structure/closet/random_hostilemobs/beacon/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/pack/rare(src) //To reward players for fighting this bullshit
 	new /obj/random/pack/rare(src)
 	new /obj/random/gun_parts/low(src)

--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -8,6 +8,7 @@
 	chance_old_mobs = 50
 
 /obj/structure/closet/random_miscellaneous/populate_contents()
+	..()
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
@@ -36,6 +37,7 @@
 	chance_old_mobs = 25
 
 /obj/structure/closet/random_tech/populate_contents()
+	..()
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -59,6 +61,7 @@
 	chance_old_mobs = 25
 
 /obj/structure/closet/random_tech/populate_contents()
+	..()
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -88,6 +91,7 @@
 	chance_old_mobs = 75
 
 /obj/structure/closet/random_milsupply/populate_contents()
+	..()
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -124,6 +128,7 @@
 	chance_old_mobs = 15
 
 /obj/structure/closet/random_medsupply/populate_contents()
+	..()
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -147,6 +152,7 @@
 	chance_old_mobs = 75
 
 /obj/structure/closet/secure_closet/rare_loot/populate_contents()
+	..()
 	new /obj/random/pack/rare(src)
 	new /obj/random/pack/rare(src)
 	new /obj/random/pack/rare(src)
@@ -176,6 +182,7 @@
 	chance_old_mobs = 95
 
 /obj/structure/closet/random_hostilemobs/populate_contents()
+	..()
 	new /obj/random/pack/rare(src) //To reward players for fighting this bullshit
 	new /obj/random/pack/rare(src)
 	new /obj/random/gun_parts/low(src)
@@ -197,6 +204,7 @@
 	has_mobs_to_spawn = TRUE //These always have roaches
 
 /obj/structure/closet/random_hostilemobs/beacon/populate_contents()
+	..()
 	new /obj/random/pack/rare(src) //To reward players for fighting this bullshit
 	new /obj/random/pack/rare(src)
 	new /obj/random/gun_parts/low(src)

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -3,7 +3,9 @@
 	icon_state = "syndicate"
 
 /obj/structure/closet/malf/suits/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/tank/jetpack/void(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/clothing/suit/space/void(src)

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -3,6 +3,7 @@
 	icon_state = "syndicate"
 
 /obj/structure/closet/malf/suits/populate_contents()
+	..()
 	new /obj/item/tank/jetpack/void(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/clothing/suit/space/void(src)

--- a/code/game/objects/structures/crates_lockers/closets/onestar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/onestar.dm
@@ -8,6 +8,9 @@
 	icon_state = "lootcloset"
 
 /obj/structure/closet/onestar/tier1/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
@@ -36,6 +39,9 @@
 	icon_state = "lootcloset1"
 
 /obj/structure/closet/onestar/tier2/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
@@ -66,6 +72,9 @@
 	icon_state = "lootcloset2"
 
 /obj/structure/closet/onestar/tier3/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
@@ -107,6 +116,9 @@
 // Empty
 /obj/structure/closet/onestar/tier1/normal/empty
 /obj/structure/closet/onestar/tier1/normal/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 2
@@ -118,6 +130,9 @@
 // Empty
 /obj/structure/closet/onestar/tier2/normal/empty
 /obj/structure/closet/onestar/tier2/normal/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 3
@@ -129,6 +144,9 @@
 // Empty
 /obj/structure/closet/onestar/tier3/normal/empty
 /obj/structure/closet/onestar/tier3/normal/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 
@@ -140,17 +158,23 @@
 	old_chance = 70
 
 /obj/structure/closet/onestar/tier1/special/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
 	new /obj/random/gun_parts/low(src)
-	..()
+
 
 // Empty
 /obj/structure/closet/onestar/tier1/special/empty
 /obj/structure/closet/onestar/tier1/special/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 2
@@ -160,6 +184,9 @@
 	old_chance = 30
 
 /obj/structure/closet/onestar/tier2/special/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
@@ -167,11 +194,14 @@
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
 	new /obj/random/gun_parts/low(src)
 	new /obj/random/gun_parts/frames(src)
-	..()
+
 
 // Empty
 /obj/structure/closet/onestar/tier2/special/empty
 /obj/structure/closet/onestar/tier2/special/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 3
@@ -181,7 +211,9 @@
 	old_chance = 10
 
 /obj/structure/closet/onestar/tier3/special/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -190,10 +222,12 @@
 	new /obj/random/gun_parts/frames(src)
 	new /obj/random/gun_parts/frames(src)
 	..()
-
 // Empty
 /obj/structure/closet/onestar/tier3/special/empty
 /obj/structure/closet/onestar/tier3/special/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 ////Mineral
@@ -204,7 +238,9 @@
 	old_chance = 70
 
 /obj/structure/closet/onestar/tier1/mineral/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -212,10 +248,12 @@
 	new /obj/random/gun_parts/frames(src)
 	new /obj/random/gun_parts/frames(src)
 	..()
-
 // Empty
 /obj/structure/closet/onestar/tier1/mineral/empty
 /obj/structure/closet/onestar/tier1/mineral/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 2
@@ -225,7 +263,9 @@
 	old_chance = 30
 
 /obj/structure/closet/onestar/tier2/mineral/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -233,10 +273,12 @@
 	new /obj/random/gun_parts/frames(src)
 	new /obj/random/gun_parts/frames(src)
 	..()
-
 // Empty
 /obj/structure/closet/onestar/tier2/mineral/empty
 /obj/structure/closet/onestar/tier2/mineral/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 3
@@ -246,7 +288,9 @@
 	old_chance = 10
 
 /obj/structure/closet/onestar/tier3/mineral/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -254,10 +298,12 @@
 	new /obj/random/gun_parts/frames(src)
 	new /obj/random/gun_parts/frames(src)
 	..()
-
 // Empty
 /obj/structure/closet/onestar/tier3/mineral/empty
 /obj/structure/closet/onestar/tier3/mineral/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 ////Medical
@@ -268,7 +314,9 @@
 	old_chance = 70
 
 /obj/structure/closet/onestar/tier1/medical/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -276,10 +324,12 @@
 	new /obj/random/gun_parts/frames(src)
 	new /obj/random/gun_parts/frames(src)
 	..()
-
 // Empty
 /obj/structure/closet/onestar/tier1/medical/empty
 /obj/structure/closet/onestar/tier1/medical/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 2
@@ -289,16 +339,20 @@
 	old_chance = 30
 
 /obj/structure/closet/onestar/tier2/medical/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
 	new /obj/random/gun_parts/low(src)
 	..()
-
 // Empty
 /obj/structure/closet/onestar/tier2/medical/empty
 /obj/structure/closet/onestar/tier2/medical/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()
 
 //Tier 3
@@ -308,15 +362,19 @@
 	old_chance = 10
 
 /obj/structure/closet/onestar/tier3/medical/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
 	new /obj/random/gun_parts/low(src)
 	new /obj/random/gun_parts/frames(src)
 	..()
-
 // Empty
 /obj/structure/closet/onestar/tier3/medical/empty
 /obj/structure/closet/onestar/tier3/medical/empty/populate_contents()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/onestar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/onestar.dm
@@ -8,6 +8,7 @@
 	icon_state = "lootcloset"
 
 /obj/structure/closet/onestar/tier1/populate_contents()
+	..()
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
@@ -35,6 +36,7 @@
 	icon_state = "lootcloset1"
 
 /obj/structure/closet/onestar/tier2/populate_contents()
+	..()
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
@@ -64,6 +66,7 @@
 	icon_state = "lootcloset2"
 
 /obj/structure/closet/onestar/tier3/populate_contents()
+	..()
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/contraband/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
@@ -104,6 +107,7 @@
 // Empty
 /obj/structure/closet/onestar/tier1/normal/empty
 /obj/structure/closet/onestar/tier1/normal/empty/populate_contents()
+	..()
 
 //Tier 2
 /obj/structure/closet/onestar/tier2/normal
@@ -114,6 +118,7 @@
 // Empty
 /obj/structure/closet/onestar/tier2/normal/empty
 /obj/structure/closet/onestar/tier2/normal/empty/populate_contents()
+	..()
 
 //Tier 3
 /obj/structure/closet/onestar/tier3/normal
@@ -124,6 +129,7 @@
 // Empty
 /obj/structure/closet/onestar/tier3/normal/empty
 /obj/structure/closet/onestar/tier3/normal/empty/populate_contents()
+	..()
 
 
 ////Special
@@ -134,6 +140,7 @@
 	old_chance = 70
 
 /obj/structure/closet/onestar/tier1/special/populate_contents()
+	..()
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -144,6 +151,7 @@
 // Empty
 /obj/structure/closet/onestar/tier1/special/empty
 /obj/structure/closet/onestar/tier1/special/empty/populate_contents()
+	..()
 
 //Tier 2
 /obj/structure/closet/onestar/tier2/special
@@ -152,6 +160,7 @@
 	old_chance = 30
 
 /obj/structure/closet/onestar/tier2/special/populate_contents()
+	..()
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -163,6 +172,7 @@
 // Empty
 /obj/structure/closet/onestar/tier2/special/empty
 /obj/structure/closet/onestar/tier2/special/empty/populate_contents()
+	..()
 
 //Tier 3
 /obj/structure/closet/onestar/tier3/special
@@ -171,6 +181,7 @@
 	old_chance = 10
 
 /obj/structure/closet/onestar/tier3/special/populate_contents()
+	..()
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/pack/rare/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -183,6 +194,7 @@
 // Empty
 /obj/structure/closet/onestar/tier3/special/empty
 /obj/structure/closet/onestar/tier3/special/empty/populate_contents()
+	..()
 
 ////Mineral
 //Tier 1
@@ -192,6 +204,7 @@
 	old_chance = 70
 
 /obj/structure/closet/onestar/tier1/mineral/populate_contents()
+	..()
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -203,6 +216,7 @@
 // Empty
 /obj/structure/closet/onestar/tier1/mineral/empty
 /obj/structure/closet/onestar/tier1/mineral/empty/populate_contents()
+	..()
 
 //Tier 2
 /obj/structure/closet/onestar/tier2/mineral
@@ -211,6 +225,7 @@
 	old_chance = 30
 
 /obj/structure/closet/onestar/tier2/mineral/populate_contents()
+	..()
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -222,6 +237,7 @@
 // Empty
 /obj/structure/closet/onestar/tier2/mineral/empty
 /obj/structure/closet/onestar/tier2/mineral/empty/populate_contents()
+	..()
 
 //Tier 3
 /obj/structure/closet/onestar/tier3/mineral
@@ -230,6 +246,7 @@
 	old_chance = 10
 
 /obj/structure/closet/onestar/tier3/mineral/populate_contents()
+	..()
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -241,6 +258,7 @@
 // Empty
 /obj/structure/closet/onestar/tier3/mineral/empty
 /obj/structure/closet/onestar/tier3/mineral/empty/populate_contents()
+	..()
 
 ////Medical
 //Tier 1
@@ -250,6 +268,7 @@
 	old_chance = 70
 
 /obj/structure/closet/onestar/tier1/medical/populate_contents()
+	..()
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -261,6 +280,7 @@
 // Empty
 /obj/structure/closet/onestar/tier1/medical/empty
 /obj/structure/closet/onestar/tier1/medical/empty/populate_contents()
+	..()
 
 //Tier 2
 /obj/structure/closet/onestar/tier2/medical
@@ -269,6 +289,7 @@
 	old_chance = 30
 
 /obj/structure/closet/onestar/tier2/medical/populate_contents()
+	..()
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -278,6 +299,7 @@
 // Empty
 /obj/structure/closet/onestar/tier2/medical/empty
 /obj/structure/closet/onestar/tier2/medical/empty/populate_contents()
+	..()
 
 //Tier 3
 /obj/structure/closet/onestar/tier3/medical
@@ -286,6 +308,7 @@
 	old_chance = 10
 
 /obj/structure/closet/onestar/tier3/medical/populate_contents()
+	..()
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/lowkeyrandom(src)
 	new /obj/random/cloth/greyson_clothing/low_chance(src)
@@ -296,3 +319,4 @@
 // Empty
 /obj/structure/closet/onestar/tier3/medical/empty
 /obj/structure/closet/onestar/tier3/medical/empty/populate_contents()
+	..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -6,7 +6,9 @@
 
 
 /obj/structure/closet/secure_closet/bar/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)
 	new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)
 	new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -6,6 +6,7 @@
 
 
 /obj/structure/closet/secure_closet/bar/populate_contents()
+	..()
 	new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)
 	new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)
 	new /obj/item/reagent_containers/food/drinks/bottle/small/beer(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -5,6 +5,7 @@
 	icon_state = "cargo"
 
 /obj/structure/closet/secure_closet/personal/cargotech/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/cargotech(src)
 	new /obj/item/clothing/shoes/color/black(src)
 	new /obj/item/device/radio/headset/headset_cargo(src)
@@ -75,6 +76,7 @@
 	icon_state = "qm"
 
 /obj/structure/closet/secure_closet/reinforced/quartermaster/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/cargotech(src)
 	new /obj/item/clothing/shoes/color/brown(src)
 	new /obj/item/device/radio/headset/headset_cargo(src)
@@ -117,6 +119,7 @@
 	armor_cache = pickweight(list("BASIC_A" = 16, "BULLET_A" = 4, "EGUN_A" = 4, "MELEE_A" = 4))
 
 /obj/structure/closet/secure_closet/personal/prospector/populate_contents()
+	..()
 	gain_rng()
 
 	new /obj/item/device/radio/headset/headset_pro(src)
@@ -349,6 +352,7 @@
 	armor_cache = pickweight(list("BASIC_A" = 12, "BULLET_A" = 4, "EGUN_A" = 4, "MELEE_A" = 8))
 
 /obj/structure/closet/secure_closet/personal/salvager/populate_contents()
+	..()
 	gain_rng()
 
 	new /obj/item/device/radio/headset/headset_pro(src)
@@ -571,6 +575,7 @@
 	armor_cache = pickweight(list("BASIC_A" = 12, "BULLET_A" = 4, "EGUN_A" = 4, "MELEE_A" = 8))
 
 /obj/structure/closet/secure_closet/reinforced/foreman/populate_contents()
+	..()
 	gain_rng()
 
 	new /obj/item/device/radio/headset/heads/foreman(src)
@@ -697,6 +702,7 @@
 	icon_state = "fence"
 
 /obj/structure/closet/secure_closet/reinforced/foreman/fence/populate_contents()
+	..()
 	new /obj/item/clothing/suit/storage/scavengerarmor(src)
 	new /obj/item/clothing/head/helmet/handmade/scavengerhelmet(src)
 	new /obj/item/gun/projectile/automatic/vector(src)
@@ -718,6 +724,7 @@
 	icon_state = "cargo"
 
 /obj/structure/closet/secure_closet/personal/artist/populate_contents()
+	..()
 	new /obj/item/clothing/suit/artist(src)
 	new /obj/item/clothing/under/rank/artist(src)
 	new /obj/item/clothing/suit/artist(src)
@@ -733,6 +740,7 @@
 /obj/structure/closet/wardrobe/color/pink/artist
 
 /obj/structure/closet/wardrobe/color/pink/artist/populate_contents()
+	..()
 	//new/obj/item/clothing/under/mime(src)
 	new/obj/item/clothing/shoes/color/black(src)
 	new/obj/item/clothing/gloves/color/white(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -5,7 +5,9 @@
 	icon_state = "cargo"
 
 /obj/structure/closet/secure_closet/personal/cargotech/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/cargotech(src)
 	new /obj/item/clothing/shoes/color/black(src)
 	new /obj/item/device/radio/headset/headset_cargo(src)
@@ -76,7 +78,9 @@
 	icon_state = "qm"
 
 /obj/structure/closet/secure_closet/reinforced/quartermaster/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/cargotech(src)
 	new /obj/item/clothing/shoes/color/brown(src)
 	new /obj/item/device/radio/headset/headset_cargo(src)
@@ -119,7 +123,9 @@
 	armor_cache = pickweight(list("BASIC_A" = 16, "BULLET_A" = 4, "EGUN_A" = 4, "MELEE_A" = 4))
 
 /obj/structure/closet/secure_closet/personal/prospector/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	gain_rng()
 
 	new /obj/item/device/radio/headset/headset_pro(src)
@@ -352,7 +358,9 @@
 	armor_cache = pickweight(list("BASIC_A" = 12, "BULLET_A" = 4, "EGUN_A" = 4, "MELEE_A" = 8))
 
 /obj/structure/closet/secure_closet/personal/salvager/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	gain_rng()
 
 	new /obj/item/device/radio/headset/headset_pro(src)
@@ -575,7 +583,9 @@
 	armor_cache = pickweight(list("BASIC_A" = 12, "BULLET_A" = 4, "EGUN_A" = 4, "MELEE_A" = 8))
 
 /obj/structure/closet/secure_closet/reinforced/foreman/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	gain_rng()
 
 	new /obj/item/device/radio/headset/heads/foreman(src)
@@ -702,7 +712,9 @@
 	icon_state = "fence"
 
 /obj/structure/closet/secure_closet/reinforced/foreman/fence/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/storage/scavengerarmor(src)
 	new /obj/item/clothing/head/helmet/handmade/scavengerhelmet(src)
 	new /obj/item/gun/projectile/automatic/vector(src)
@@ -724,7 +736,9 @@
 	icon_state = "cargo"
 
 /obj/structure/closet/secure_closet/personal/artist/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/artist(src)
 	new /obj/item/clothing/under/rank/artist(src)
 	new /obj/item/clothing/suit/artist(src)
@@ -740,7 +754,9 @@
 /obj/structure/closet/wardrobe/color/pink/artist
 
 /obj/structure/closet/wardrobe/color/pink/artist/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	//new/obj/item/clothing/under/mime(src)
 	new/obj/item/clothing/shoes/color/black(src)
 	new/obj/item/clothing/gloves/color/white(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -4,7 +4,9 @@
 	icon_state = "head_preacher"
 
 /obj/structure/closet/secure_closet/reinforced/preacher/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(25))
 		new /obj/item/storage/backpack/neotheology(src)
 	else if(prob(25))

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -4,6 +4,7 @@
 	icon_state = "head_preacher"
 
 /obj/structure/closet/secure_closet/reinforced/preacher/populate_contents()
+	..()
 	if(prob(25))
 		new /obj/item/storage/backpack/neotheology(src)
 	else if(prob(25))

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -4,6 +4,7 @@
 	icon_state = "ce"
 
 /obj/structure/closet/secure_closet/reinforced/engineering_chief/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/industrial(src)
 	else
@@ -48,6 +49,7 @@
 	icon_door = "eng_elec"
 
 /obj/structure/closet/secure_closet/engineering_electrical/populate_contents()
+	..()
 	new /obj/item/clothing/gloves/insulated(src)
 	new /obj/item/clothing/gloves/insulated(src)
 	new /obj/item/storage/toolbox/electrical(src)
@@ -69,6 +71,7 @@
 	icon_door = "eng_weld"
 
 /obj/structure/closet/secure_closet/engineering_welding/populate_contents()
+	..()
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
@@ -92,6 +95,7 @@
 	icon_door = "eng_secure"
 
 /obj/structure/closet/secure_closet/personal/engineering_personal/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/industrial(src)
 	else

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -4,7 +4,9 @@
 	icon_state = "ce"
 
 /obj/structure/closet/secure_closet/reinforced/engineering_chief/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/industrial(src)
 	else
@@ -49,7 +51,9 @@
 	icon_door = "eng_elec"
 
 /obj/structure/closet/secure_closet/engineering_electrical/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/gloves/insulated(src)
 	new /obj/item/clothing/gloves/insulated(src)
 	new /obj/item/storage/toolbox/electrical(src)
@@ -71,7 +75,9 @@
 	icon_door = "eng_weld"
 
 /obj/structure/closet/secure_closet/engineering_welding/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/head/welding(src)
@@ -95,7 +101,9 @@
 	icon_door = "eng_secure"
 
 /obj/structure/closet/secure_closet/personal/engineering_personal/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/industrial(src)
 	else

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -7,7 +7,9 @@
 	req_access = list(access_kitchen)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	for(var/i in 1 to 6)
 		new /obj/item/reagent_containers/food/condiment/flour(src)
 	new /obj/item/reagent_containers/food/condiment/sugar(src)
@@ -24,7 +26,9 @@
 	icon_state = "frig"
 
 /obj/structure/closet/secure_closet/freezer/meat/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/food/snacks/meat/monkey(src)
 
@@ -33,7 +37,9 @@
 	icon_state = "freezer"
 
 /obj/structure/closet/secure_closet/freezer/blood/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/blood/OMinus(src)
 
@@ -42,7 +48,9 @@
 	icon_state = "frig"
 
 /obj/structure/closet/secure_closet/freezer/fridge/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/food/drinks/milk(src)
 	for(var/i in 1 to 3)
@@ -57,7 +65,9 @@
 	req_access = list(access_heads_vault)
 
 /obj/structure/closet/secure_closet/freezer/money/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	for(var/i in 1 to 3)
 		new /obj/item/spacecash/bundle/c1000(src)
 	for(var/i in 1 to 3)
@@ -71,7 +81,9 @@
 	icon_state = "advanced_freezer"
 
 /obj/structure/closet/secure_closet/freezer/mini/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	for(var/i in 1 to 6)
 		new /obj/item/reagent_containers/food/drinks/cans/monster(src)
 	for(var/i in 1 to 3)
@@ -97,7 +109,9 @@
 	icon_state = "simpledf"
 
 /obj/structure/closet/secure_closet/freezer/icebox/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	for(var/i in 1 to 6)
 		new /obj/item/reagent_containers/food/drinks/cans/baton_rent_a_cop(src)
 	for(var/i in 1 to 3)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -7,6 +7,7 @@
 	req_access = list(access_kitchen)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/populate_contents()
+	..()
 	for(var/i in 1 to 6)
 		new /obj/item/reagent_containers/food/condiment/flour(src)
 	new /obj/item/reagent_containers/food/condiment/sugar(src)
@@ -23,6 +24,7 @@
 	icon_state = "frig"
 
 /obj/structure/closet/secure_closet/freezer/meat/populate_contents()
+	..()
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/food/snacks/meat/monkey(src)
 
@@ -31,6 +33,7 @@
 	icon_state = "freezer"
 
 /obj/structure/closet/secure_closet/freezer/blood/populate_contents()
+	..()
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/blood/OMinus(src)
 
@@ -39,6 +42,7 @@
 	icon_state = "frig"
 
 /obj/structure/closet/secure_closet/freezer/fridge/populate_contents()
+	..()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/food/drinks/milk(src)
 	for(var/i in 1 to 3)
@@ -53,6 +57,7 @@
 	req_access = list(access_heads_vault)
 
 /obj/structure/closet/secure_closet/freezer/money/populate_contents()
+	..()
 	for(var/i in 1 to 3)
 		new /obj/item/spacecash/bundle/c1000(src)
 	for(var/i in 1 to 3)
@@ -66,6 +71,7 @@
 	icon_state = "advanced_freezer"
 
 /obj/structure/closet/secure_closet/freezer/mini/populate_contents()
+	..()
 	for(var/i in 1 to 6)
 		new /obj/item/reagent_containers/food/drinks/cans/monster(src)
 	for(var/i in 1 to 3)
@@ -91,6 +97,7 @@
 	icon_state = "simpledf"
 
 /obj/structure/closet/secure_closet/freezer/icebox/populate_contents()
+	..()
 	for(var/i in 1 to 6)
 		new /obj/item/reagent_containers/food/drinks/cans/baton_rent_a_cop(src)
 	for(var/i in 1 to 3)

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -5,7 +5,9 @@
 	icon_state = "hydro"
 
 /obj/structure/closet/secure_closet/personal/hydroponics/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(25))
 		new /obj/item/storage/backpack/botanist(src)
 	else if(prob(25))
@@ -40,7 +42,9 @@
 	icon_state = "botanist"
 
 /obj/structure/closet/secure_closet/personal/agrolyte/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/rank/botanist(src)
 	new /obj/item/storage/belt/utility/neotheology(src)
 	new /obj/item/storage/bag/produce(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -5,6 +5,7 @@
 	icon_state = "hydro"
 
 /obj/structure/closet/secure_closet/personal/hydroponics/populate_contents()
+	..()
 	if(prob(25))
 		new /obj/item/storage/backpack/botanist(src)
 	else if(prob(25))
@@ -39,6 +40,7 @@
 	icon_state = "botanist"
 
 /obj/structure/closet/secure_closet/personal/agrolyte/populate_contents()
+	..()
 	new /obj/item/clothing/suit/rank/botanist(src)
 	new /obj/item/storage/belt/utility/neotheology(src)
 	new /obj/item/storage/bag/produce(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -5,6 +5,7 @@
 	req_access = list(access_medical_equip)
 
 /obj/structure/closet/secure_closet/medicine/populate_contents()
+	..()
 	new /obj/item/storage/box/autoinjectors(src)
 	new /obj/item/storage/box/syringes(src)
 	new /obj/item/reagent_containers/dropper(src)
@@ -24,6 +25,7 @@
 	req_access = list(access_moebius)
 
 /obj/structure/closet/secure_closet/anesthetics/populate_contents()
+	..()
 	new /obj/item/tank/anesthetic(src)
 	new /obj/item/tank/anesthetic(src)
 	new /obj/item/tank/anesthetic(src)
@@ -39,6 +41,7 @@
 	icon_state = "med"
 
 /obj/structure/closet/secure_closet/personal/doctor/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -85,6 +88,7 @@
 
 
 /obj/structure/closet/secure_closet/personal/paramedic/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -125,6 +129,7 @@
 
 
 /obj/structure/closet/secure_closet/personal/orderly/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -153,6 +158,7 @@
 	icon_state = "cmo"
 
 /obj/structure/closet/secure_closet/reinforced/CMO/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -198,6 +204,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/animal/populate_contents()
+	..()
 	new /obj/item/device/assembly/signaler(src)
 	new /obj/item/device/radio/electropack(src)
 	new /obj/item/device/radio/electropack(src)
@@ -211,6 +218,7 @@
 	req_access = list(access_chemistry)
 
 /obj/structure/closet/secure_closet/chemical/populate_contents()
+	..()
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/pouch/tubular/vial(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -5,7 +5,9 @@
 	req_access = list(access_medical_equip)
 
 /obj/structure/closet/secure_closet/medicine/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/box/autoinjectors(src)
 	new /obj/item/storage/box/syringes(src)
 	new /obj/item/reagent_containers/dropper(src)
@@ -25,7 +27,9 @@
 	req_access = list(access_moebius)
 
 /obj/structure/closet/secure_closet/anesthetics/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/tank/anesthetic(src)
 	new /obj/item/tank/anesthetic(src)
 	new /obj/item/tank/anesthetic(src)
@@ -41,7 +45,9 @@
 	icon_state = "med"
 
 /obj/structure/closet/secure_closet/personal/doctor/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -88,7 +94,9 @@
 
 
 /obj/structure/closet/secure_closet/personal/paramedic/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -129,7 +137,9 @@
 
 
 /obj/structure/closet/secure_closet/personal/orderly/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -158,7 +168,9 @@
 	icon_state = "cmo"
 
 /obj/structure/closet/secure_closet/reinforced/CMO/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/medical(src)
 	else
@@ -204,7 +216,9 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/animal/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/device/assembly/signaler(src)
 	new /obj/item/device/radio/electropack(src)
 	new /obj/item/device/radio/electropack(src)
@@ -218,7 +232,9 @@
 	req_access = list(access_chemistry)
 
 /obj/structure/closet/secure_closet/chemical/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/pouch/tubular/vial(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/militia.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/militia.dm
@@ -4,6 +4,7 @@
 	icon_state = "mc"
 
 /obj/structure/closet/secure_closet/reinforced/commander/populate_contents()
+	..()
 	new /obj/item/gunbox/commanding_officer(src) // Secondary on their personal hardcase, primary on the locker.
 	new /obj/item/tool/fireaxe/militia_tomahawk(src)
 	new /obj/item/tool/disciplinary_action(src)
@@ -38,6 +39,7 @@
 	icon_state = "armorer"
 
 /obj/structure/closet/secure_closet/armorer/populate_contents()
+	..()
 	new /obj/item/voucher/blackshield/sargprimary(src)
 	new /obj/item/voucher/blackshield/secondary(src)
 	new /obj/item/voucher/blackshield/armor(src)
@@ -75,6 +77,7 @@
 	icon_state = "corpsman"
 
 /obj/structure/closet/secure_closet/personal/corpsman/populate_contents()
+	..()
 	new /obj/item/voucher/blackshield/corpsprimary(src)
 	new /obj/item/voucher/blackshield/secondary(src)
 	new /obj/item/voucher/blackshield/armorcorpsman(src)
@@ -119,6 +122,7 @@
 	icon_state = "trooper"
 
 /obj/structure/closet/secure_closet/personal/trooper/populate_contents()
+	..()
 	new /obj/item/voucher/blackshield/primary(src)
 	new /obj/item/voucher/blackshield/secondary(src)
 	new /obj/item/voucher/blackshield/armor(src)
@@ -156,7 +160,8 @@
 	req_access = list(access_brig)
 	icon_state = "trooper"
 
-/obj/structure/closet/secure_closet/militia/armor/populate_contents() //6 Helmets / 6 Carriers
+/obj/structure/closet/secure_closet/militia/armor/populate_contents()
+	..() //6 Helmets / 6 Carriers
 	new /obj/item/clothing/head/helmet/ballistic/militia(src)
 	new /obj/item/clothing/head/helmet/ballistic/militia(src)
 	new /obj/item/clothing/head/helmet/ballistic/militia/full(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/militia.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/militia.dm
@@ -4,7 +4,9 @@
 	icon_state = "mc"
 
 /obj/structure/closet/secure_closet/reinforced/commander/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/gunbox/commanding_officer(src) // Secondary on their personal hardcase, primary on the locker.
 	new /obj/item/tool/fireaxe/militia_tomahawk(src)
 	new /obj/item/tool/disciplinary_action(src)
@@ -39,7 +41,9 @@
 	icon_state = "armorer"
 
 /obj/structure/closet/secure_closet/armorer/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/voucher/blackshield/sargprimary(src)
 	new /obj/item/voucher/blackshield/secondary(src)
 	new /obj/item/voucher/blackshield/armor(src)
@@ -77,7 +81,9 @@
 	icon_state = "corpsman"
 
 /obj/structure/closet/secure_closet/personal/corpsman/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/voucher/blackshield/corpsprimary(src)
 	new /obj/item/voucher/blackshield/secondary(src)
 	new /obj/item/voucher/blackshield/armorcorpsman(src)
@@ -122,7 +128,9 @@
 	icon_state = "trooper"
 
 /obj/structure/closet/secure_closet/personal/trooper/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/voucher/blackshield/primary(src)
 	new /obj/item/voucher/blackshield/secondary(src)
 	new /obj/item/voucher/blackshield/armor(src)
@@ -161,7 +169,9 @@
 	icon_state = "trooper"
 
 /obj/structure/closet/secure_closet/militia/armor/populate_contents()
-	..() //6 Helmets / 6 Carriers
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/head/helmet/ballistic/militia(src)
 	new /obj/item/clothing/head/helmet/ballistic/militia(src)
 	new /obj/item/clothing/head/helmet/ballistic/militia/full(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal/subtypes.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal/subtypes.dm
@@ -1,5 +1,7 @@
 /obj/structure/closet/secure_closet/personal/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack(src)
 	else
@@ -11,7 +13,9 @@
 	name = "patient's closet"
 
 /obj/structure/closet/secure_closet/personal/patient/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/shoes/color(src)
 
@@ -20,7 +24,9 @@
 	icon_lock = "cabinet"
 
 /obj/structure/closet/secure_closet/personal/cabinet/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/backpack/satchel/leather/withwallet(src)
 	new /obj/item/device/radio/headset(src)
 
@@ -37,5 +43,6 @@
 	dense_when_open = TRUE
 
 /obj/structure/closet/secure_closet/personal/trade/populate_contents()
-	..()
-	return
+	if(populated_contents)
+		return
+	populated_contents = TRUE

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal/subtypes.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal/subtypes.dm
@@ -1,4 +1,5 @@
 /obj/structure/closet/secure_closet/personal/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack(src)
 	else
@@ -10,6 +11,7 @@
 	name = "patient's closet"
 
 /obj/structure/closet/secure_closet/personal/patient/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/shoes/color(src)
 
@@ -18,6 +20,7 @@
 	icon_lock = "cabinet"
 
 /obj/structure/closet/secure_closet/personal/cabinet/populate_contents()
+	..()
 	new /obj/item/storage/backpack/satchel/leather/withwallet(src)
 	new /obj/item/device/radio/headset(src)
 
@@ -34,4 +37,5 @@
 	dense_when_open = TRUE
 
 /obj/structure/closet/secure_closet/personal/trade/populate_contents()
+	..()
 	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -5,7 +5,9 @@
 	icon_state = "science"
 
 /obj/structure/closet/secure_closet/personal/scientist/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(50))
 		new /obj/item/storage/backpack/purple/scientist(src)
 	else
@@ -27,7 +29,9 @@
 	icon_state = "rd"
 
 /obj/structure/closet/secure_closet/reinforced/RD/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/backpack/satchel/leather/withwallet(src)
 	new /obj/item/clothing/suit/bio_suit/scientist(src)
 	new /obj/item/clothing/head/bio_hood/scientist(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -5,6 +5,7 @@
 	icon_state = "science"
 
 /obj/structure/closet/secure_closet/personal/scientist/populate_contents()
+	..()
 	if(prob(50))
 		new /obj/item/storage/backpack/purple/scientist(src)
 	else
@@ -26,6 +27,7 @@
 	icon_state = "rd"
 
 /obj/structure/closet/secure_closet/reinforced/RD/populate_contents()
+	..()
 	new /obj/item/storage/backpack/satchel/leather/withwallet(src)
 	new /obj/item/clothing/suit/bio_suit/scientist(src)
 	new /obj/item/clothing/head/bio_hood/scientist(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -4,6 +4,7 @@
 	icon_state = "cap"
 
 /obj/structure/closet/secure_closet/reinforced/captains/populate_contents()
+	..()
 	new /obj/item/storage/backpack/captain(src)
 	new /obj/item/storage/backpack/satchel/captain(src)
 	new /obj/item/clothing/under/rank/captain(src)
@@ -28,6 +29,7 @@
 	icon_state = "hop"
 
 /obj/structure/closet/secure_closet/reinforced/hop/populate_contents()
+	..()
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/clothing/under/rank/first_officer(src)
 	new /obj/item/clothing/head/rank/first_officer(src)
@@ -48,6 +50,7 @@
 	icon_state = "hos"
 
 /obj/structure/closet/secure_closet/reinforced/hos/populate_contents()
+	..()
 	new /obj/item/device/t_scanner/advanced(src)
 	new /obj/item/clothing/head/rank/commander(src)
 	new /obj/item/clothing/mask/gas/ihs(src)
@@ -82,6 +85,7 @@
 	icon_state = "warden"
 
 /obj/structure/closet/secure_closet/warden/populate_contents()
+	..()
 	new /obj/item/device/bullet_scanner(src)
 	new /obj/item/gun_upgrade/trigger/dnalock(src)
 	new /obj/item/device/holowarrant(src)
@@ -120,6 +124,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/personal/security/populate_contents()
+	..()
 	new /obj/item/storage/backpack/ironhammer(src)
 	if(prob(50))
 		new /obj/item/storage/backpack/ironhammer(src)
@@ -151,6 +156,7 @@
 	icon_state = "cabinetdetective"
 
 /obj/structure/closet/secure_closet/personal/detective/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/inspector(src)
 	new /obj/item/clothing/mask/gas/ihs(src)
 	new /obj/item/clothing/gloves/thick(src)
@@ -180,6 +186,7 @@
 	icon_state = "secure"
 
 /obj/structure/closet/secure_closet/injection/populate_contents()
+	..()
 	new /obj/item/reagent_containers/syringe/ld50_syringe/choral(src)
 	new /obj/item/reagent_containers/syringe/ld50_syringe/choral(src)
 
@@ -191,6 +198,7 @@
 	var/id
 
 /obj/structure/closet/secure_closet/brig/populate_contents()
+	..()
 	new /obj/item/clothing/under/orange(src)
 	new /obj/item/clothing/shoes/orange(src)
 
@@ -200,6 +208,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/courtroom/populate_contents()
+	..()
 	new /obj/item/clothing/shoes/color/brown(src)
 	new /obj/item/paper/court(src)
 	new /obj/item/paper/court(src)
@@ -215,6 +224,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/armory_explosive/populate_contents()
+	..()
 	new /obj/item/storage/box/blast_grenade_shells(src)
 	new /obj/item/storage/box/blast_grenade_shells(src)
 	new /obj/item/storage/box/blast_grenade_shells(src)
@@ -228,6 +238,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/armory_ltl_emp/populate_contents()
+	..()
 	new /obj/item/storage/box/baton_rounds(src)
 	new /obj/item/storage/box/baton_rounds(src)
 	new /obj/item/storage/box/anti_photons(src)
@@ -241,6 +252,7 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/armory_ltl_shotgun/populate_contents()
+	..()
 	new /obj/item/ammo_magazine/ammobox/shotgun/beanbags(src)
 	new /obj/item/ammo_magazine/ammobox/shotgun/beanbags(src)
 	new /obj/item/ammo_magazine/ammobox/shotgun/flashshells(src)
@@ -253,4 +265,5 @@
 	icon_state = "weaponcrate"
 
 /obj/structure/closet/crate/secure/weapon/amr/populate_contents()
+	..()
 	new /obj/item/storage/box/syndie_kit/antimateriel_rifle(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -4,7 +4,9 @@
 	icon_state = "cap"
 
 /obj/structure/closet/secure_closet/reinforced/captains/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/backpack/captain(src)
 	new /obj/item/storage/backpack/satchel/captain(src)
 	new /obj/item/clothing/under/rank/captain(src)
@@ -29,7 +31,9 @@
 	icon_state = "hop"
 
 /obj/structure/closet/secure_closet/reinforced/hop/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/clothing/under/rank/first_officer(src)
 	new /obj/item/clothing/head/rank/first_officer(src)
@@ -50,7 +54,9 @@
 	icon_state = "hos"
 
 /obj/structure/closet/secure_closet/reinforced/hos/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/device/t_scanner/advanced(src)
 	new /obj/item/clothing/head/rank/commander(src)
 	new /obj/item/clothing/mask/gas/ihs(src)
@@ -85,7 +91,9 @@
 	icon_state = "warden"
 
 /obj/structure/closet/secure_closet/warden/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/device/bullet_scanner(src)
 	new /obj/item/gun_upgrade/trigger/dnalock(src)
 	new /obj/item/device/holowarrant(src)
@@ -124,7 +132,9 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/personal/security/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/backpack/ironhammer(src)
 	if(prob(50))
 		new /obj/item/storage/backpack/ironhammer(src)
@@ -156,7 +166,9 @@
 	icon_state = "cabinetdetective"
 
 /obj/structure/closet/secure_closet/personal/detective/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/inspector(src)
 	new /obj/item/clothing/mask/gas/ihs(src)
 	new /obj/item/clothing/gloves/thick(src)
@@ -186,7 +198,9 @@
 	icon_state = "secure"
 
 /obj/structure/closet/secure_closet/injection/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/reagent_containers/syringe/ld50_syringe/choral(src)
 	new /obj/item/reagent_containers/syringe/ld50_syringe/choral(src)
 
@@ -198,7 +212,9 @@
 	var/id
 
 /obj/structure/closet/secure_closet/brig/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/orange(src)
 	new /obj/item/clothing/shoes/orange(src)
 
@@ -208,7 +224,9 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/courtroom/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/shoes/color/brown(src)
 	new /obj/item/paper/court(src)
 	new /obj/item/paper/court(src)
@@ -224,7 +242,9 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/armory_explosive/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/box/blast_grenade_shells(src)
 	new /obj/item/storage/box/blast_grenade_shells(src)
 	new /obj/item/storage/box/blast_grenade_shells(src)
@@ -238,7 +258,9 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/armory_ltl_emp/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/box/baton_rounds(src)
 	new /obj/item/storage/box/baton_rounds(src)
 	new /obj/item/storage/box/anti_photons(src)
@@ -252,7 +274,9 @@
 	icon_state = "sec"
 
 /obj/structure/closet/secure_closet/armory_ltl_shotgun/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/ammo_magazine/ammobox/shotgun/beanbags(src)
 	new /obj/item/ammo_magazine/ammobox/shotgun/beanbags(src)
 	new /obj/item/ammo_magazine/ammobox/shotgun/flashshells(src)
@@ -265,5 +289,7 @@
 	icon_state = "weaponcrate"
 
 /obj/structure/closet/crate/secure/weapon/amr/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/box/syndie_kit/antimateriel_rifle(src)

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -10,6 +10,7 @@
 	desc = "It's a storage unit for operative gear."
 
 /obj/structure/closet/syndicate/personal/populate_contents()
+	..()
 	new /obj/item/tank/jetpack/oxygen(src)
 	new /obj/item/clothing/mask/gas/tactical(src)
 	new /obj/item/clothing/under/syndicate(src)
@@ -29,6 +30,7 @@
 	desc = "It's a storage unit for voidsuits."
 
 /obj/structure/closet/syndicate/suit/populate_contents()
+	..()
 	new /obj/item/tank/jetpack/oxygen(src)
 	new /obj/item/clothing/shoes/magboots(src)
 	new /obj/item/clothing/suit/space/void/merc(src)
@@ -40,6 +42,7 @@
 	desc = "It's a storage unit for nuclear-operative gear."
 
 /obj/structure/closet/syndicate/nuclear/populate_contents()
+	..()
 	new /obj/item/ammo_magazine/smg_35(src)
 	new /obj/item/ammo_magazine/smg_35(src)
 	new /obj/item/ammo_magazine/smg_35(src)

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -10,7 +10,9 @@
 	desc = "It's a storage unit for operative gear."
 
 /obj/structure/closet/syndicate/personal/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/tank/jetpack/oxygen(src)
 	new /obj/item/clothing/mask/gas/tactical(src)
 	new /obj/item/clothing/under/syndicate(src)
@@ -30,7 +32,9 @@
 	desc = "It's a storage unit for voidsuits."
 
 /obj/structure/closet/syndicate/suit/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/tank/jetpack/oxygen(src)
 	new /obj/item/clothing/shoes/magboots(src)
 	new /obj/item/clothing/suit/space/void/merc(src)
@@ -42,7 +46,9 @@
 	desc = "It's a storage unit for nuclear-operative gear."
 
 /obj/structure/closet/syndicate/nuclear/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/ammo_magazine/smg_35(src)
 	new /obj/item/ammo_magazine/smg_35(src)
 	new /obj/item/ammo_magazine/smg_35(src)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -18,7 +18,9 @@
 	icon_state = "emergency"
 
 /obj/structure/closet/emcloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	switch(pickweight(list("small" = 55, "aid" = 25, "tank" = 10, "both" = 10)))
 		if ("small")
 			new /obj/item/tank/emergency_oxygen(src)
@@ -50,7 +52,9 @@
 			new /obj/item/clothing/head/helmet/space/emergency(src)
 
 /obj/structure/closet/emcloset/legacy/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/tank/oxygen(src)
 	new /obj/item/clothing/mask/gas(src)
 
@@ -63,7 +67,9 @@
 	icon_state = "fire"
 
 /obj/structure/closet/firecloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/fire(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/tank/oxygen/red(src)
@@ -82,7 +88,9 @@
 	icon_door = "eng_tool"
 
 /obj/structure/closet/toolcloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	if(prob(40))
 		new /obj/item/clothing/suit/storage/hazardvest(src)
 	if(prob(70))
@@ -137,7 +145,9 @@
 	icon_door = "eng_rad"
 
 /obj/structure/closet/radiation/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/clothing/suit/radiation(src)
@@ -152,14 +162,18 @@
 	icon_state = "bomb"
 
 /obj/structure/closet/bombcloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/space/bomb(src)
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/shoes/color/black(src)
 	new /obj/item/clothing/head/helmet/space/bomb(src)
 
 /obj/structure/closet/bombcloset/security/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/space/bomb(src)
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/shoes/color/brown(src)

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -18,6 +18,7 @@
 	icon_state = "emergency"
 
 /obj/structure/closet/emcloset/populate_contents()
+	..()
 	switch(pickweight(list("small" = 55, "aid" = 25, "tank" = 10, "both" = 10)))
 		if ("small")
 			new /obj/item/tank/emergency_oxygen(src)
@@ -49,6 +50,7 @@
 			new /obj/item/clothing/head/helmet/space/emergency(src)
 
 /obj/structure/closet/emcloset/legacy/populate_contents()
+	..()
 	new /obj/item/tank/oxygen(src)
 	new /obj/item/clothing/mask/gas(src)
 
@@ -61,6 +63,7 @@
 	icon_state = "fire"
 
 /obj/structure/closet/firecloset/populate_contents()
+	..()
 	new /obj/item/clothing/suit/fire(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/tank/oxygen/red(src)
@@ -79,6 +82,7 @@
 	icon_door = "eng_tool"
 
 /obj/structure/closet/toolcloset/populate_contents()
+	..()
 	if(prob(40))
 		new /obj/item/clothing/suit/storage/hazardvest(src)
 	if(prob(70))
@@ -133,6 +137,7 @@
 	icon_door = "eng_rad"
 
 /obj/structure/closet/radiation/populate_contents()
+	..()
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/clothing/suit/radiation(src)
@@ -147,12 +152,14 @@
 	icon_state = "bomb"
 
 /obj/structure/closet/bombcloset/populate_contents()
+	..()
 	new /obj/item/clothing/suit/space/bomb(src)
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/shoes/color/black(src)
 	new /obj/item/clothing/head/helmet/space/bomb(src)
 
 /obj/structure/closet/bombcloset/security/populate_contents()
+	..()
 	new /obj/item/clothing/suit/space/bomb(src)
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/shoes/color/brown(src)

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -14,6 +14,7 @@
 	icon_state = "emerg"
 
 /obj/structure/closet/wall_mounted/emcloset/populate_contents()
+	..()
 	new /obj/item/tank/emergency_oxygen(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/emergency_oxygen(src)
@@ -30,6 +31,7 @@
 	icon_state = "hydrant"
 
 /obj/structure/closet/wall_mounted/firecloset/populate_contents()
+	..()
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)
 	new /obj/item/stack/medical/ointment(src)

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -14,7 +14,9 @@
 	icon_state = "emerg"
 
 /obj/structure/closet/wall_mounted/emcloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/tank/emergency_oxygen(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/emergency_oxygen(src)
@@ -31,7 +33,9 @@
 	icon_state = "hydrant"
 
 /obj/structure/closet/wall_mounted/firecloset/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/inflatable/door(src)
 	new /obj/item/inflatable/door(src)
 	new /obj/item/stack/medical/ointment(src)

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -10,6 +10,7 @@
 	icon_door = "black"
 
 /obj/structure/closet/wardrobe/color/black/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/colorskirt/black(src)
@@ -28,6 +29,7 @@
 	icon_door = "pink"
 
 /obj/structure/closet/wardrobe/color/pink/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/colorskirt/pink(src)
@@ -40,6 +42,7 @@
 	icon_door = "green"
 
 /obj/structure/closet/wardrobe/color/green/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/colorskirt/green(src)
@@ -58,6 +61,7 @@
 	icon_door = "yellow"
 
 /obj/structure/closet/wardrobe/color/yellow/populate_contents()
+	..()
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/colorskirt(src)
@@ -76,6 +80,7 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/color/white/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/colorskirt/white(src)
@@ -92,6 +97,7 @@
 	icon_door = "red"
 
 /obj/structure/closet/wardrobe/color/red/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/red(src)
 	new /obj/item/clothing/under/color/red(src)
 	new /obj/item/clothing/under/colorskirt/red(src)
@@ -110,6 +116,7 @@
 	icon_door = "blue"
 
 /obj/structure/closet/wardrobe/color/blue/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/colorskirt/blue(src)
@@ -128,6 +135,7 @@
 	icon_door = "grey"
 
 /obj/structure/closet/wardrobe/color/grey/populate_contents()
+	..()
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/colorskirt/grey(src)
@@ -144,6 +152,7 @@
 	icon_door = "mixed"
 
 /obj/structure/closet/wardrobe/color/mixed/populate_contents()
+	..()
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/color/green(src)
@@ -175,6 +184,7 @@
 	icon_door = "yellow"
 
 /obj/structure/closet/wardrobe/job/engineering_yellow/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
@@ -193,6 +203,7 @@
 	icon_door = "blue"
 
 /obj/structure/closet/wardrobe/job/sec/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/head/seccap(src)
@@ -215,6 +226,7 @@
 	icon_door = "militia"
 
 /obj/structure/closet/wardrobe/militia/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/trooper/gorka(src)
 	new /obj/item/clothing/under/rank/trooper/gorka(src)
 	new /obj/item/clothing/under/rank/trooper/cadet(src)
@@ -243,6 +255,7 @@
 	icon_door = "militia"
 
 /obj/structure/closet/wardrobe/militia/accessory/populate_contents()
+	..()
 	new /obj/item/clothing/accessory/holster/leg(src)
 	new /obj/item/clothing/accessory/holster/leg(src)
 	new /obj/item/clothing/accessory/holster/leg(src)
@@ -287,6 +300,7 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/science_white/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
@@ -305,6 +319,7 @@
 	icon_door = "black"
 
 /obj/structure/closet/wardrobe/job/robotics_black/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/roboticist(src)
 	new /obj/item/clothing/under/rank/roboticist(src)
 	new /obj/item/clothing/suit/storage/rank/robotech_jacket(src)
@@ -319,6 +334,7 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/chemistry_white/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/shoes/color(src)
@@ -331,6 +347,7 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/virology_white/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/shoes/color(src)
@@ -345,6 +362,7 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/medic_white/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/scrubs(src)
@@ -365,6 +383,7 @@
 	icon_door = "black"
 
 /obj/structure/closet/wardrobe/job/chaplain_black/populate_contents()
+	..()
 	new /obj/item/clothing/under/rank/preacher(src)
 	new /obj/item/clothing/shoes/color/black(src)
 	new /obj/item/clothing/suit/costume/job/nun(src)
@@ -384,6 +403,7 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/misc/pjs/populate_contents()
+	..()
 	new /obj/item/clothing/under/pj(src)
 	new /obj/item/clothing/under/pj(src)
 	new /obj/item/clothing/under/pj/blue(src)
@@ -399,6 +419,7 @@
 	desc = "A dingey old locker full of old SolFed SWAT gear."
 
 /obj/structure/closet/wardrobe/misc/tactical/populate_contents()
+	..()
 	new /obj/item/clothing/under/turtleneck/tacticalgreen(src)
 	new /obj/item/clothing/suit/storage/vest/swat(src)
 	new /obj/item/clothing/head/helmet/swat(src)
@@ -414,6 +435,7 @@
 	icon_door = "orange"
 
 /obj/structure/closet/wardrobe/misc/prison/populate_contents()
+	..()
 	new /obj/item/clothing/under/orange(src)
 	new /obj/item/clothing/under/orange(src)
 	new /obj/item/clothing/under/orange(src)

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -10,7 +10,9 @@
 	icon_door = "black"
 
 /obj/structure/closet/wardrobe/color/black/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/colorskirt/black(src)
@@ -29,7 +31,9 @@
 	icon_door = "pink"
 
 /obj/structure/closet/wardrobe/color/pink/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/colorskirt/pink(src)
@@ -42,7 +46,9 @@
 	icon_door = "green"
 
 /obj/structure/closet/wardrobe/color/green/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/colorskirt/green(src)
@@ -61,7 +67,9 @@
 	icon_door = "yellow"
 
 /obj/structure/closet/wardrobe/color/yellow/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/colorskirt(src)
@@ -80,7 +88,9 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/color/white/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/colorskirt/white(src)
@@ -97,7 +107,9 @@
 	icon_door = "red"
 
 /obj/structure/closet/wardrobe/color/red/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/red(src)
 	new /obj/item/clothing/under/color/red(src)
 	new /obj/item/clothing/under/colorskirt/red(src)
@@ -116,7 +128,9 @@
 	icon_door = "blue"
 
 /obj/structure/closet/wardrobe/color/blue/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/colorskirt/blue(src)
@@ -135,7 +149,9 @@
 	icon_door = "grey"
 
 /obj/structure/closet/wardrobe/color/grey/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/colorskirt/grey(src)
@@ -152,7 +168,9 @@
 	icon_door = "mixed"
 
 /obj/structure/closet/wardrobe/color/mixed/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color(src)
 	new /obj/item/clothing/under/color/green(src)
@@ -184,7 +202,9 @@
 	icon_door = "yellow"
 
 /obj/structure/closet/wardrobe/job/engineering_yellow/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
@@ -203,7 +223,9 @@
 	icon_door = "blue"
 
 /obj/structure/closet/wardrobe/job/sec/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/under/rank/security(src)
 	new /obj/item/clothing/head/seccap(src)
@@ -226,7 +248,9 @@
 	icon_door = "militia"
 
 /obj/structure/closet/wardrobe/militia/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/trooper/gorka(src)
 	new /obj/item/clothing/under/rank/trooper/gorka(src)
 	new /obj/item/clothing/under/rank/trooper/cadet(src)
@@ -255,7 +279,9 @@
 	icon_door = "militia"
 
 /obj/structure/closet/wardrobe/militia/accessory/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/accessory/holster/leg(src)
 	new /obj/item/clothing/accessory/holster/leg(src)
 	new /obj/item/clothing/accessory/holster/leg(src)
@@ -300,7 +326,9 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/science_white/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
@@ -319,7 +347,9 @@
 	icon_door = "black"
 
 /obj/structure/closet/wardrobe/job/robotics_black/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/roboticist(src)
 	new /obj/item/clothing/under/rank/roboticist(src)
 	new /obj/item/clothing/suit/storage/rank/robotech_jacket(src)
@@ -334,7 +364,9 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/chemistry_white/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/shoes/color(src)
@@ -347,7 +379,9 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/virology_white/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/shoes/color(src)
@@ -362,7 +396,9 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/job/medic_white/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/scrubs(src)
@@ -383,7 +419,9 @@
 	icon_door = "black"
 
 /obj/structure/closet/wardrobe/job/chaplain_black/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/rank/preacher(src)
 	new /obj/item/clothing/shoes/color/black(src)
 	new /obj/item/clothing/suit/costume/job/nun(src)
@@ -403,7 +441,9 @@
 	icon_door = "white"
 
 /obj/structure/closet/wardrobe/misc/pjs/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/pj(src)
 	new /obj/item/clothing/under/pj(src)
 	new /obj/item/clothing/under/pj/blue(src)
@@ -419,7 +459,9 @@
 	desc = "A dingey old locker full of old SolFed SWAT gear."
 
 /obj/structure/closet/wardrobe/misc/tactical/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/turtleneck/tacticalgreen(src)
 	new /obj/item/clothing/suit/storage/vest/swat(src)
 	new /obj/item/clothing/head/helmet/swat(src)
@@ -435,7 +477,9 @@
 	icon_door = "orange"
 
 /obj/structure/closet/wardrobe/misc/prison/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/under/orange(src)
 	new /obj/item/clothing/under/orange(src)
 	new /obj/item/clothing/under/orange(src)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -91,6 +91,7 @@
 	icon_state = "o2crate"
 
 /obj/structure/closet/crate/internals/populate_contents()
+	..()
 	new /obj/item/tank/emergency_oxygen(src)
 	new /obj/item/tank/emergency_oxygen(src)
 	new /obj/item/tank/emergency_oxygen(src)
@@ -142,6 +143,7 @@
 	icon_state = "crate"
 
 /obj/structure/closet/crate/rcd/populate_contents()
+	..()
 	new /obj/item/stack/material/compressed_matter(src,30)
 	new /obj/item/rcd(src)
 
@@ -149,6 +151,7 @@
 	name = "solar pack crate"
 
 /obj/structure/closet/crate/solar/populate_contents()
+	..()
 	new /obj/item/solar_assembly(src)
 	new /obj/item/solar_assembly(src)
 	new /obj/item/solar_assembly(src)
@@ -185,6 +188,7 @@
 
 
 /obj/structure/closet/crate/freezer/rations/populate_contents()
+	..()
 	new /obj/item/reagent_containers/food/snacks/openable/liquidfood(src)
 	new /obj/item/reagent_containers/food/snacks/openable/liquidfood(src)
 	new /obj/item/reagent_containers/food/snacks/openable/liquidfood(src)
@@ -202,6 +206,7 @@
 	icon_state = "radiation"
 
 /obj/structure/closet/crate/radiation/populate_contents()
+	..()
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/clothing/suit/radiation(src)
@@ -344,6 +349,7 @@
 /obj/structure/closet/crate/voidwolf/voidwolfdrugs
 
 /obj/structure/closet/crate/voidwolf/voidwolfdrugs/populate_contents()
+	..()
 
 	new /obj/item/reagent_containers/hypospray/autoinjector/drugs(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/drugs(src)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -91,7 +91,9 @@
 	icon_state = "o2crate"
 
 /obj/structure/closet/crate/internals/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/tank/emergency_oxygen(src)
 	new /obj/item/tank/emergency_oxygen(src)
 	new /obj/item/tank/emergency_oxygen(src)
@@ -143,7 +145,9 @@
 	icon_state = "crate"
 
 /obj/structure/closet/crate/rcd/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/stack/material/compressed_matter(src,30)
 	new /obj/item/rcd(src)
 
@@ -151,7 +155,9 @@
 	name = "solar pack crate"
 
 /obj/structure/closet/crate/solar/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/solar_assembly(src)
 	new /obj/item/solar_assembly(src)
 	new /obj/item/solar_assembly(src)
@@ -188,7 +194,9 @@
 
 
 /obj/structure/closet/crate/freezer/rations/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/reagent_containers/food/snacks/openable/liquidfood(src)
 	new /obj/item/reagent_containers/food/snacks/openable/liquidfood(src)
 	new /obj/item/reagent_containers/food/snacks/openable/liquidfood(src)
@@ -206,7 +214,9 @@
 	icon_state = "radiation"
 
 /obj/structure/closet/crate/radiation/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 	new /obj/item/clothing/suit/radiation(src)
@@ -349,8 +359,9 @@
 /obj/structure/closet/crate/voidwolf/voidwolfdrugs
 
 /obj/structure/closet/crate/voidwolf/voidwolfdrugs/populate_contents()
-	..()
-
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/reagent_containers/hypospray/autoinjector/drugs(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/drugs(src)
 	new /obj/item/reagent_containers/syringe/drugs(src)
@@ -366,7 +377,6 @@
 	new /obj/item/reagent_containers/food/snacks/grown/ambrosiavulgaris(src)
 	new /obj/item/reagent_containers/food/snacks/grown/ambrosiavulgaris(src)
 
-	. = ..()
 
 /obj/structure/closet/crate/serbcrate_gray
 	desc = "A secure metallic crate."

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -7,7 +7,9 @@
 	access_occupy = list(access_mining)
 
 /obj/structure/closet/secure_closet/personal/miner/populate_contents()
-	..()
+	if(populated_contents)
+		return
+	populated_contents = TRUE
 	new /obj/item/storage/backpack/industrial(src)
 	new /obj/item/storage/backpack/satchel/industrial(src)
 	new /obj/item/device/radio/headset/headset_cargo(src)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -7,7 +7,7 @@
 	access_occupy = list(access_mining)
 
 /obj/structure/closet/secure_closet/personal/miner/populate_contents()
-
+	..()
 	new /obj/item/storage/backpack/industrial(src)
 	new /obj/item/storage/backpack/satchel/industrial(src)
 	new /obj/item/device/radio/headset/headset_cargo(src)

--- a/maps/_DeepForest/map/_Beast_Cave.dmm
+++ b/maps/_DeepForest/map/_Beast_Cave.dmm
@@ -526,9 +526,6 @@
 /obj/effect/overlay/water{
 	layer = 3
 	},
-/obj/effect/overlay/water/top{
-	layer = 3
-	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
@@ -3106,6 +3103,8 @@
 "li" = (
 /obj/structure/flora/big/bush2,
 /obj/random/flora/small_jungle_tree,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "lj" = (
@@ -4693,9 +4692,6 @@
 /obj/effect/overlay/water{
 	layer = 3
 	},
-/obj/effect/overlay/water/top{
-	layer = 3
-	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
@@ -4763,9 +4759,6 @@
 	dir = 1
 	},
 /obj/effect/overlay/water{
-	layer = 3
-	},
-/obj/effect/overlay/water/top{
 	layer = 3
 	},
 /obj/machinery/porta_turret/One_star{
@@ -6205,6 +6198,7 @@
 /obj/effect/overlay/water/top,
 /obj/effect/overlay/water/top,
 /mob/living/simple_animal/hostile/frog,
+/obj/effect/overlay/water,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "vr" = (
@@ -7032,11 +7026,10 @@
 /turf/simulated/floor/beach/water/swamp,
 /area/nadezhda/outside/forest/beast_cave_light)
 "xV" = (
-/obj/machinery/mining/brace{
-	anchored = 1;
-	dir = 4
-	},
-/turf/simulated/floor/rock,
+/obj/random/flora/jungle_tree,
+/obj/effect/overlay/water/top,
+/obj/effect/overlay/water,
+/turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "xW" = (
 /turf/simulated/floor/beach/water/swamp,
@@ -7276,13 +7269,6 @@
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
 	})
-"yI" = (
-/obj/effect/overlay/water/top{
-	pixel_y = -11
-	},
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungle,
-/area/nadezhda/outside/forest/beast_cave_light)
 "yJ" = (
 /obj/structure/table/steel,
 /obj/item/storage/hcases/med/has_items_spawn,
@@ -8205,13 +8191,6 @@
 /obj/item/organ/internal/scaffold/aberrant/teratoma/random/rare,
 /turf/simulated/floor/industrial/grey_slates,
 /area/nadezhda/dungeon/outside/prepper/alpha)
-"BI" = (
-/obj/machinery/mining/brace{
-	anchored = 1;
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest/beast_cave_light)
 "BJ" = (
 /obj/machinery/door/airlock/hatch{
 	locked = 1
@@ -9448,16 +9427,6 @@
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
 	})
-"FA" = (
-/obj/effect/overlay/water/top{
-	pixel_y = -22
-	},
-/obj/effect/overlay/water/top{
-	pixel_y = -13
-	},
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungle,
-/area/nadezhda/outside/forest/beast_cave_light)
 "FB" = (
 /mob/living/simple_animal/hostile/carp/shark,
 /turf/simulated/floor/beach/water/shallow,
@@ -10618,9 +10587,6 @@
 /obj/effect/overlay/water{
 	layer = 3
 	},
-/obj/effect/overlay/water/top{
-	layer = 3
-	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
@@ -11483,11 +11449,10 @@
 	requires_power = 0
 	})
 "LP" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/mining/drill{
-	anchored = 1
-	},
-/turf/simulated/floor/asteroid/grass,
+/mob/living/simple_animal/frog,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "LQ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -11588,11 +11553,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest/beast_cave_light)
-"Mi" = (
-/obj/structure/flora/big/bush2,
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungle,
-/area/nadezhda/outside/forest/beast_cave_light)
 "Mj" = (
 /obj/item/remains,
 /turf/simulated/floor/asteroid/grass,
@@ -11683,16 +11643,6 @@
 "Mx" = (
 /obj/effect/floor_decal/industrial/road/straight1,
 /turf/simulated/floor/rock/manmade/asphalt,
-/area/nadezhda/outside/forest/beast_cave_light)
-"My" = (
-/obj/effect/overlay/water/top{
-	pixel_y = -10
-	},
-/obj/effect/overlay/water/top{
-	pixel_y = -18
-	},
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "Mz" = (
 /obj/effect/overlay/water/top,
@@ -11814,9 +11764,6 @@
 /obj/effect/overlay/water{
 	layer = 3
 	},
-/obj/effect/overlay/water/top{
-	layer = 3
-	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
@@ -11860,14 +11807,6 @@
 "MX" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/alpha)
-"MY" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/mining/brace{
-	anchored = 1;
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest/beast_cave_light)
 "MZ" = (
 /obj/item/stack/material/glass/random,
 /obj/effect/floor_decal/border/techfloor/orange{
@@ -11920,17 +11859,10 @@
 /turf/simulated/floor/industrial,
 /area/nadezhda/dungeon/outside/prepper/alpha)
 "Nh" = (
-/obj/effect/overlay/water/top{
-	pixel_y = -14
-	},
-/obj/effect/overlay/water/top{
-	pixel_y = -22
-	},
-/obj/effect/overlay/water/top{
-	pixel_y = -6
-	},
+/obj/random/flora/jungle_tree,
+/obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungle,
+/turf/simulated/floor/beach/water/swamp,
 /area/nadezhda/outside/forest/beast_cave_light)
 "Ni" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -12022,6 +11954,8 @@
 /obj/random/flora/jungle_tree{
 	pixel_x = -49
 	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "Nz" = (
@@ -12582,10 +12516,6 @@
 /mob/living/simple_animal/fennec,
 /turf/simulated/floor/beach/water/swamp,
 /area/nadezhda/outside/forest/beast_cave_light)
-"Pn" = (
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/jungle,
-/area/nadezhda/outside/forest/beast_cave_light)
 "Pp" = (
 /obj/item/oddity/common/old_radio,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -12916,6 +12846,7 @@
 "Qm" = (
 /obj/effect/overlay/water/top,
 /obj/effect/overlay/water/top,
+/obj/effect/overlay/water,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "Qn" = (
@@ -13050,15 +12981,6 @@
 "QK" = (
 /obj/structure/bonfire/permanent,
 /turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest/beast_cave_light)
-"QL" = (
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/mining/brace{
-	anchored = 1;
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/beast_cave_light)
 "QM" = (
 /obj/effect/decal/cleanable/blood{
@@ -13368,14 +13290,6 @@
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
 	})
-"RD" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/machinery/mining/brace{
-	anchored = 1;
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest/beast_cave_light)
 "RE" = (
 /turf/unsimulated/mineral/cold,
 /area/nadezhda/outside/forest/beast_cave_light)
@@ -13820,10 +13734,6 @@
 /obj/random/cluster/roaches,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/beast_cave_dark)
-"Tb" = (
-/obj/effect/overlay/water,
-/turf/simulated/floor/beach/water/jungle,
-/area/nadezhda/outside/forest/beast_cave_light)
 "Tc" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/rock/grey,
@@ -13910,9 +13820,10 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/beast_cave_dark)
 "Ts" = (
-/obj/random/traps/low_chance,
+/obj/random/flora/small_jungle_tree,
+/obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/swamp,
+/turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "Tt" = (
 /obj/item/remains/unathi,
@@ -14330,9 +14241,6 @@
 "UA" = (
 /obj/structure/window/reinforced,
 /obj/effect/overlay/water{
-	layer = 3
-	},
-/obj/effect/overlay/water/top{
 	layer = 3
 	},
 /obj/machinery/porta_turret/One_star{
@@ -15021,12 +14929,6 @@
 /obj/structure/flora/stump/small,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/forest/beast_cave_light)
-"WE" = (
-/obj/machinery/mining/drill{
-	anchored = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest/beast_cave_light)
 "WF" = (
 /obj/structure/flora/small/snow/rock4,
 /turf/simulated/floor/snow,
@@ -15333,14 +15235,6 @@
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
 	})
-"XL" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/mining/brace{
-	anchored = 1;
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest/beast_cave_light)
 "XM" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -15725,13 +15619,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/beast_cave_light)
 "YU" = (
-/obj/effect/overlay/water/top{
-	pixel_y = -9
-	},
-/obj/effect/overlay/water/top{
-	pixel_y = -21
-	},
+/obj/effect/overlay/water,
+/obj/random/flora/jungle_tree,
 /obj/effect/overlay/water/top,
+/obj/effect/overlay/water,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/forest/beast_cave_light)
 "YW" = (
@@ -15915,13 +15806,6 @@
 /area/nadezhda/dungeon/outside/prepper/alpha{
 	requires_power = 0
 	})
-"Zz" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/mining/drill{
-	anchored = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest/beast_cave_light)
 "ZA" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/suit/radiation,
@@ -18660,7 +18544,7 @@ et
 AT
 AT
 Mo
-xV
+QB
 Yw
 Iu
 QN
@@ -18862,7 +18746,7 @@ Wj
 Qk
 AT
 AT
-WE
+et
 QB
 Yj
 MH
@@ -19064,7 +18948,7 @@ AT
 AT
 AT
 et
-BI
+et
 pt
 VP
 Gp
@@ -19273,7 +19157,7 @@ PA
 Uh
 VP
 eJ
-RD
+fa
 et
 et
 qK
@@ -19466,7 +19350,7 @@ AT
 Wj
 AT
 AT
-QL
+AT
 AT
 AT
 VP
@@ -19475,7 +19359,7 @@ FK
 uh
 VP
 eJ
-LP
+eJ
 AT
 AT
 et
@@ -19668,7 +19552,7 @@ AT
 AT
 qK
 AT
-Zz
+AT
 et
 AT
 VP
@@ -19677,7 +19561,7 @@ Nu
 Uh
 VP
 Af
-XL
+eJ
 AT
 AT
 et
@@ -19870,7 +19754,7 @@ AT
 qK
 AT
 AT
-MY
+AT
 AT
 et
 VP
@@ -22742,23 +22626,23 @@ Ru
 gy
 gy
 Mv
-xW
-xW
+Oy
+Oy
 dS
-pC
-pC
-pC
-pC
-ej
+Ru
+Ru
+Ru
+Ru
+ZP
 pD
 Qm
 vq
-Pn
+PU
 QC
-Pn
-ej
+PU
+PU
 dS
-pC
+xV
 xW
 QZ
 dS
@@ -22938,28 +22822,28 @@ Ox
 QA
 Ct
 QA
-Pn
-ej
-ej
-pC
-pC
-rI
-Ox
-Ox
-dS
-ej
-ej
-ej
-en
-ej
-Uw
-QA
-QA
-QA
 PU
-yI
-Pn
-Pn
+ZP
+ZP
+Ru
+Ru
+rI
+Nh
+Nh
+dS
+ZP
+ZP
+ZP
+LP
+ZP
+Uw
+Qj
+Qj
+Qj
+PU
+PU
+PU
+PU
 gy
 gy
 xW
@@ -23140,19 +23024,19 @@ xW
 Qj
 Qj
 vp
-Pn
-Pn
-ej
-ej
-ej
+PU
+PU
+ZP
+ZP
+ZP
 Ny
-Ts
+ZF
 gm
 Qj
 PU
 PU
 PV
-Pn
+PU
 PU
 Qj
 CE
@@ -23164,7 +23048,7 @@ PU
 PU
 Qj
 UC
-Pn
+PU
 dS
 dS
 dS
@@ -23344,8 +23228,8 @@ Qj
 IZ
 PU
 UG
-My
-Nh
+PU
+PU
 PU
 PU
 Qj
@@ -23365,8 +23249,8 @@ PU
 PU
 Ka
 Ka
-Tb
 ZP
+FX
 ZP
 ZP
 dS
@@ -23567,10 +23451,10 @@ PU
 PU
 PU
 Ka
-Tb
-wH
-FA
-pD
+ZP
+Oy
+PU
+YU
 dS
 Ug
 Ug
@@ -23769,8 +23653,8 @@ Sz
 PU
 ZP
 xU
-wH
-wH
+Oy
+Oy
 vh
 ZP
 dS
@@ -23971,8 +23855,8 @@ Oy
 Oy
 Oy
 Oy
-wH
-wH
+Oy
+Oy
 Oy
 Oy
 dS
@@ -24175,7 +24059,7 @@ Pd
 DX
 pR
 pR
-KC
+CE
 Ct
 dS
 Ug
@@ -24482,8 +24366,8 @@ ZP
 ZP
 PU
 Wi
-Pn
-ei
+PU
+Ts
 dS
 dS
 dS
@@ -24685,8 +24569,8 @@ OY
 ZP
 ZP
 vk
-eh
-ej
+OY
+ZP
 li
 dS
 dS
@@ -24884,12 +24768,12 @@ Cn
 ZP
 VK
 VK
-Mi
+YH
 wX
-Mi
-ei
-ej
-ej
+YH
+Ts
+ZP
+ZP
 dS
 dS
 dS
@@ -29390,7 +29274,7 @@ vR
 gy
 cD
 gy
-QA
+Qj
 PU
 PU
 PU
@@ -29589,10 +29473,10 @@ et
 dS
 dS
 dS
-QA
-QA
-QA
-QA
+Qj
+Qj
+Qj
+Qj
 Ka
 Ka
 Ka
@@ -29791,11 +29675,11 @@ pa
 dS
 dS
 dS
-Ox
-xW
-xW
-pC
-PU
+Nh
+Oy
+Oy
+dS
+pD
 PU
 PU
 PU
@@ -29996,8 +29880,8 @@ dS
 dS
 dS
 dS
-pC
-PU
+dS
+pD
 PU
 PU
 PU
@@ -30198,11 +30082,11 @@ dS
 dS
 dS
 dS
-pC
 dS
-ej
-ej
-YU
+dS
+dS
+dS
+dS
 pD
 gy
 gm
@@ -30810,7 +30694,7 @@ aa
 aa
 aa
 aa
-ZP
+aa
 ZP
 ZP
 ZP
@@ -31012,8 +30896,8 @@ aa
 aa
 aa
 aa
-ZP
-ZP
+aa
+aa
 ZP
 ZP
 ZP
@@ -31214,8 +31098,8 @@ aa
 aa
 aa
 aa
-ZP
-ZP
+aa
+aa
 ZP
 ZP
 ZP
@@ -31233,7 +31117,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+dS
 dS
 Ug
 tA
@@ -31416,9 +31300,9 @@ aa
 aa
 aa
 aa
-ZP
-ZP
-ZP
+aa
+aa
+aa
 ZP
 ZP
 ZP
@@ -31435,7 +31319,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+dS
 dS
 Ug
 zi
@@ -31618,9 +31502,9 @@ aa
 aa
 aa
 aa
-ZP
-ZP
-ZP
+aa
+aa
+aa
 ZP
 ZP
 ZP
@@ -31637,7 +31521,7 @@ ZP
 ZP
 ZP
 ZP
-ZP
+dS
 dS
 Ug
 Xu
@@ -31820,10 +31704,10 @@ aa
 aa
 aa
 aa
-ZP
-ZP
-ZP
-ZP
+aa
+aa
+aa
+aa
 ZP
 ZP
 Tp
@@ -31838,8 +31722,8 @@ ZP
 ZP
 ZP
 ZP
-ZP
-ZP
+dS
+dS
 dS
 Ug
 qM
@@ -32022,10 +31906,10 @@ aa
 aa
 aa
 aa
-ZP
-ZP
-ZP
-ZP
+aa
+aa
+aa
+dS
 ZP
 ZP
 Tp
@@ -32039,9 +31923,9 @@ ZP
 ZP
 ZP
 ZP
-ZP
-ZP
-ZP
+dS
+dS
+uk
 dS
 Ug
 Ug
@@ -32224,11 +32108,11 @@ aa
 aa
 aa
 aa
-ZP
-ZP
-ZP
-ZP
-ZP
+aa
+aa
+aa
+dS
+dS
 ZP
 Tp
 ND
@@ -32237,13 +32121,13 @@ Hu
 Cl
 ND
 qd
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
+dS
+dS
+dS
+dS
+dS
+uk
+dS
 dS
 Ug
 Ug
@@ -32426,12 +32310,12 @@ aa
 aa
 aa
 aa
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
+aa
+aa
+aa
+uk
+dS
+dS
 ZP
 FZ
 FZ
@@ -32439,13 +32323,13 @@ FZ
 FZ
 FZ
 ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
-ZP
+dS
+dS
+dS
+dS
+dS
+dS
+dS
 dS
 tn
 Ug
@@ -32630,6 +32514,9 @@ aa
 aa
 aa
 aa
+aa
+uk
+uk
 dS
 dS
 dS
@@ -32638,16 +32525,13 @@ dS
 dS
 dS
 dS
+uk
+uk
+uk
+uk
+uk
 dS
-dS
-dS
-dS
-dS
-dS
-dS
-dS
-dS
-dS
+uk
 dS
 dS
 dS
@@ -32835,6 +32719,7 @@ rK
 sl
 dS
 dS
+uk
 dS
 dS
 dS
@@ -32847,8 +32732,7 @@ dS
 dS
 dS
 dS
-dS
-dS
+uk
 dS
 dS
 dS

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -164,6 +164,7 @@
 /area/nadezhda/dungeon/outside/prepper/lima)
 "aho" = (
 /obj/item/storage/fancy/mre_cracker,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -323,7 +324,7 @@
 /area/nadezhda/dungeon/outside/prepper)
 "ape" = (
 /obj/random/dungeon_armor_mods/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -2710,7 +2711,7 @@
 "chw" = (
 /obj/machinery/light,
 /obj/structure/bed,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -4236,9 +4237,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/fiction{
-	name = "Communist Manifesto"
-	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -6640,7 +6638,7 @@
 "eUU" = (
 /obj/item/trash/liquidfood,
 /obj/structure/bed,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -7756,7 +7754,7 @@
 /area/nadezhda/dungeon/outside/prepper/delta)
 "fLB" = (
 /obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -8388,7 +8386,7 @@
 /area/nadezhda/outside/one_star)
 "gjj" = (
 /obj/item/trash/mre_shokoladka,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -8921,7 +8919,7 @@
 "gAf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -9123,6 +9121,7 @@
 /area/nadezhda/outside/meadow)
 "gFS" = (
 /obj/structure/salvageable/data_os,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -12718,8 +12717,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "jgj" = (
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -15577,10 +15576,12 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "loq" = (
-/obj/landmark/corpse/excelsior,
-/obj/item/mine/armed,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "loD" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/asteroid/dirt,
@@ -19737,7 +19738,7 @@
 "ojC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/pouch/hardcase,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -21961,10 +21962,6 @@
 /obj/structure/flora/small/grassb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"pKF" = (
-/obj/random/mob/xenomorphs,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "pKQ" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall27";
@@ -28206,7 +28203,7 @@
 	dir = 1
 	},
 /obj/structure/bed,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -31418,9 +31415,15 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "wzc" = (
-/obj/landmark/corpse/excelsior,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
+/obj/random/junk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wzn" = (
 /obj/structure/table/onestar,
 /obj/item/storage/fancy/cigarettes/khi,
@@ -54915,7 +54918,7 @@ qbU
 qbU
 qbU
 qbU
-euc
+sLE
 euc
 qbU
 qbU
@@ -55954,7 +55957,7 @@ qbU
 qbU
 qbU
 euc
-pKF
+sLE
 euc
 qbU
 qbU
@@ -55962,7 +55965,7 @@ qbU
 qbU
 qbU
 euc
-euc
+sLE
 qbU
 qbU
 xBq
@@ -56161,7 +56164,7 @@ qbU
 qbU
 qbU
 qbU
-wzc
+euc
 euc
 qbU
 qbU
@@ -56359,25 +56362,25 @@ qbU
 uVX
 dpk
 uVX
-loq
+djA
 qbU
 qbU
 qbU
 qbU
 qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+sLE
 qbU
 qbU
 qbU
 qbU
 qbU
 euc
-qbU
-qbU
-qbU
-qbU
-qbU
-euc
-euc
+sLE
 qbU
 qbU
 qbU
@@ -58460,7 +58463,7 @@ xtV
 hOg
 oNj
 bRP
-oNj
+jQS
 oNj
 xCX
 bRP
@@ -59717,7 +59720,7 @@ pXi
 aWi
 izA
 izA
-pXi
+oNj
 xtV
 coU
 coU
@@ -59926,7 +59929,7 @@ xmM
 jrF
 mZo
 dzj
-pXi
+opq
 xtV
 coU
 coU
@@ -60129,13 +60132,13 @@ hgL
 lrx
 hgL
 szl
-byy
-hgL
+jgj
+oNj
 xmM
 ojC
-dpI
-hgL
-xmM
+xCX
+oNj
+bRP
 xtV
 coU
 coU
@@ -60338,12 +60341,12 @@ szl
 szl
 xtV
 xtV
-hgL
-hgL
+oNj
+oNj
 xmM
-hgL
-jgj
-umz
+oNj
+snd
+loq
 xmM
 xtV
 coU
@@ -60547,8 +60550,8 @@ oNj
 oNj
 hTF
 xtV
-hgL
-dpI
+oNj
+xCX
 xmM
 xmM
 xmM
@@ -60759,9 +60762,9 @@ xtV
 gjj
 fLB
 ape
-jgj
-hgL
-hgL
+snd
+oNj
+oNj
 hyA
 xtV
 coU
@@ -60966,11 +60969,11 @@ aFi
 snd
 xtV
 ufe
-pHI
+bRP
 gAf
-hgL
+oNj
 eUU
-pHI
+bRP
 chw
 xtV
 coU
@@ -61386,7 +61389,7 @@ xtV
 eHy
 vbn
 vHY
-wJm
+wzc
 wJm
 wqX
 xhW
@@ -61790,7 +61793,7 @@ lgv
 hgL
 hgL
 xTs
-szl
+xtV
 oNj
 kZp
 oNj

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -94,13 +94,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"afk" = (
-/obj/structure/flora/pottedplant/rotwood,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "afB" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
@@ -135,10 +128,6 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "agk" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/structure/boulder,
 /obj/item/trash/material/metal{
 	icon_state = "metal3"
@@ -180,33 +169,12 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"ahL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/automatic/nordwind/strelki/sawn,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ahW" = (
 /obj/random/junk,
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"ais" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "aiR" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -291,18 +259,6 @@
 /obj/machinery/gym/toughness,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"amQ" = (
-/obj/random/junk,
-/obj/random/junk,
-/obj/item/clothing/head/helmet/bulletproof,
-/obj/random/boxes/low_chance,
-/obj/random/gun_cheap/low_chance,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "amT" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -372,26 +328,10 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"apv" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "apW" = (
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"aqi" = (
-/obj/effect/decal/cleanable/generic,
-/mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aqj" = (
 /obj/structure/table/onestar,
 /obj/item/reagent_containers/food/drinks/teapot,
@@ -399,13 +339,6 @@
 /obj/item/reagent_containers/food/drinks/mug/teacup,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"aqy" = (
-/obj/machinery/suit_storage_unit/excelsior,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aqA" = (
 /obj/machinery/floodlight,
 /turf/simulated/shuttle/floor/mining{
@@ -533,7 +466,7 @@
 	name = "officer cap";
 	desc = "A peaked cap with a red triangle insignia."
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "avp" = (
 /obj/item/trash/liquidfood,
@@ -605,13 +538,6 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
-"axL" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "axM" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -629,35 +555,6 @@
 /obj/item/gun/energy/tesla_shotgun,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"ayn" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"ayt" = (
-/obj/item/bedsheet,
-/obj/structure/bed,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "ayu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -689,15 +586,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"azg" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "azq" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/suit,
@@ -770,38 +658,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "aBh" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "aBn" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
 /obj/machinery/light/small,
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -875,19 +736,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/remains,
 /obj/random/cloth/armor,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "aDw" = (
 /obj/random/tool/advanced,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"aDy" = (
-/obj/item/trash/broken_robot_part,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aDz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
@@ -994,21 +848,7 @@
 	name = "Abandoned Bunker"
 	})
 "aHX" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "aIu" = (
@@ -1024,14 +864,6 @@
 /obj/random/structures,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"aIM" = (
-/obj/random/junk,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aIS" = (
 /obj/item/trash/mre/os,
 /turf/simulated/floor/wood/wild5,
@@ -1074,42 +906,18 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "aJT" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "aKk" = (
 /obj/structure/railing/grey{
 	dir = 1;
 	icon_state = "grey_railing0"
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white,
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -1136,13 +944,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"aLI" = (
-/mob/living/simple_animal/hostile/bear/excelsior,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aLU" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha3,
@@ -1173,21 +974,6 @@
 /obj/item/clothing/suit/armor/heavy,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"aME" = (
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo/low_chance,
-/obj/random/ammo/low_chance,
-/obj/item/ammo_magazine/ammobox/antim_small,
-/obj/random/gun_cheap/low_chance,
-/obj/random/gun_cheap/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aMH" = (
 /obj/item/remains,
 /obj/random/gun_cheap,
@@ -1269,37 +1055,6 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"aOF" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"aOH" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/blast/regular/open{
-	name = "LOCKDOWN";
-	id = "lima9entrance2"
-	},
-/obj/effect/spider/stickyweb,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "aOP" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -1329,28 +1084,7 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"aQr" = (
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"aRj" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "aRH" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1429,15 +1163,6 @@
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"aVm" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/clothing/glasses/welding/superior/shades,
-/obj/item/tool/multitool/uplink,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aVB" = (
 /obj/structure/girder{
 	name = "Connector"
@@ -1510,7 +1235,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
 /turf/simulated/wall/untinted/onestar_reinforced{
 	name = "Train Hull"
 	},
@@ -1552,16 +1276,6 @@
 /obj/structure/girder{
 	name = "Connector"
 	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "aZT" = (
@@ -1569,21 +1283,6 @@
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"bam" = (
-/obj/machinery/recharger,
-/obj/structure/table/standard,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/melee,
-/obj/random/material/low_chance,
-/obj/random/material/low_chance,
-/obj/random/material/low_chance,
-/obj/random/material/low_chance,
-/obj/random/pouch/hardcase/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "baC" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock/manmade/ruin2,
@@ -1672,14 +1371,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"beH" = (
-/mob/living/simple_animal/hostile/diyaab,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "beQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood/wild5,
@@ -1740,23 +1431,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "bis" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
 	icon_state = "blob_idle";
 	name = "biomass";
 	color = "#750008"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "biF" = (
 /obj/structure/disposalpipe/segment{
@@ -1844,31 +1525,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"blx" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/semki,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"bly" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mech_recharger,
-/obj/random/mecha/damaged/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"blC" = (
-/obj/item/bananapeel,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "blK" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/surgery,
@@ -1910,29 +1566,6 @@
 /obj/structure/flora/small/grassb5,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"bnf" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "bnm" = (
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/dirt,
@@ -2005,16 +1638,6 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "bpv" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -2165,17 +1788,6 @@
 	icon_state = "3,7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"bvs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/rotwood_green,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "bvC" = (
 /obj/structure/table/standard,
 /obj/random/powercell/medium_safe,
@@ -2209,17 +1821,6 @@
 /obj/random/mob/prepper_boss_lowchance,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"bwE" = (
-/obj/random/junk,
-/obj/random/junk,
-/obj/item/clothing/suit/armor/platecarrier,
-/obj/item/clothing/suit/chameleon,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "bwH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -2266,20 +1867,6 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "bxV" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /mob/living/simple_animal/hostile/creature/tissue,
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -2316,39 +1903,9 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"bzx" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "bzR" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"bAa" = (
-/obj/item/mine/excelsior,
-/obj/landmark/corpse/excelsior,
-/turf/simulated/floor/rock/manmade/ruin2,
-/area/asteroid/rogue)
 "bAm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2360,15 +1917,6 @@
 /obj/item/trash/raisins,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"bAJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "bAQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/ammo/shotgun,
@@ -2408,18 +1956,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"bCs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/clothing/shoes/jackboots/janitor,
-/obj/structure/closet/l3closet/janitor,
-/obj/item/toy/figure/character/civilian/janitor,
-/obj/item/clothing/under/rank/janitor,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "bCw" = (
 /obj/item/material/shard,
 /turf/simulated/floor/wood/wild2,
@@ -2429,13 +1965,6 @@
 /obj/structure/flora/pottedplant/barrel_cactus,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"bCY" = (
-/obj/item/trash/mre_candy,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "bDk" = (
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -2571,12 +2100,6 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "bJJ" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -2678,42 +2201,12 @@
 "bMh" = (
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"bMw" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "bMG" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"bMK" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "bNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -2758,29 +2251,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
 "bOU" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "bPg" = (
 /obj/random/mob/voidwolf,
@@ -2868,13 +2341,6 @@
 /area/nadezhda/outside/meadow)
 "bRP" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"bRR" = (
-/obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -3065,9 +2531,6 @@
 /obj/item/material/shard,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"bZw" = (
-/turf/simulated/wall/wood,
-/area/asteroid/rogue)
 "bZE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3089,13 +2552,6 @@
 "bZQ" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
-"cam" = (
-/obj/item/trash/mre_shokoladka,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "caq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame,
@@ -3170,15 +2626,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"cco" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bananapeel,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ccK" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/cafe,
@@ -3193,23 +2640,8 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cdY" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/ash{
-	name = "dust";
-	desc = "A clump of dust"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "ces" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -3262,14 +2694,6 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"cgh" = (
-/obj/random/junk,
-/obj/random/gun_parts/low,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cgw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/small/bushb3,
@@ -3284,9 +2708,8 @@
 /turf/simulated/wall/r_wall,
 /area/colony/exposedsun/pastgate)
 "chw" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
+/obj/structure/bed,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -3324,12 +2747,6 @@
 	tag = "icon-cargoshwall7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"ciV" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "ciY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/catwalk,
@@ -3351,14 +2768,6 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
 "cju" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -3375,13 +2784,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"cjK" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cjV" = (
 /obj/structure/salvageable/personal,
 /turf/simulated/floor/tiled/dark/danger,
@@ -3395,19 +2797,9 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
 "ckd" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "cki" = (
 /obj/random/closet_tech,
@@ -3531,13 +2923,6 @@
 	},
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
-"coO" = (
-/obj/structure/flora/small/grassb4,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "coU" = (
 /turf/unsimulated/mineral,
 /area/asteroid/rogue)
@@ -3632,26 +3017,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"cqX" = (
-/obj/item/trash/mre,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "crC" = (
 /obj/item/remains/tajaran,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"crF" = (
-/obj/item/trash/tray,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "crM" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/cafe,
@@ -3750,20 +3120,6 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"ctv" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cty" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4098,41 +3454,9 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cDT" = (
-/obj/random/dungeon_ammo/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"cEk" = (
-/obj/effect/decal/cleanable/generic,
-/obj/random/closet,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cEw" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"cEx" = (
-/obj/machinery/gibber,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"cEA" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cEB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4147,19 +3471,6 @@
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"cEZ" = (
-/obj/structure/table/standard,
-/obj/random/medical/low_chance,
-/obj/random/gun_cheap/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cFd" = (
 /obj/structure/flora/small/grassa4,
 /obj/structure/flora/big/bush3,
@@ -4169,7 +3480,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
 /obj/structure/sign/warning/hazard_biohazard,
 /turf/simulated/wall/untinted/onestar_reinforced{
 	name = "Train Hull"
@@ -4199,16 +3509,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"cGo" = (
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4
-	},
-/obj/machinery/porta_turret/excelsior/preloaded,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cGr" = (
 /obj/structure/railing{
 	dir = 1;
@@ -4244,16 +3544,6 @@
 /turf/simulated/floor/rock/manmade/ruin3,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "cGT" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/border/techfloor/orange{
@@ -4262,7 +3552,7 @@
 	name = "biomass";
 	color = "#750008"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "cHm" = (
 /obj/random/mob/prepper,
@@ -4322,27 +3612,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "cJL" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /obj/structure/girder{
 	name = "Connector"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "cJQ" = (
 /turf/simulated/floor/tiled/white,
@@ -4396,15 +3671,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
-"cLc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cLf" = (
 /obj/structure/catwalk,
 /obj/structure/mopbucket,
@@ -4428,27 +3694,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"cLU" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/material/device,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"cLV" = (
-/obj/structure/table/standard,
-/obj/random/medical/low_chance,
-/obj/machinery/light,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cLY" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/wood/wild5,
@@ -4472,20 +3717,6 @@
 /obj/item/pen,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"cMR" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cNa" = (
 /obj/item/remains/ribcage,
 /turf/simulated/floor/tiled/cafe,
@@ -4514,15 +3745,21 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "cOt" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/transit_tube{
+	name = "liquid tube"
 	},
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
+/obj/effect/floor_decal/border/techfloor/orange{
+	icon = 'icons/mob/blob.dmi';
+	icon_state = "blob_idle";
+	name = "biomass";
+	color = "#750008"
+	},
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/prepper/lima)
 "cOO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/science,
@@ -4592,14 +3829,6 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cQc" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "cQj" = (
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -4678,14 +3907,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"cTi" = (
-/obj/machinery/door/airlock,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cTM" = (
 /obj/structure/table/standard,
 /obj/random/common_oddities,
@@ -4715,14 +3936,6 @@
 	},
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
-"cUA" = (
-/obj/structure/table/rack,
-/obj/random/gun_parts,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "cUI" = (
 /obj/structure/catwalk,
 /obj/structure/largecrate,
@@ -4873,14 +4086,6 @@
 /obj/structure/closet/secure_closet/anesthetics,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/zoo)
-"cZS" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dae" = (
 /obj/random/mob/nightmare,
 /turf/simulated/floor/wood/wild5,
@@ -4896,23 +4101,6 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"daD" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/structure/table/rack/shelf,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo/shotgun/low_chance,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "daI" = (
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
@@ -4923,59 +4111,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"dbi" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/random/medical,
-/obj/item/storage/firstaid,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dbn" = (
 /obj/random/common_oddities,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"dbo" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"dbE" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dbJ" = (
 /obj/structure/girder,
 /obj/effect/floor_decal/border/techfloor/orange{
@@ -4992,20 +4131,6 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
 "dcc" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/creature/tissue,
 /turf/simulated/floor/tiled/cafe,
@@ -5161,15 +4286,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"dhV" = (
-/obj/random/common_oddities,
-/obj/structure/table/standard,
-/obj/item/device/science_tool,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dig" = (
 /mob/living/carbon/superior_animal/roach/tazntz,
 /obj/structure/snowfall{
@@ -5186,34 +4302,7 @@
 /obj/effect/overlay/water,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"diE" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "diS" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "Surveillance"
 	},
@@ -5260,18 +4349,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"dkE" = (
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "dkG" = (
 /obj/random/scrap/sparse_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -5322,14 +4399,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"dnv" = (
-/obj/effect/decal/cleanable/filth,
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dnw" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -5387,7 +4456,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "dpG" = (
 /obj/structure/cable{
@@ -5520,18 +4589,6 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"dup" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "duC" = (
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark,
@@ -5683,26 +4740,12 @@
 /obj/item/tank/anesthetic,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"dyI" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "dyP" = (
-/obj/machinery/cooking_with_jane/grill,
-/obj/structure/table/marble,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/random/oddity_guns,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -5714,31 +4757,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"dzn" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "dzp" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -5765,9 +4783,6 @@
 /area/nadezhda/outside/one_star)
 "dzS" = (
 /obj/item/device/lighting/glowstick/undark,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
 /obj/item/trash/material/metal,
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/plating/under,
@@ -6057,14 +5072,6 @@
 /obj/machinery/chemical_dispenser/beer,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
-"dHR" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dIi" = (
 /obj/effect/floor_decal/industrial/caution{
 	dir = 8
@@ -6152,15 +5159,6 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"dKT" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/table/marble,
-/obj/machinery/microwave,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dLt" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault)
@@ -6178,7 +5176,7 @@
 	name = "dust";
 	desc = "A clump of dust"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "dLT" = (
 /obj/structure/table/standard,
@@ -6347,17 +5345,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"dTV" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dUx" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/dark,
@@ -6383,14 +5370,6 @@
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"dWp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_cheap/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "dWA" = (
 /obj/item/stack/medical/bruise_pack,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -6424,7 +5403,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "dYb" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -6475,23 +5454,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"eas" = (
-/obj/structure/flora/small/grassa2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"ebi" = (
-/obj/machinery/cooking_with_jane/stove{
-	desc = "A set of four burners for cooking food. \nCtrl+Click: Set Temperatures / Timers \nShift+Ctrl+Click: Turn on a burner."
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ebz" = (
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/tiled/dark,
@@ -6505,16 +5467,18 @@
 /obj/random/toolbox/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"ech" = (
-/obj/item/gun/projectile/automatic/ak47/saiga,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "eci" = (
-/obj/structure/sign/warning/nosmoking,
-/turf/simulated/wall/r_wall,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28
+	},
+/obj/machinery/power/port_gen/pacman/diesel/anchored,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -6628,16 +5592,6 @@
 /obj/random/medical,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"ehe" = (
-/obj/random/junk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ehh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6705,16 +5659,8 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "ejz" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "ejF" = (
@@ -6885,12 +5831,6 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "eoA" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -6931,13 +5871,6 @@
 "epQ" = (
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"epY" = (
-/obj/item/trash/syndi_cakes,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "eqk" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -6964,7 +5897,6 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "era" = (
 /obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/industrial/road/straight3,
 /obj/structure/boulder,
 /turf/simulated/floor/rock/manmade/ruin3,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -7068,26 +6000,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "etY" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "euc" = (
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -7171,20 +6088,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"evX" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "ewd" = (
 /obj/structure/flora/small/busha2,
 /mob/living/carbon/superior_animal/vox/ashen,
@@ -7238,7 +6141,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "eyt" = (
 /obj/structure/catwalk{
@@ -7300,50 +6203,10 @@
 /obj/structure/flora/small/grassa2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"eBe" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"eBR" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "eBV" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"eCv" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/filth,
-/obj/item/gun_upgrade/trigger/boom,
-/obj/random/cloth/armor/low_chance,
-/obj/random/cloth/helmet/low_chance,
-/obj/item/storage/box/syndie_kit/imp_uplink,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "eCK" = (
 /obj/structure/closet/random_hostilemobs,
 /turf/simulated/floor/tiled/dark,
@@ -7429,15 +6292,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
-"eGQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "eGW" = (
 /obj/effect/decal/cleanable/filth,
 /obj/structure/table/rack/shelf,
@@ -7529,15 +6383,6 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"eLD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "eLI" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/microwave,
@@ -7788,41 +6633,18 @@
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "eTv" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/creature/tissue,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "eUU" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
+/obj/item/trash/liquidfood,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eUV" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb3,
@@ -7943,21 +6765,6 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"eYX" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
 /area/nadezhda/dungeon/outside/prepper/lima)
 "eZh" = (
 /obj/structure/table/standard,
@@ -8095,27 +6902,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"fda" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "fdz" = (
 /obj/machinery/porta_turret/prepper,
 /turf/simulated/floor/tiled/dark,
@@ -8330,20 +7116,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "fkV" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/head/hardhat,
 /obj/item/clothing/under/overalls,
@@ -8488,15 +7260,6 @@
 /obj/random/ammo/shotgun,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"fqQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/standard,
-/obj/random/booze,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fqU" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark,
@@ -8520,27 +7283,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"fsd" = (
-/obj/random/closet,
-/obj/random/pouch/hardcase/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fsf" = (
 /obj/effect/step_trigger/swampcaves_to_riverforest_2_B,
 /turf/simulated/floor/asteroid/dirt,
 /area/colony/exposedsun/pastgate)
-"fsF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fsT" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/reagent_containers/spray/cleaner,
@@ -8552,14 +7298,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"ftz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/firedoor_assembly,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ftE" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -8620,15 +7358,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"fvE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk,
-/obj/random/gun_parts/low,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fvS" = (
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
@@ -8700,24 +7429,10 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"fyp" = (
-/obj/item/trash/peachcan,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fyx" = (
 /obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"fyX" = (
-/obj/machinery/complant_teleporter,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fze" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -8802,27 +7517,6 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"fDb" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "fDn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -8836,21 +7530,6 @@
 /obj/random/gun_cheap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
-"fDD" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/filth,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/random/closet_tech/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fDS" = (
 /obj/machinery/light{
 	dir = 4;
@@ -8881,14 +7560,6 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"fET" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fFb" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark,
@@ -8990,16 +7661,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
-"fIb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/random/gun_combat/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fIy" = (
 /obj/random/scrap,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -9100,14 +7761,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"fLF" = (
-/obj/machinery/door/airlock/centcom,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fLW" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushc2,
@@ -9203,14 +7856,6 @@
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"fQu" = (
-/obj/effect/decal/cleanable/ash,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fQx" = (
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -9221,14 +7866,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"fQG" = (
-/obj/item/trash/os_coco_wrapper,
-/obj/random/gun_parts/low,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fQH" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -9248,13 +7885,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"fRD" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fRZ" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/plating/under,
@@ -9373,19 +8003,6 @@
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"fVt" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fVA" = (
 /obj/effect/decal/cleanable/blood/splatter{
 	icon_state = "gib5"
@@ -9467,16 +8084,6 @@
 	name = "Abandoned Bunker"
 	})
 "fWS" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#0892d0"
@@ -9487,21 +8094,7 @@
 	name = "biomass";
 	color = "#750008"
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"fXc" = (
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "fXe" = (
 /obj/structure/window/reinforced{
@@ -9513,16 +8106,6 @@
 /obj/random/pouch,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"fXg" = (
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "cobweb1"
-	},
-/obj/structure/flora/pottedplant/rotwood_blue,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fXI" = (
 /obj/structure/railing/grey,
 /obj/effect/step_trigger/vault_bunker_2F,
@@ -9682,11 +8265,12 @@
 	name = "biomass";
 	color = "#750008"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "gfM" = (
-/obj/item/gun/projectile/automatic/thompson,
-/turf/simulated/floor/asteroid/grass,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -9775,13 +8359,6 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"gia" = (
-/obj/machinery/cooking_with_jane/oven,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "gid" = (
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -9811,7 +8388,6 @@
 /area/nadezhda/outside/one_star)
 "gjj" = (
 /obj/item/trash/mre_shokoladka,
-/obj/machinery/clonepod,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -9873,15 +8449,6 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"glZ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "gmm" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -10006,7 +8573,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/remains,
 /obj/random/voidsuit/low_chance,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "gpC" = (
 /obj/structure/sink/kitchen{
@@ -10293,14 +8860,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"gyS" = (
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman/diesel/anchored,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "gyZ" = (
 /obj/effect/overlay/water/top{
 	color = "#61DE2A"
@@ -10324,16 +8883,6 @@
 "gzl" = (
 /obj/machinery/computer{
 	stat = 1;
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
@@ -10370,11 +8919,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "gAf" = (
-/obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -10538,7 +9085,7 @@
 	},
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "gEz" = (
 /obj/structure/catwalk{
@@ -10941,23 +9488,15 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "gTi" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/cafe,
+/obj/effect/floor_decal/border/techfloor/orange{
+	icon = 'icons/mob/blob.dmi';
+	icon_state = "blob_damaged2";
+	name = "biomass";
+	color = "#750008"
+	},
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "gTj" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -11109,20 +9648,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "gXB" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
 	icon_state = "blob_damaged2";
@@ -11215,16 +9740,6 @@
 	narrate = "This building seems to have been quickly fabricated within the depths of the small rocky hill over it. Whoever made it seems to have fled, as the interior seems both roughened by fighting, but also completely abandoned, with machines either falling into disarray or intentionally sabotaged along with the rest of the outpost."
 	})
 "hbp" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/structure/table/rack/shelf,
 /obj/item/tool/baton/mini,
 /obj/item/device/lighting/glowstick/undark,
@@ -11255,16 +9770,6 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"hcF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk,
-/obj/random/closet,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -11313,35 +9818,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"hdR" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/blast/regular/open{
-	name = "LOCKDOWN";
-	id = "lima9entrance2"
-	},
-/obj/effect/spider/stickyweb,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "hdZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/big/bush2,
@@ -11371,14 +9847,6 @@
 /obj/structure/flora/small/bushc3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"heK" = (
-/obj/random/closet,
-/obj/random/pouch/hardcase/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "heS" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark/danger,
@@ -11429,13 +9897,6 @@
 /obj/item/remains/mummy2,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"his" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "hiu" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11450,13 +9911,12 @@
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "hjc" = (
-/obj/machinery/door/unpowered/simple/wood,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield/batton,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -11484,21 +9944,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/prepper)
-"hka" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "hkf" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 1
@@ -11586,13 +10031,6 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"hmx" = (
-/obj/structure/flora/small/grassb2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hmJ" = (
 /obj/item/trash/raisins,
 /obj/effect/decal/cleanable/dirt,
@@ -11642,16 +10080,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"hnP" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hnQ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/paper_bin,
@@ -11684,13 +10112,6 @@
 /area/nadezhda/outside/one_star)
 "hox" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"hoF" = (
-/obj/item/ammo_magazine/ammobox/rifle_75/lethal,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -11733,20 +10154,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
-"hpw" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "hqo" = (
 /obj/structure/sign/warning/secure_area/small,
 /turf/simulated/wall/r_wall,
@@ -11850,77 +10257,20 @@
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "huK" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "huO" = (
 /mob/living/simple_animal/hostile/render,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"huR" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"hva" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hvb" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/big/bush3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
 "hvX" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /mob/living/simple_animal/hostile/creature/tissue,
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -12021,21 +10371,13 @@
 	alpha = 0;
 	icon_state = "error"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "hyp" = (
 /obj/item/remains/human,
 /obj/random/gun_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"hyw" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hyy" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -12085,21 +10427,6 @@
 /obj/item/storage/box/frag_grenade_shells,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
-"hAJ" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "hAO" = (
 /obj/structure/salvageable/data_os{
 	icon_state = "data0"
@@ -12117,19 +10444,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"hAV" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hBa" = (
 /obj/structure/boulder,
 /obj/item/mine/armed,
@@ -12157,9 +10471,6 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "hCC" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
@@ -12193,13 +10504,6 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"hDc" = (
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hDP" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -12389,16 +10693,6 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "hKu" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -12457,13 +10751,6 @@
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"hNR" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hNY" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha3,
@@ -12497,16 +10784,6 @@
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"hOw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hPm" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/plating/under,
@@ -12539,16 +10816,6 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "hQw" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/table/woodentable,
 /obj/machinery/light/small{
 	dir = 4
@@ -12571,15 +10838,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/plate,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"hQX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/standard,
-/mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -12692,16 +10950,6 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "hTs" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/inflatable/door,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -12751,14 +10999,6 @@
 	light_color = "#0892d0"
 	},
 /turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"hUw" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "hUA" = (
 /turf/simulated/floor/beach/sand,
@@ -12932,20 +11172,6 @@
 /obj/effect/damagedfloor/rust,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"ice" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/random/dungeon_ammo/really_low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "icq" = (
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
@@ -13032,14 +11258,6 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"iey" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/gym/robustness,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ieH" = (
 /obj/structure/bed/roller,
 /obj/item/remains,
@@ -13098,17 +11316,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"igW" = (
-/obj/structure/table/gamblingtable,
-/obj/item/gun/projectile/makarov/preloaded,
-/obj/item/ammo_magazine/pistol_35/lethal,
-/obj/item/ammo_casing,
-/obj/random/cigarettes,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ihc" = (
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/cafe,
@@ -13154,25 +11361,7 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"iip" = (
-/obj/item/trash/cheesie,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "iiu" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral/random/rogue,
 /area/nadezhda/dungeon/outside/prepper/lima)
@@ -13180,19 +11369,6 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"iiJ" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "iiZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/candy/proteinbar,
@@ -13307,14 +11483,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"ima" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "imx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -13356,19 +11524,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"ioz" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "ioB" = (
 /obj/structure/flora/small/bushc2,
 /turf/unsimulated/wall/jungle,
@@ -13387,14 +11542,6 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"ipS" = (
-/obj/random/junk,
-/obj/random/boxes/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ipX" = (
 /obj/item/trash/candy/proteinbar,
 /obj/effect/damagedfloor,
@@ -13607,14 +11754,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"iwU" = (
-/obj/random/closet,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "iwV" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/bushb1,
@@ -13732,13 +11871,6 @@
 /obj/item/trash/cigbutt/ishimura,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"iAz" = (
-/obj/structure/closet/random_milsupply,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "iAE" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/beakers,
@@ -13833,16 +11965,6 @@
 	name = "Abandoned Bunker"
 	})
 "iDP" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/machinery/papershredder,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -13953,16 +12075,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"iHb" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/item/gun/projectile/boltgun,
-/obj/random/cloth/armor/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "iHc" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/asteroid/grass,
@@ -14029,7 +12141,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
 /turf/simulated/floor/rock/manmade/ruin3,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "iII" = (
@@ -14056,7 +12167,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "iJI" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -14107,18 +12218,6 @@
 /obj/item/storage/box/syndie_kit/space,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"iKV" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "iLf" = (
 /obj/random/medical_lowcost,
 /turf/simulated/floor/tiled/cafe,
@@ -14274,7 +12373,6 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "iTu" = (
-/obj/effect/floor_decal/corner_oldtile/white,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -14452,21 +12550,6 @@
 /obj/item/stash_spawner,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
-"jbf" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "jbh" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush2{
@@ -14624,15 +12707,6 @@
 /obj/item/stool/custom/bar_special,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
-"jfz" = (
-/obj/random/closet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jfW" = (
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -14672,15 +12746,6 @@
 /obj/item/stool,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"jgN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bananapeel,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jgR" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -14881,18 +12946,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"jlf" = (
-/obj/effect/decal/cleanable/filth,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/random/boxes/low_chance,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jln" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -14910,13 +12963,6 @@
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"jlL" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jlR" = (
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/carpet/bcarpet,
@@ -15026,17 +13072,6 @@
 /obj/machinery/power/port_gen/pacman/scrap,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"jpT" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cloth/belt/low_chance,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jqD" = (
 /obj/structure/table/standard,
 /obj/item/oddity/common/old_radio,
@@ -15108,14 +13143,6 @@
 /obj/item/stock_parts/micro_laser/one_star,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"jva" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jvj" = (
 /obj/structure/catwalk{
 	icon_state = "catwalk4-0"
@@ -15174,13 +13201,6 @@
 /obj/item/oddity/common/book_bible,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/prepper)
-"jyM" = (
-/obj/random/pouch/hardcase,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jyY" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/tool/shovel/spade,
@@ -15239,26 +13259,6 @@
 /obj/structure/salvageable/computer,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper)
-"jCD" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "jCE" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/constructable_frame/machine_frame/vertical,
@@ -15305,16 +13305,6 @@
 /obj/item/mine_old,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"jFt" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "jFP" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/small_jungle_tree,
@@ -15348,16 +13338,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "jGH" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -15368,7 +13348,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "jGI" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central3{
@@ -15448,21 +13428,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/zoo)
 "jJt" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "jJz" = (
 /obj/structure/table/standard,
@@ -15572,14 +13542,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"jNt" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/random/gun_combat/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "jND" = (
 /obj/structure/closet/crate/serbcrate,
 /obj/item/rig_module/device/drill,
@@ -15639,19 +13601,6 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"jOT" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_idle";
-	name = "biomass";
-	color = "#750008"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "jPd" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood,
@@ -15953,31 +13902,11 @@
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
-"kao" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
-/obj/effect/floor_decal/steeldecal/steel_decals_central3{
-	dir = 1
-	},
-/obj/machinery/door/blast/regular/open{
-	name = "LOCKDOWN";
-	id = "cmdcentre"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "kaq" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/dungeon/outside/prepper/lima)
 "kbC" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/item/reagent_containers/glass/bottle/petrel,
@@ -15990,20 +13919,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"kck" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "kcq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -16048,14 +13963,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"kdd" = (
-/obj/machinery/light,
-/obj/random/pouch/hardcase,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kdx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -16147,15 +14054,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kfH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
@@ -16170,14 +14068,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kfS" = (
-/obj/landmark/corpse/excelsior,
-/obj/structure/closet/coffin,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kfT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bikehorn,
@@ -16384,26 +14274,7 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"koI" = (
-/obj/random/junk,
-/obj/item/ammo_casing,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "koK" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Chief Clinical Overseer"
@@ -16490,16 +14361,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"ksu" = (
-/obj/structure/table/marble,
-/obj/item/storage/pouch/ammo,
-/obj/random/contraband,
-/obj/random/pouch/hardcase,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ksF" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -16517,25 +14378,10 @@
 /obj/item/clothing/gloves/thick/ablasive/iron_lock_security,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"kts" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/cobweb2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ktF" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "ktU" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/structure/boulder,
 /obj/item/trash/material/metal{
 	icon_state = "metal2"
@@ -16609,7 +14455,6 @@
 /area/nadezhda/dungeon/outside/prepper)
 "kwa" = (
 /obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/industrial/road/straight3,
 /turf/simulated/floor/rock/manmade/ruin3,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "kwb" = (
@@ -16716,14 +14561,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"kzu" = (
-/obj/effect/decal/cleanable/filth,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kzF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16744,31 +14581,8 @@
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
 "kAK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"kBi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/dungeon_ammo/low_chance,
-/obj/random/dungeon_ammo/low_chance,
-/obj/random/dungeon_ammo/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
+/turf/unsimulated/mineral,
+/area/nadezhda/dungeon/outside/zoo)
 "kBn" = (
 /obj/item/ammo_magazine/light_rifle_257/empty,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -16796,16 +14610,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "kCi" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/lima)
@@ -16867,21 +14671,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"kEO" = (
-/obj/effect/decal/cleanable/filth,
-/obj/random/pouch/hardcase/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"kEX" = (
-/obj/structure/showcase/horrific_experiment_cloning,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kFl" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/grass,
@@ -16958,16 +14747,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "kIl" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -17045,32 +14824,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/colony/exposedsun/pastgate)
-"kKX" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"kLe" = (
-/obj/structure/reagent_dispensers/fueltank/derelict,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kLn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -17125,14 +14878,6 @@
 /obj/structure/flora/small/grassb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"kNe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/dungeon_ammo/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kNj" = (
 /obj/structure/table/woodentable,
 /obj/random/oddity_guns,
@@ -17185,15 +14930,6 @@
 /obj/structure/reagent_dispensers/watertank/huge/derelict,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kPt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/salvageable/autolathe,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kQa" = (
 /obj/machinery/button/remote/airlock{
 	dir = 8;
@@ -17265,14 +15001,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
-"kSE" = (
-/obj/machinery/light,
-/obj/structure/closet/random_medsupply,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kSN" = (
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/r_wall,
@@ -17357,27 +15085,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"kVt" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/mug,
-/obj/item/reagent_containers/food/drinks/drinkingglass/mug,
-/obj/item/reagent_containers/food/drinks/drinkingglass/mug,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "kVv" = (
 /obj/structure/scrap_cube,
 /obj/random/uplink/low_chance,
@@ -17391,12 +15098,9 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "kVE" = (
-/mob/living/carbon/superior_animal/xenomorph{
-	name = "Greg";
-	desc = "Fuck you, Greg."
-	},
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
+/obj/structure/salvageable/server,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/dungeon/outside/zoo)
 "kVF" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/grassb4,
@@ -17481,13 +15185,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/remains,
 /obj/random/cloth/armor,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "kZp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fireaxecabinet{
-	pixel_y = 30
-	},
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield/batton,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -17533,15 +15234,6 @@
 /obj/effect/step_trigger/vault_bunker_1G,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"laf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "laj" = (
 /obj/structure/table/marble,
 /obj/random/medical,
@@ -17581,31 +15273,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"lcE" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "lcK" = (
 /obj/structure/flora/small/bushb2,
@@ -17704,7 +15371,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/dungeon_gun_mods,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "lgZ" = (
 /obj/structure/table/onestar,
@@ -17880,13 +15547,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"llF" = (
-/mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "llJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -18044,26 +15704,15 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/untinted/onestar_reinforced{
 	name = "Train Hull"
 	},
 /area/nadezhda/dungeon/outside/prepper/delta)
 "ltj" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "ltt" = (
 /obj/structure/table/steel_reinforced,
@@ -18164,7 +15813,7 @@
 	id = "cmdcentre";
 	color = "B7B099"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "lyG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18270,22 +15919,12 @@
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "lCM" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "lDq" = (
 /obj/structure/flora/small/grassb3,
@@ -18497,14 +16136,6 @@
 /obj/random/tool/advanced/onestar/low_chance,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
-"lIh" = (
-/obj/effect/decal/cleanable/filth,
-/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "lIk" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/under,
@@ -18514,13 +16145,6 @@
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"lJy" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "lJE" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/mineral/planet,
@@ -18591,21 +16215,6 @@
 /obj/effect/step_trigger/prepper_to_vbunker_6_A,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"lMF" = (
-/obj/random/closet,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"lNk" = (
-/obj/machinery/suit_storage_unit/excelsior,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "lNE" = (
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/white/panels,
@@ -18651,7 +16260,8 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "lOU" = (
-/obj/structure/flora/pottedplant/star_root,
+/obj/random/common_oddities,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -18666,14 +16276,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"lPa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "lPc" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -18696,28 +16298,6 @@
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"lQj" = (
-/obj/item/tool/baton/excelbaton,
-/obj/item/tool/baton/excelbaton,
-/obj/item/clothing/suit/space/void/excelsior,
-/obj/item/clothing/head/helmet/space/void/excelsior,
-/obj/random/melee/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/boltgun/heavysniper,
-/obj/item/gun/projectile/automatic/vintorez/NM_colony,
-/obj/structure/closet/crate,
-/obj/item/gun/projectile/automatic/ak47,
-/obj/random/gun_cheap/low_chance,
-/obj/random/gun_cheap/low_chance,
-/obj/random/gun_combat/low_chance,
-/obj/random/gun_combat/low_chance,
-/obj/random/gun_combat/low_chance,
-/obj/random/gun_combat/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "lQk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -18752,14 +16332,6 @@
 "lRw" = (
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/outside/meadow)
-"lRO" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "lRR" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/girder{
@@ -18861,7 +16433,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "lUG" = (
-/obj/effect/floor_decal/corner_oldtile,
 /obj/effect/decal/cleanable/ash{
 	name = "dust";
 	desc = "A clump of dust"
@@ -19028,22 +16599,9 @@
 	name = "Abandoned Bunker"
 	})
 "lXN" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "lXT" = (
 /obj/machinery/light,
@@ -19093,20 +16651,6 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "mbn" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /mob/living/simple_animal/hostile/creature/tissue,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -19127,25 +16671,7 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
-"mbY" = (
-/obj/random/junk,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "mex" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /obj/structure/cable{
@@ -19154,7 +16680,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "mey" = (
 /obj/random/scrap/sparse_even,
@@ -19248,29 +16774,6 @@
 /obj/item/stack/nanopaste,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"mho" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "mhv" = (
 /obj/structure/closet,
 /obj/random/gun_cheap,
@@ -19290,23 +16793,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"miU" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"mjb" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/stack/medical/bruise_pack,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "mjo" = (
 /obj/structure/table/standard,
 /obj/random/gun_energy_cheap,
@@ -19417,13 +16903,6 @@
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
-"mng" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "mnB" = (
 /obj/machinery/light{
 	dir = 8
@@ -19535,14 +17014,6 @@
 /obj/random/toolbox,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"mqX" = (
-/obj/machinery/light,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "mqZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -19564,46 +17035,11 @@
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"mrJ" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "mrR" = (
 /obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
 "mrS" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
 	icon_state = "blob_idle";
@@ -19628,21 +17064,10 @@
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
 "msB" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "msY" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -19680,7 +17105,6 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "mtY" = (
 /obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/industrial/road/straight3,
 /turf/simulated/wall/untinted/onestar_reinforced{
 	name = "Train Hull"
 	},
@@ -19812,20 +17236,6 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "mAM" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /mob/living/simple_animal/hostile/creature/tissue,
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -20026,7 +17436,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "mFJ" = (
 /obj/random/mob/prepper,
@@ -20040,11 +17450,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "mGe" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
@@ -20263,24 +17669,6 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"mMx" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central3,
-/obj/machinery/door/blast/regular/open{
-	name = "LOCKDOWN";
-	id = "cmdcentre"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "mMA" = (
 /obj/machinery/drone_fabricator/derelict{
 	fabricator_tag = "Vault Bunker"
@@ -20348,30 +17736,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"mOC" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "mOL" = (
 /obj/structure/boulder,
 /obj/structure/barricade,
@@ -20523,21 +17887,6 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"mTV" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "mTX" = (
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass,
@@ -20558,44 +17907,12 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"mUC" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "mUG" = (
 /obj/structure/cryofeed,
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "5,20"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"mUI" = (
-/obj/item/trash/popcorn,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "mVa" = (
 /obj/random/material_rare,
 /obj/random/material_rare,
@@ -20708,8 +18025,9 @@
 /area/colony/exposedsun/pastgate)
 "mZo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/random/dungeon_armor_mods/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/obj/machinery/optable,
+/obj/random/uplink/low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -20742,21 +18060,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
 "naB" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "naL" = (
 /obj/structure/cable{
@@ -20886,20 +18194,6 @@
 /turf/simulated/floor/greengrid,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "ned" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/structure/table/rack,
 /obj/random/toolbox,
 /turf/simulated/floor/tiled/cafe,
@@ -20963,24 +18257,6 @@
 /obj/structure/flora/rock,
 /turf/simulated/floor/beach/sand/desert,
 /area/nadezhda/dungeon/outside/zoo)
-"ngA" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"ngB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/largecrate/animal/cat,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ngF" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall36";
@@ -21002,14 +18278,6 @@
 "nhc" = (
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
-"nhe" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/storage/pouch/ammo,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nhk" = (
 /obj/structure/salvageable/data_os{
 	icon_state = "data0"
@@ -21035,26 +18303,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"nhS" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "niM" = (
 /obj/structure/table/marble,
 /obj/random/junkfood/low_chance,
@@ -21119,21 +18367,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"nld" = (
-/obj/structure/scrap,
-/obj/random/pouch/hardcase,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"nle" = (
-/obj/structure/salvageable/implant_container_os,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nlq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21153,14 +18386,6 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"nlD" = (
-/obj/random/dungeon_ammo/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nlG" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -21172,23 +18397,12 @@
 	stat = 1;
 	dir = 1
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "nmq" = (
 /obj/structure/table/onestar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"nmv" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "nmw" = (
 /obj/structure/cable,
 /obj/structure/cable{
@@ -21301,14 +18515,6 @@
 	desc = "A huge chunk of uranium melded together"
 	},
 /area/nadezhda/dungeon/outside/prepper/lima)
-"nob" = (
-/obj/structure/table/standard,
-/obj/random/booze,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nod" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/cardboard/random,
@@ -21427,24 +18633,10 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
 "nsu" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "nsw" = (
 /obj/structure/catwalk,
@@ -21502,16 +18694,6 @@
 "nuk" = (
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
-"nuy" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "nuB" = (
 /obj/effect/decal/cleanable/filth,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
@@ -21523,16 +18705,6 @@
 "nuE" = (
 /obj/item/trash/gamerchips,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"nuW" = (
-/obj/structure/table/marble,
-/obj/item/gun/projectile/automatic/ak47,
-/obj/random/contraband,
-/obj/item/gun/projectile/automatic/ppsh/NM_colony,
-/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -21569,16 +18741,6 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
 "nvJ" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/pen/multi,
@@ -21655,33 +18817,10 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
 "nxJ" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"nxU" = (
-/obj/item/towel,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nxY" = (
 /turf/unsimulated/mineral,
 /area/colony)
@@ -21725,14 +18864,6 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"nAW" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nBv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -21741,16 +18872,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"nBK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/machinery/light,
-/obj/structure/showcase/television,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nBY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -21759,16 +18880,6 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "nCd" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/structure/table/rack/shelf,
 /obj/random/ammo/shotgun/low_chance,
 /obj/random/ammo/shotgun/low_chance,
@@ -22037,15 +19148,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"nMq" = (
-/obj/structure/janitorialcart,
-/obj/item/keys/janitor,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nMX" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -22084,15 +19186,6 @@
 /obj/structure/salvageable/console_broken_os,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"nPm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nPq" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/jungle_tree,
@@ -22102,14 +19195,6 @@
 /obj/item/device/binoculars,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"nPJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nPK" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/dirt,
@@ -22128,7 +19213,7 @@
 	bsod = 1;
 	stat = 1
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "nQn" = (
 /obj/structure/catwalk{
@@ -22167,13 +19252,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"nQY" = (
-/obj/structure/computerframe,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nRe" = (
 /obj/random/contraband,
 /obj/effect/decal/cleanable/dirt,
@@ -22313,14 +19391,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber/yggdrasil,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"nYl" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nYn" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -22357,14 +19427,6 @@
 /obj/structure/sign/warning/nosmoking/largeburnt,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"nZp" = (
-/obj/random/cloth/armor,
-/obj/random/cloth/helmet,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "nZq" = (
 /obj/item/trash/material/metal,
 /turf/simulated/floor/asteroid/dirt,
@@ -22415,13 +19477,6 @@
 /obj/item/solar_assembly,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"obJ" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oco" = (
 /obj/item/part/gun/frame/kalash,
 /turf/simulated/floor/asteroid/grass,
@@ -22483,13 +19538,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"oel" = (
-/obj/machinery/gym/robustness,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oes" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
@@ -22537,10 +19585,9 @@
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/meadow)
 "ofK" = (
-/obj/machinery/door/airlock/centcom,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield/batton,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -22735,20 +19782,6 @@
 	dir = 1;
 	icon_state = "grey_railing0"
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "oli" = (
@@ -22763,14 +19796,6 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"olN" = (
-/obj/item/part/gun/frame/vintorez,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "omd" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/bushc2,
@@ -22813,7 +19838,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "onN" = (
 /obj/machinery/light/small,
@@ -22898,16 +19923,6 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
 "oqK" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/structure/table/rack/shelf,
 /obj/random/ammo_fancy,
 /obj/random/ammo_fancy,
@@ -22960,14 +19975,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"osM" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/random/pouch/hardcase,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "osT" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -23093,35 +20100,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"ovW" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/machinery/door/blast/regular/open{
-	name = "LOCKDOWN";
-	id = "lima9entrance2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "owa" = (
 /obj/structure/salvageable/data,
 /obj/structure/table/standard,
@@ -23165,14 +20143,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/colony/exposedsun/crashed_shop/outsider)
-"oxg" = (
-/obj/structure/barricade,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oxj" = (
 /obj/machinery/light{
 	dir = 1
@@ -23210,19 +20180,6 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"oyi" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "oyr" = (
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
@@ -23354,14 +20311,6 @@
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"oDU" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oEs" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central3{
 	dir = 4
@@ -23420,7 +20369,6 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "oFk" = (
-/obj/structure/barricade,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -23548,39 +20496,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
 "oJK" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /turf/simulated/floor/rock/manmade/road{
 	name = "dust"
 	},
 /area/nadezhda/dungeon/outside/prepper/lima)
-"oJL" = (
-/obj/structure/table/bench/standard,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"oKr" = (
-/obj/structure/sign/departmentold/medical2,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oKx" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/white,
@@ -23720,13 +20640,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"oPF" = (
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oPJ" = (
 /obj/machinery/botany,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -23751,14 +20664,6 @@
 /obj/structure/flora/rock/variant2,
 /turf/simulated/floor/beach/sand/desert,
 /area/nadezhda/dungeon/outside/zoo)
-"oRj" = (
-/obj/machinery/washing_machine,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oRl" = (
 /obj/machinery/light/small,
 /obj/structure/table/standard,
@@ -23790,14 +20695,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
-"oRQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/boozeomat,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oSf" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha1,
@@ -23961,15 +20858,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"oWB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mech_recharger,
-/obj/random/mecha,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oWV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/reagent_dispensers/fueltank,
@@ -23995,14 +20883,6 @@
 /obj/random/pack/junk_machine,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"oXO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/autoinjector/drugs,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oYe" = (
 /obj/machinery/light{
 	dir = 8;
@@ -24145,13 +21025,6 @@
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"pfV" = (
-/obj/item/ammo_casing,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pgh" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "General Containment"
@@ -24293,7 +21166,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
 /turf/simulated/wall/untinted/onestar_reinforced{
 	name = "Loading Crane"
 	},
@@ -24350,15 +21222,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"pky" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pkC" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/busha1,
@@ -24397,7 +21260,7 @@
 	layer = 4
 	},
 /obj/item/clothing/suit/storage/toggle/labcoat,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "plm" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -24410,19 +21273,6 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"plG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/random/uplink/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "plK" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -24431,40 +21281,17 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "plV" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "pmi" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"pmY" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/random/dungeon_ammo/really_low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pnn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -24542,14 +21369,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "ppl" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/random/dungeon_ammo/really_low_chance,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -24584,20 +21404,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
-"pqO" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "pre" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/asteroid/dirt,
@@ -24676,13 +21482,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"pve" = (
-/obj/structure/sign/directions/medical,
-/turf/simulated/wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pvh" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell,
@@ -24847,43 +21646,11 @@
 	name = "Radioactive Waste"
 	},
 /area/nadezhda/dungeon/outside/prepper/lima)
-"pzz" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pzW" = (
 /obj/structure/flora/small/busha2,
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"pAv" = (
-/obj/item/tool/baton/excelbaton,
-/obj/item/tool/baton/excelbaton,
-/obj/item/clothing/suit/space/void/excelsior,
-/obj/item/clothing/head/helmet/space/void/excelsior,
-/obj/random/melee/low_chance,
-/obj/item/gun/projectile/automatic/drozd,
-/obj/item/gun/projectile/automatic/drozd,
-/obj/item/clothing/glasses/eyepatch/secpatch,
-/obj/item/gun/projectile/revolver/wayfarer,
-/obj/item/gun/projectile/revolver/wayfarer,
-/obj/structure/closet/crate,
-/obj/item/gun/projectile/automatic/ak47/saiga/NM_colony,
-/obj/item/gun/projectile/automatic/ak47/saiga/NM_colony,
-/obj/random/gun_cheap/low_chance,
-/obj/random/gun_cheap/low_chance,
-/obj/random/gun_combat/low_chance,
-/obj/random/gun_combat/low_chance,
-/obj/random/gun_combat/low_chance,
-/obj/random/gun_combat/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pAx" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild5,
@@ -24893,15 +21660,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"pAW" = (
-/obj/machinery/door/airlock/centcom,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pBb" = (
 /obj/structure/table/onestar,
 /obj/structure/salvageable/implant_container_os,
@@ -25006,13 +21764,6 @@
 /obj/item/mine_old,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"pFf" = (
-/obj/item/mine/armed,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pFt" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/hazmatsuit,
@@ -25062,14 +21813,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"pGP" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/closet/random_medsupply,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pHb" = (
 /obj/structure/medical_stand/anesthetic,
 /turf/simulated/floor/tiled/cafe,
@@ -25190,28 +21933,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"pJU" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "pKj" = (
 /obj/structure/flora/big/bush2{
 	pixel_x = -24;
@@ -25286,15 +22007,6 @@
 /mob/living/simple_animal/lizard,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"pMm" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/random/dungeon_ammo/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pMx" = (
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 1
@@ -25314,14 +22026,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "pMT" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/rubble,
-/obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
+/obj/structure/salvageable/personal,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/dungeon/outside/zoo)
 "pMY" = (
 /obj/item/contraband/poster/placed/generic/fruit_bowl{
 	pixel_y = 32
@@ -25346,14 +22053,6 @@
 /obj/random/cloth/belt,
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"pNG" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/structure/curtain/medical,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pNN" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -25496,14 +22195,6 @@
 	},
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"pRo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_parts/low,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pRE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25573,7 +22264,7 @@
 	name = "dust";
 	desc = "A clump of dust"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "pSX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25603,13 +22294,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"pTI" = (
-/obj/machinery/light,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pTP" = (
 /obj/item/trash/material/circuit,
 /obj/effect/decal/cleanable/dirt,
@@ -25761,14 +22445,6 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"pZG" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "pZH" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -25816,14 +22492,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"qcp" = (
-/obj/item/trash/plate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qdm" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/excelsior/mixed{
@@ -25929,17 +22597,6 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"qgn" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/drozd/NM_colony,
-/obj/item/gun/projectile/automatic/drozd/NM_colony,
-/obj/random/cloth/armor/low_chance,
-/obj/random/cloth/helmet/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qgw" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -25948,20 +22605,6 @@
 /obj/random/scrap,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"qhe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/ammo/shotgun,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo_fancy,
-/obj/random/ammo_fancy,
-/obj/random/gun_cheap/low_chance,
-/obj/random/gun_cheap/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qhr" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
@@ -25999,14 +22642,6 @@
 /obj/random/gun_normal/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"qio" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/random_medsupply,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qiC" = (
 /obj/machinery/light/floor{
 	dir = 4;
@@ -26052,26 +22687,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"qjP" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "qjT" = (
 /obj/structure/closet/crate/large,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -26137,33 +22752,15 @@
 	},
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/item/clothing/glasses/binoclard_lenses,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"qlq" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "qlu" = (
 /obj/structure/railing/grey{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "qlz" = (
 /obj/structure/table/steel_reinforced,
@@ -26311,28 +22908,12 @@
 /turf/simulated/floor/greengrid,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "qre" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
+/obj/structure/boulder,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "qrg" = (
 /turf/simulated/open,
@@ -26412,18 +22993,8 @@
 /obj/structure/salvageable/computer_os{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"qts" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/random/closet,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qtD" = (
 /obj/random/dungeon_ammo/low_chance,
 /obj/random/dungeon_ammo/low_chance,
@@ -26463,14 +23034,6 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"qvg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qvn" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/dark,
@@ -26479,23 +23042,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/creature/tissue,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "qvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/pack/junk_machine,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"qvM" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qwh" = (
 /obj/structure/salvageable/data_os{
 	icon_state = "computer0"
@@ -26543,15 +23096,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"qxH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/dungeon_ammo/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qxJ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -26627,13 +23171,6 @@
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"qzT" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -26811,15 +23348,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"qGH" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/obj/item/trash/popcorn,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "qGS" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/small/bushc3,
@@ -26892,13 +23420,6 @@
 /area/nadezhda/dungeon/outside/smuggler_zone{
 	name = "Abandoned Outpost";
 	narrate = "This building seems to have been quickly fabricated within the depths of the small rocky hill over it. Whoever made it seems to have fled, as the interior seems both roughened by fighting, but also completely abandoned, with machines either falling into disarray or intentionally sabotaged along with the rest of the outpost."
-	})
-"qJt" = (
-/obj/structure/sign/warning/armory/small,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
 	})
 "qJD" = (
 /obj/random/junk,
@@ -27037,12 +23558,8 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/zoo)
 "qPt" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/drozd/NM_colony,
-/obj/random/cloth/armor/low_chance,
-/obj/random/cloth/helmet/low_chance,
-/obj/random/gun_combat/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield/batton,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -27075,16 +23592,13 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "qPV" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qQw" = (
 /mob/living/simple_animal/hostile/bear/polar,
 /turf/simulated/floor/asteroid/dirt,
@@ -27166,12 +23680,8 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "qTm" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/salvageable/autolathe,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -27262,23 +23772,13 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "qVL" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
 	icon_state = "blob_damaged2";
 	name = "biomass";
 	color = "#750008"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "qWt" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -27307,22 +23807,6 @@
 /obj/structure/cable,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"qXS" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "qYd" = (
 /obj/item/reagent_containers/food/snacks/meat,
@@ -27500,38 +23984,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"rdx" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"rdH" = (
-/obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "rdN" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -27595,18 +24047,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rhr" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/structure/table/standard,
-/obj/random/booze,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "rhw" = (
 /mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
@@ -27914,16 +24354,6 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
 "rsU" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
@@ -28010,31 +24440,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"rvO" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "rwa" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/stack/material/platinum/random,
@@ -28112,7 +24517,7 @@
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/item/clothing/glasses/binoclard_lenses,
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "rxo" = (
 /obj/machinery/light/small{
@@ -28187,14 +24592,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"rAJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "rAV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
@@ -28207,7 +24604,6 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "rBp" = (
-/obj/effect/floor_decal/corner_oldtile,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road{
@@ -28503,22 +24899,9 @@
 /obj/effect/overlay/water,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"rKn" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "rKz" = (
 /turf/simulated/wall/r_wall,
 /area/asteroid/rogue)
-"rLO" = (
-/obj/machinery/light,
-/obj/structure/firedoor_assembly,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "rMe" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/asteroid/grass,
@@ -28581,7 +24964,7 @@
 "rPC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "rPE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28600,7 +24983,7 @@
 /obj/item/clothing/suit/greatcoat/general{
 	name = "officer greatcoat"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "rPG" = (
 /obj/structure/closet/wall_mounted/firecloset{
@@ -28668,19 +25051,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"rRO" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_parts,
-/obj/item/gun_upgrade/barrel/faulty,
-/obj/item/grenade/frag,
-/obj/item/grenade/frag,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "rSp" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -28737,32 +25107,12 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "rUI" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "rUS" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/machinery/door/airlock/glass{
 	locked = 1
 	},
@@ -28802,15 +25152,6 @@
 /obj/item/trash/material/metal,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"rWf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -28861,7 +25202,7 @@
 /obj/item/device/radio/headset{
 	icon_state = "bs_bowman_headset"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "rXE" = (
 /obj/machinery/light/floor,
@@ -28921,51 +25262,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"saF" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"saT" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_idle";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "sbn" = (
 /obj/structure/table/reinforced,
 /obj/random/credits/c5000,
@@ -28995,23 +25291,14 @@
 	name = "Abandoned Bunker"
 	})
 "sch" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/cafe,
+/obj/effect/floor_decal/border/techfloor/orange{
+	icon = 'icons/mob/blob.dmi';
+	icon_state = "blob_idle";
+	name = "biomass";
+	color = "#750008"
+	},
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "scJ" = (
 /obj/effect/floor_decal/industrial/caution,
@@ -29063,15 +25350,6 @@
 /obj/random/pack/junk_machine,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"sdu" = (
-/obj/effect/decal/cleanable/filth,
-/obj/random/dungeon_ammo/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "sdL" = (
 /turf/simulated/wall/untinted/onestar_reinforced{
 	name = "elevator cabin"
@@ -29092,18 +25370,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/zoo)
-"sem" = (
-/obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "sep" = (
 /obj/machinery/gibber,
 /turf/simulated/floor/tiled/white/panels,
@@ -29122,25 +25388,11 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "seX" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "sfb" = (
 /obj/effect/floor_decal/industrial/road/warning3,
@@ -29221,29 +25473,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/zoo)
-"shr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/random/closet_tech/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"shs" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "shv" = (
 /obj/structure/table/onestar,
 /obj/random/pack/tech_loot/onestar,
@@ -29295,7 +25524,6 @@
 	dir = 1;
 	icon_state = "grey_railing0"
 	},
-/obj/effect/floor_decal/corner_oldtile/white,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "sjc" = (
@@ -29338,27 +25566,8 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"sjS" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "ska" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
 /obj/effect/floor_decal/sign/a,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/dungeon/outside/prepper/lima)
@@ -29451,15 +25660,6 @@
 	icon_state = "OLDplating"
 	},
 /area/nadezhda/dungeon/outside/prepper/delta)
-"snc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/peachcan,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "snd" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
@@ -29467,20 +25667,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"sno" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/rock/manmade/road{
-	name = "dust"
-	},
-/area/nadezhda/dungeon/outside/prepper/lima)
 "sns" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
@@ -29585,14 +25771,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"srx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/pottedplant/green_rock,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "srB" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/undergroundmob/low_chance,
@@ -29604,16 +25782,6 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"ssO" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/vintorez,
-/obj/random/cloth/armor/low_chance,
-/obj/random/cloth/helmet/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ssP" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -29633,30 +25801,6 @@
 	color = "#750008"
 	},
 /turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"ssX" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_idle";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "stb" = (
 /obj/effect/decal/cleanable/rubble,
@@ -29791,27 +25935,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"swp" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/mob/living/simple_animal/hostile/creature/tissue,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "sww" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/random/cloth/helmet,
@@ -29856,13 +25979,6 @@
 /obj/structure/table/reinforced,
 /obj/random/credits/c100,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"syp" = (
-/obj/structure/flora/pottedplant/stoutbush,
-/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -29955,9 +26071,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"sBI" = (
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "sBS" = (
 /obj/machinery/cryopod{
 	dir = 4;
@@ -30000,13 +26113,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"sDd" = (
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "sDt" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
@@ -30145,14 +26251,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"sHB" = (
-/obj/random/closet,
-/obj/random/melee/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "sHM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/greengrid,
@@ -30288,13 +26386,6 @@
 /obj/random/closet_tech,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"sNe" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "sNA" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -30494,23 +26585,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
 "sXw" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#0892d0"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "sXz" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
@@ -30561,14 +26641,6 @@
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"sZH" = (
-/obj/random/pouch/hardcase,
-/obj/random/pouch/hardcase,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "sZV" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
@@ -30604,25 +26676,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"tbr" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "tbF" = (
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
@@ -30703,29 +26756,6 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"tdv" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "tdw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/prothesis,
@@ -30807,32 +26837,6 @@
 /obj/random/tool_upgrade/low_chance,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"thh" = (
-/mob/living/simple_animal/hostile/bear/excelsior,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"thk" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "thG" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -30869,16 +26873,6 @@
 /mob/living/simple_animal/hostile/panther,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"tiB" = (
-/obj/structure/synthesized_instrument/synthesizer/piano,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "tji" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -30945,7 +26939,6 @@
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "tkZ" = (
@@ -31008,14 +27001,6 @@
 /obj/item/frame/apc,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"tnh" = (
-/obj/random/junk,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "tnz" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/trash/icecreambowl,
@@ -31064,16 +27049,6 @@
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "tot" = (
 /obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/item/device/radio/phone,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -31122,7 +27097,7 @@
 /obj/structure/bed/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "tqb" = (
 /obj/structure/curtain,
@@ -31173,20 +27148,6 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "tsm" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "tsz" = (
@@ -31195,16 +27156,6 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
 "ttt" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
@@ -31212,7 +27163,7 @@
 	name = "biomass";
 	color = "#750008"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "ttu" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central3{
@@ -31284,16 +27235,6 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
 "tvk" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/floor_decal/border/techfloor/orange{
 	icon = 'icons/mob/blob.dmi';
 	icon_state = "blob_idle";
@@ -31303,7 +27244,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "tvq" = (
 /obj/structure/closet/random_medsupply,
@@ -31421,24 +27362,7 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tAf" = (
-/obj/structure/noticeboard/medical,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "tAn" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/closet/crate/bin,
 /obj/item/tool_upgrade/productivity/ergonomic_grip,
 /obj/effect/decal/cleanable/dirt,
@@ -31572,7 +27496,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "tEm" = (
 /obj/random/closet,
@@ -31634,18 +27558,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"tFS" = (
-/obj/structure/table/standard,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "tFU" = (
 /obj/structure/flora/small/busha2,
 /obj/item/mine/armed,
@@ -31673,26 +27585,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "tHu" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"tIm" = (
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "tIC" = (
 /obj/item/paper_bin,
 /obj/item/paper_bin,
@@ -31708,19 +27603,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"tIF" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "tIV" = (
 /obj/asteroid_spawner/rogue_teleporter,
 /obj/rogue/teleporter,
@@ -31901,44 +27783,11 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"tPR" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_damaged2";
-	name = "biomass";
-	color = "#750008"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "tQf" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"tQp" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "tQt" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/carpet,
@@ -32003,14 +27852,6 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tTP" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "tUF" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -32233,22 +28074,6 @@
 /obj/random/rations,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"uao" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/random/closet_tech/low_chance,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uaR" = (
 /obj/structure/catwalk{
 	icon_state = "catwalk0-0"
@@ -32260,7 +28085,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "uaW" = (
 /obj/machinery/light/small{
@@ -32270,13 +28095,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"ubp" = (
-/obj/random/closet,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ubu" = (
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
@@ -32330,14 +28148,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"ucC" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "udc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/guns/large,
@@ -32371,53 +28181,14 @@
 /obj/item/ammo_casing/pistol_35/scrap/prespawned,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"uea" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/lapvend,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uec" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/one_star)
-"uep" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/tool/sword/saber,
-/obj/effect/decal/cleanable/blood,
-/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/clothing/head/costume/history/jester/court,
-/obj/item/remains/human,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uet" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/roaches,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "ueX" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -32431,10 +28202,10 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
 "ufe" = (
-/obj/machinery/clonepod,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/bed,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -32475,16 +28246,6 @@
 	name = "Abandoned Outpost";
 	narrate = "This building seems to have been quickly fabricated within the depths of the small rocky hill over it. Whoever made it seems to have fled, as the interior seems both roughened by fighting, but also completely abandoned, with machines either falling into disarray or intentionally sabotaged along with the rest of the outpost."
 	})
-"ufW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/random/closet,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ugd" = (
 /obj/structure/table/onestar,
 /obj/item/stock_parts/matter_bin/one_star,
@@ -32518,18 +28279,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"ugC" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 30
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ugY" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -32559,6 +28308,7 @@
 /area/nadezhda/outside/one_star)
 "uhF" = (
 /mob/living/carbon/superior_animal/human/excelsior,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield/batton,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -32671,7 +28421,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/dungeon_armor_mods,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "unD" = (
 /turf/simulated/floor/tiled/dark,
@@ -32785,14 +28535,6 @@
 	tag = "icon-cargoshwall6"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"urD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_parts/low,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "usA" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -32831,13 +28573,6 @@
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"utC" = (
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "utY" = (
 /mob/living/simple_animal/penguin/baby,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -32943,15 +28678,6 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
-"uyY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uzt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/remains/human,
@@ -33071,13 +28797,6 @@
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"uCV" = (
-/obj/machinery/door/window/holowindoor,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uDa" = (
 /obj/structure/closet/random_hostilemobs,
 /obj/effect/decal/cleanable/dirt,
@@ -33120,16 +28839,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"uEi" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/item/taperoll/police,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uEq" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -33202,13 +28911,6 @@
 /obj/item/clothing/suit/armor/vest/iron_lock_security,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"uFT" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "uGO" = (
 /obj/structure/closet/wardrobe/misc/prison,
 /obj/effect/decal/cleanable/dirt,
@@ -33274,16 +28976,6 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"uIZ" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uJw" = (
 /turf/simulated/wall/wood_old,
 /area/asteroid/rogue)
@@ -33306,13 +28998,6 @@
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"uJW" = (
-/obj/item/trash/mre,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uKY" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/wood/wild4,
@@ -33396,15 +29081,6 @@
 /mob/living/simple_animal/hostile/creature/tissue,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"uOi" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/random/cloth/armor/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uOw" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/suit/space/void/engineering,
@@ -33418,15 +29094,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"uOI" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/item/storage/firstaid/combat,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uOJ" = (
 /obj/structure/girder{
 	name = "Connector"
@@ -33633,18 +29300,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"uVr" = (
-/obj/structure/transit_tube{
-	name = "liquid tube"
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_idle";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "uVu" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -33687,13 +29342,6 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"uWM" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "uXk" = (
 /obj/structure/flora/small/busha3,
 /obj/random/mob/vox/low_chance,
@@ -33970,8 +29618,9 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
 "vic" = (
-/obj/random/gun_combat/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/effect/decal/cleanable/filth,
+/mob/living/carbon/superior_animal/human/excelsior/excel_hammer_shield/batton,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -34012,13 +29661,6 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
-"vjc" = (
-/obj/structure/sign/departmentold/janitorial,
-/turf/simulated/wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "vjl" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/dirt,
@@ -34049,13 +29691,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"vkM" = (
-/obj/machinery/power/smes,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "vkQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -34139,19 +29774,6 @@
 /obj/item/material/shard/shrapnel,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"vnE" = (
-/obj/effect/decal/cleanable/cobweb2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "spiderling";
-	name = "dead spider"
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "vom" = (
 /obj/structure/table/plasmaglass,
 /obj/item/ammo_casing/flare/blue/prespawn,
@@ -34264,36 +29886,6 @@
 "vrO" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/dungeon/outside/prepper/lima)
-"vss" = (
-/obj/structure/scrap_cube,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
-"vsO" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "vsV" = (
 /obj/machinery/light{
@@ -34492,14 +30084,6 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"vBH" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "vBO" = (
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark,
@@ -34628,7 +30212,7 @@
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/item/clothing/glasses/regular,
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "vFc" = (
 /obj/structure/flora/small/bushb2,
@@ -34729,11 +30313,6 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"vIC" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "vIH" = (
 /obj/item/material/shard/shrapnel/scrap,
 /turf/simulated/floor/tiled/dark,
@@ -34838,23 +30417,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"vMO" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/turf/simulated/mineral/random/rogue,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "vMR" = (
 /obj/structure/cable/ender{
 	id = "preppergrid"
@@ -34979,15 +30541,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"vQG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/ammo,
-/obj/random/ammo,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "vQT" = (
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/pastgate)
@@ -35226,16 +30779,6 @@
 /area/nadezhda/outside/meadow)
 "vZL" = (
 /obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -35278,16 +30821,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "wbE" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/structure/bed/chair/office/light,
 /obj/item/remains/mummy2{
 	layer = 4
@@ -35339,14 +30872,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"wdn" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "wdt" = (
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark,
@@ -35442,7 +30967,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "wir" = (
 /obj/item/mine_old,
@@ -35562,30 +31087,7 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"wmo" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/glasses/powered/night,
-/obj/random/cloth/armor/low_chance,
-/obj/random/cloth/helmet/low_chance,
-/obj/random/cloth/glasses/low_chance,
-/obj/random/gun_combat/low_chance,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "wmD" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -35602,16 +31104,6 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "wmQ" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/machinery/door/window{
 	dir = 4
 	},
@@ -35640,13 +31132,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"wot" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "woM" = (
 /obj/structure/boulder,
 /obj/item/mine_old{
@@ -35657,18 +31142,6 @@
 "woQ" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
-"woR" = (
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/item/gun/projectile/grenade,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "wpr" = (
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/dungeon/outside/prepper/lima)
@@ -35694,10 +31167,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"wqu" = (
-/obj/structure/bed/chair/comfy,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "wqG" = (
 /obj/structure/boulder,
 /turf/simulated/floor/rock/dark,
@@ -35798,13 +31267,6 @@
 /obj/structure/flora/small/bushc3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"wtz" = (
-/obj/random/dungeon_gun_ballistic,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "wtC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -35832,19 +31294,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"wvi" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/stunrevolver,
-/obj/random/cloth/armor/low_chance,
-/obj/random/cloth/helmet/low_chance,
-/obj/random/cloth/glasses/low_chance,
-/obj/random/gun_combat/low_chance,
-/obj/random/medical,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "wvp" = (
 /obj/item/bedsheet/brown,
 /obj/structure/bed/padded,
@@ -36063,16 +31512,6 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"wEw" = (
-/obj/structure/salvageable/console_broken_os,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "wEV" = (
 /obj/item/trash/mre_paste,
 /obj/effect/decal/cleanable/filth,
@@ -36125,10 +31564,6 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
 "wGM" = (
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white,
 /obj/item/trash/material/metal{
 	icon_state = "metal3"
 	},
@@ -36153,7 +31588,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/road/straight3,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock/manmade/ruin3,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -36206,7 +31640,7 @@
 	dir = 1;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "wKN" = (
 /obj/item/stool,
@@ -36371,33 +31805,6 @@
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"wPa" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_idle";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "wPb" = (
 /obj/structure/table/steel,
 /obj/item/device/radio,
@@ -36459,11 +31866,18 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
 "wSZ" = (
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/border/techfloor/orange{
+	icon = 'icons/mob/blob.dmi';
+	icon_state = "blob_idle";
+	name = "biomass";
+	color = "#750008"
+	},
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/dungeon/outside/prepper/lima)
 "wTe" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -36498,7 +31912,7 @@
 	layer = 4
 	},
 /obj/item/clothing/glasses/binoclard_lenses,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "wUP" = (
 /obj/structure/flora/small/bushc1,
@@ -36678,14 +32092,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
-"xav" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xbf" = (
 /obj/item/ammo_casing/heavy_rifle_408/spent,
 /obj/item/ammo_casing/heavy_rifle_408/spent,
@@ -36701,14 +32107,6 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
 "xbs" = (
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/rock/manmade/road{
@@ -36716,20 +32114,6 @@
 	},
 /area/nadezhda/dungeon/outside/prepper/lima)
 "xbN" = (
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/security/chief{
 	pixel_x = 35
@@ -36773,14 +32157,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"xcF" = (
-/obj/item/trash/mre_paste,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xcI" = (
 /mob/living/simple_animal/hostile/creature/tissue,
 /turf/simulated/floor/tiled/dark,
@@ -37102,16 +32478,6 @@
 	})
 "xnt" = (
 /obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -37144,21 +32510,7 @@
 /area/nadezhda/dungeon/outside/prepper/lima)
 "xoG" = (
 /obj/structure/reagent_dispensers/fueltank/derelict,
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/dungeon/outside/prepper/lima)
@@ -37262,16 +32614,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"xrC" = (
-/obj/structure/boulder,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xrG" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/danger,
@@ -37340,13 +32682,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"xvh" = (
-/obj/random/oddity_guns,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xvi" = (
 /obj/item/pizzabox/vegetable,
 /obj/random/boxes,
@@ -37526,18 +32861,6 @@
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"xCH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xCX" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_platform,
@@ -37551,7 +32874,6 @@
 /area/nadezhda/dungeon/outside/prepper)
 "xDj" = (
 /obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/industrial/road/straight3,
 /obj/structure/girder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/delta)
@@ -37571,16 +32893,6 @@
 /area/nadezhda/dungeon/outside/prepper/delta)
 "xDB" = (
 /obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
 /obj/item/paper_bin,
 /obj/item/pen/multi,
 /turf/simulated/floor/tiled/cafe,
@@ -37620,13 +32932,9 @@
 /turf/simulated/floor/greengrid,
 /area/nadezhda/dungeon/outside/prepper/delta)
 "xEH" = (
-/obj/machinery/door/airlock,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
+/obj/structure/salvageable/implant_container,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/dungeon/outside/zoo)
 "xEO" = (
 /obj/structure/table/bench/wooden,
 /obj/item/trash/broken_robot_part,
@@ -37854,7 +33162,7 @@
 	name = "dust";
 	desc = "A clump of dust"
 	},
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "xMU" = (
 /obj/random/junk,
@@ -37980,18 +33288,6 @@
 /obj/structure/salvageable/server_os,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"xRl" = (
-/obj/random/junk,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/structure/flora/pottedplant/decorative,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xRr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/dark,
@@ -38002,29 +33298,6 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"xRv" = (
-/obj/effect/floor_decal/industrial/road/straight1,
-/obj/effect/floor_decal/industrial/road/straight2,
-/obj/effect/floor_decal/industrial/road/straight3,
-/obj/effect/floor_decal/industrial/road/straight4,
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/techfloor/orange{
-	icon = 'icons/mob/blob.dmi';
-	icon_state = "blob_idle";
-	name = "biomass";
-	color = "#750008"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/lima)
 "xRw" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
@@ -38052,15 +33325,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"xSJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/sosjerky,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xSP" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -38071,12 +33335,8 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "xTs" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cloth/belt/low_chance,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/structure/salvageable/console_broken_os,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -38101,14 +33361,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"xTT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/complant_teleporter,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xTW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/pistol_35/spent,
@@ -38283,15 +33535,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/lima)
-"ybJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ybU" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/scrap/poor,
@@ -38312,19 +33555,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"ycQ" = (
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_oldtile,
-/obj/effect/floor_decal/corner_oldtile{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/prepper/delta)
 "ycT" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -38346,13 +33576,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"ydw" = (
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ydI" = (
 /obj/item/mine/armed,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -38361,10 +33584,6 @@
 	name = "Abandoned Bunker"
 	})
 "ydJ" = (
-/obj/effect/floor_decal/corner_oldtile/white,
-/obj/effect/floor_decal/corner_oldtile/white{
-	dir = 4
-	},
 /obj/item/trash/material/metal,
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/plating/under,
@@ -38446,7 +33665,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/prepper/lima)
 "yhY" = (
 /obj/machinery/light,
@@ -39704,7 +34923,7 @@ qzG
 nLW
 nLW
 dzS
-tIF
+bJJ
 ydJ
 ycL
 mtY
@@ -39912,9 +35131,9 @@ qPy
 qzG
 ttu
 xDv
-shs
-qPV
-his
+bJJ
+bJJ
+bJJ
 bJJ
 xDj
 rFz
@@ -40123,7 +35342,7 @@ php
 ndh
 eoA
 wGM
-dyI
+bJJ
 nLW
 mtY
 rum
@@ -40145,7 +35364,7 @@ prC
 ndM
 sVv
 opB
-aRj
+rCa
 tsm
 kGw
 iVY
@@ -40355,7 +35574,7 @@ ndM
 opB
 opB
 opB
-wot
+rCa
 bQf
 cqG
 mGZ
@@ -43679,9 +38898,9 @@ coU
 nLW
 nLW
 xDB
-ycQ
+tsm
 rsU
-ycQ
+tsm
 tot
 nLW
 kVX
@@ -44097,9 +39316,9 @@ coU
 nLW
 nLW
 nCd
-ycQ
-ycQ
-ycQ
+tsm
+tsm
+tsm
 hbp
 nLW
 hrT
@@ -44306,10 +39525,10 @@ coU
 nLW
 nLW
 oqK
-ioz
-ioz
-ioz
-daD
+tsm
+tsm
+tsm
+nCd
 nLW
 pFt
 qzG
@@ -44723,9 +39942,9 @@ dQF
 coU
 opB
 opB
-vMO
+opB
 acG
-ciV
+uSj
 gXB
 tsm
 tsm
@@ -44735,10 +39954,10 @@ tsm
 gXB
 gXB
 tsm
-qlq
+pLN
 dcc
-qlq
-qlq
+pLN
+pLN
 tsm
 tsm
 gXB
@@ -44932,10 +40151,10 @@ qbU
 coU
 opB
 opB
-vMO
+opB
 fTt
 jTL
-apv
+uSj
 tsm
 tsm
 tsm
@@ -44944,10 +40163,10 @@ jTL
 tsm
 tsm
 tsm
-qlq
-qlq
-qlq
-qlq
+pLN
+pLN
+pLN
+pLN
 mbn
 tsm
 tsm
@@ -45141,10 +40360,10 @@ coU
 coU
 opB
 opB
-vMO
+opB
 fTt
 fTt
-ciV
+uSj
 gXB
 gXB
 jTL
@@ -45153,9 +40372,9 @@ uuq
 pDn
 bxV
 gXB
-qlq
-qlq
-qlq
+pLN
+pLN
+pLN
 xbN
 gXB
 gXB
@@ -46222,8 +41441,8 @@ qbU
 qbU
 coU
 nLW
-ycQ
-ycQ
+tsm
+tsm
 nLW
 tXe
 fpP
@@ -46431,8 +41650,8 @@ qbU
 qbU
 coU
 nLW
-ycQ
-ycQ
+tsm
+tsm
 nLW
 nLW
 nLW
@@ -46640,10 +41859,10 @@ qbU
 qbU
 coU
 nLW
-ycQ
-ycQ
+tsm
+tsm
 tHu
-ycQ
+tsm
 rUS
 qPQ
 etp
@@ -46849,10 +42068,10 @@ qbU
 qbU
 coU
 nLW
-ycQ
-ycQ
+tsm
+tsm
 tHu
-ycQ
+tsm
 rUS
 qPQ
 kqj
@@ -57515,12 +52734,12 @@ qbU
 qbU
 qbU
 qbU
-coU
-coU
-coU
-coU
-coU
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -57724,12 +52943,12 @@ qbU
 qbU
 qbU
 qbU
-coU
 qbU
 qbU
 qbU
 qbU
-coU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -57932,13 +53151,13 @@ qbU
 qbU
 qbU
 qbU
-coU
-coU
 qbU
 qbU
 qbU
 qbU
-coU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -58128,26 +53347,26 @@ mxn
 mxn
 qbU
 qbU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-rKz
 qbU
 qbU
 qbU
 qbU
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -58337,26 +53556,26 @@ mxn
 qbU
 qbU
 qbU
-coU
-oGU
-oGU
-oGU
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-kSN
-vsO
-oGU
-oGU
-oGU
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -58546,26 +53765,26 @@ qbU
 qbU
 qbU
 qbU
-coU
-oGU
-oGU
-oGU
-iqD
-jpg
-kTJ
-mjJ
-ezY
-fCz
-wkt
-kpS
-fQx
-bWn
-mjJ
-gTi
-sch
-sch
-oGU
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -58755,26 +53974,26 @@ qbU
 qbU
 qbU
 qbU
-coU
-idB
-oGU
-lRO
-jpg
-hqL
-xVI
-lGG
-tnM
-iwf
-ssT
-iwf
-iZq
-xVI
-uSr
-lXN
-sch
-sch
-oGU
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -58961,29 +54180,29 @@ qbU
 qbU
 qbU
 qbU
-coU
-coU
-coU
-coU
-idB
-owd
-hUw
-vLc
-hqL
-eSV
-bKS
-fLq
-sjs
-qFL
-kpS
-fQx
-bWn
-mjJ
-qre
-gTi
-sch
-oGU
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -59157,42 +54376,42 @@ uDC
 uJw
 qbU
 qbU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-rKz
-rKz
-rKz
-idB
-uVr
-oyi
-hqL
-amZ
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-iCg
-wPa
-lXN
-huR
-idB
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -59366,42 +54585,42 @@ uJw
 uJw
 qbU
 qbU
-coU
-oGU
-oGU
-oGU
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-dck
-pwT
-idB
-uVr
-jOT
-hqL
-hqL
-idB
-coU
-coU
-coU
-coU
-coU
-coU
-coU
-idB
-qre
-lXN
-ssX
-idB
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
@@ -59575,41 +54794,41 @@ qbU
 qbU
 qbU
 qbU
-coU
-oGU
-oGU
-oGU
-amZ
-amZ
-uBQ
-hqL
-jIZ
-idB
-jpo
-hqL
-syZ
-ayV
-tcY
-pPW
-inG
-idB
-uVr
-uFT
-hqL
-vLc
-idB
-coU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
 qbU
 qbU
 qbU
 qbU
 qbU
 coU
-idB
-qre
-lXN
-saT
-idB
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -59785,39 +55004,39 @@ qbU
 qbU
 qbU
 coU
-oGU
-oGU
-mJI
-ott
-vLc
-hqL
-vLc
-vLc
-smB
-hqL
-hqL
-hqL
-hqL
-pLC
-kcW
-pPW
-idB
-uVr
-oyi
-hqL
-vLc
-idB
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+kSN
 qre
-huR
-rdx
+oGU
+oGU
 oGU
 coU
 qbU
@@ -59996,38 +55215,38 @@ qbU
 coU
 oGU
 oGU
-iqD
-jpg
+oGU
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+dck
+pwT
+idB
+bVx
 hqL
-vLc
-amZ
-amZ
-idB
-jpo
 hqL
-syZ
-kSs
-tcY
-xGr
-kUu
-idB
-uVr
-nmv
 hqL
-fXc
-idB
-coU
-qbU
-qbU
-qbU
-qbU
-qbU
-coU
-idB
-ssX
-qre
-gTi
-idB
+kTJ
+mjJ
+ezY
+fCz
+wkt
+kpS
+fQx
+bWn
+mjJ
+lXN
+nxJ
+nxJ
+oGU
 coU
 qbU
 qbU
@@ -60204,39 +55423,39 @@ qbU
 qbU
 coU
 oGU
-mJI
-jpg
+oGU
+oGU
+amZ
+amZ
+uBQ
 hqL
+jIZ
 idB
+jpo
+hqL
+syZ
+ayV
+tcY
+pPW
+inG
 idB
-idB
-idB
-idB
-wHo
-smB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-uWc
-idB
-idB
-coU
-qbU
-qbU
-qbU
-qbU
-qbU
-coU
-idB
-ssX
-lXN
-lXN
-idB
+bVx
+hqL
+hqL
+hqL
+xVI
+lGG
+tnM
+iwf
+ssT
+iwf
+iZq
+xVI
+uSr
+aBh
+nxJ
+nxJ
+oGU
 coU
 qbU
 qbU
@@ -60413,39 +55632,39 @@ qbU
 qbU
 coU
 oGU
-amZ
+oGU
+mJI
 ott
+vLc
 hqL
-idB
-gOt
-wWq
-qKo
-idB
-cYy
-hqL
-hQa
-idB
-blK
-wxd
-eli
-fuI
-idB
+vLc
+vLc
+smB
 hqL
 hqL
 hqL
+hqL
+pLC
+kcW
+pPW
 idB
-coU
-qbU
-qbU
-qbU
-qbU
-qbU
-coU
-idB
-qre
+bVx
+hqL
+hqL
+hqL
+eSV
+bKS
+fLq
+sjs
+qFL
+kpS
+fQx
+bWn
+mjJ
+ttt
 lXN
-lXN
-idB
+nxJ
+oGU
 coU
 qbU
 qbU
@@ -60621,38 +55840,38 @@ qbU
 qbU
 qbU
 coU
-idB
+oGU
+oGU
+iqD
+jpg
+hqL
+vLc
 amZ
 amZ
-hqL
-uWc
-hqL
-hqL
-niR
 idB
-mWl
+jpo
 hqL
-cYe
+syZ
+kSs
+tcY
+xGr
+kUu
 idB
-eQG
-hqL
-hqL
-mBL
-uWc
+kaq
 hqL
 hqL
 hqL
 idB
-coU
-qbU
-qbU
-qbU
-qbU
-qbU
-coU
 idB
-lXN
-lXN
+idB
+idB
+idB
+idB
+idB
+idB
+iCg
+wSZ
+aBh
 gTi
 idB
 coU
@@ -60830,40 +56049,40 @@ qbU
 qbU
 qbU
 coU
+oGU
+mJI
+jpg
+hqL
 idB
-amZ
-vLc
-hqL
-bNX
-hqL
-hqL
-iSa
 idB
-vLc
-hqL
-fDn
 idB
-eQG
-mBL
-hqL
-hqL
-uWc
+idB
+idB
+wHo
+smB
+idB
+idB
+idB
+idB
+idB
+idB
+thG
 hqL
 hqL
 jrd
 idB
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
 coU
 idB
-gTi
-gTi
+ttt
+aBh
 sch
-oGU
+idB
 coU
 qbU
 qbU
@@ -61039,23 +56258,23 @@ qbU
 qbU
 qbU
 coU
-idB
+oGU
 amZ
-vLc
+ott
 hqL
-oGk
-hqL
-hqL
-hUN
 idB
-fKJ
-gMp
-rWg
+gOt
+wWq
+qKo
 idB
-blK
-cYe
-nDn
-iLA
+cYy
+hqL
+hQa
+idB
+idB
+idB
+idB
+idB
 idB
 ieH
 tye
@@ -61069,9 +56288,9 @@ qbU
 qbU
 coU
 oGU
-sch
-sch
-sch
+nxJ
+nxJ
+nxJ
 oGU
 coU
 qbU
@@ -61249,22 +56468,22 @@ qbU
 qbU
 coU
 idB
-vLc
+amZ
+amZ
+hqL
+uWc
 hqL
 hqL
-oGk
-vmp
-kuS
-eLX
+niR
 idB
-rPS
-vLc
-rWg
+mWl
+hqL
+cYe
 idB
-idB
-idB
-idB
-idB
+blK
+wxd
+eli
+fuI
 idB
 jIZ
 hqL
@@ -61458,22 +56677,22 @@ qbU
 qbU
 coU
 idB
-llm
+amZ
+vLc
 hqL
-sMm
+bNX
+hqL
+hqL
+iSa
 idB
+vLc
+hqL
+fDn
 idB
-idB
-idB
-idB
-idB
-idB
-idB
-idB
-hTW
-qSd
-jJI
-qSd
+eQG
+hqL
+hqL
+mBL
 idB
 llm
 hqL
@@ -61667,20 +56886,20 @@ qbU
 qbU
 coU
 idB
-hqL
+amZ
 vLc
-amZ
-idB
-thG
-vIC
-sBw
-uzK
-uzK
-amZ
-amZ
-idB
+hqL
+oGk
 hqL
 hqL
+hUN
+idB
+fKJ
+gMp
+rWg
+idB
+eQG
+mBL
 hqL
 hqL
 uWc
@@ -61876,22 +57095,22 @@ qbU
 qbU
 coU
 idB
-jIZ
 vLc
-amZ
+hqL
+hqL
+oGk
+vmp
+kuS
+eLX
 idB
+rPS
 vLc
-hqL
-hqL
-hqL
-vLc
-vLc
-amZ
+rWg
 idB
-qSd
-wwD
-qSd
-qSd
+blK
+cYe
+nDn
+iLA
 idB
 llm
 hqL
@@ -62085,17 +57304,17 @@ qbU
 qbU
 coU
 idB
+llm
 hqL
-hqL
-vLc
-wMW
-vLc
-hqL
-hqL
-hqL
-hqL
-hqL
-vLc
+sMm
+idB
+idB
+idB
+idB
+idB
+idB
+idB
+idB
 idB
 idB
 idB
@@ -62295,16 +57514,16 @@ qbU
 coU
 idB
 hqL
-hqL
 vLc
-wMW
-vLc
+amZ
+idB
+thG
 hqL
-hqL
-hqL
-hqL
-hqL
-vLc
+sBw
+uzK
+uzK
+amZ
+amZ
 idB
 llm
 hqL
@@ -62324,8 +57543,8 @@ aHX
 tOP
 nqW
 iTu
-mho
-sch
+aBh
+nxJ
 idB
 coU
 coU
@@ -62503,17 +57722,17 @@ qbU
 qbU
 coU
 idB
-hqL
-hqL
-hqL
+jIZ
+vLc
+amZ
+idB
 vLc
 hqL
 hqL
 hqL
-hqL
-hqL
-hqL
-hqL
+vLc
+vLc
+amZ
 vwQ
 hqL
 hqL
@@ -62522,8 +57741,8 @@ hqL
 hqL
 hqL
 jrd
-hqL
-idB
+oGU
+oGU
 coU
 qbU
 coU
@@ -62532,9 +57751,9 @@ aHX
 ska
 tOP
 nqW
-kKX
-mUC
-tbr
+aBh
+aBh
+uet
 idB
 coU
 coU
@@ -62604,7 +57823,7 @@ mNA
 lEJ
 kcL
 iFU
-bAa
+iFU
 mNA
 coU
 coU
@@ -62714,25 +57933,25 @@ coU
 idB
 hqL
 hqL
+vLc
+wMW
+vLc
 hqL
 hqL
 hqL
 hqL
 hqL
-hqL
-hqL
-hqL
-jIZ
+vLc
 idB
 lcC
 hqL
 hqL
 hqL
+jrd
 hqL
 hqL
-hqL
-hqL
-idB
+oGU
+oGU
 coU
 qbU
 coU
@@ -62741,9 +57960,9 @@ iRj
 aHX
 tOP
 nqW
-lXN
-mUC
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -62931,17 +58150,17 @@ idB
 lhn
 bVx
 bVx
-rKn
+hqL
 idB
 fuI
 fuI
-hqL
-hqL
-jrd
-hqL
-hqL
-hqL
-idB
+cOt
+cOt
+cOt
+cOt
+cOt
+owd
+oGU
 coU
 qbU
 coU
@@ -62950,9 +58169,9 @@ sdL
 sdL
 sdL
 izC
-bnf
-mUC
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -63125,10 +58344,10 @@ qbU
 uLM
 qbU
 qbU
-qbU
-qbU
-qbU
-coU
+idB
+idB
+idB
+idB
 idB
 idB
 idB
@@ -63148,9 +58367,9 @@ idB
 idB
 idB
 idB
-idB
-idB
-idB
+oGU
+oGU
+oGU
 coU
 qbU
 coU
@@ -63159,9 +58378,9 @@ coU
 coU
 coU
 idB
-xRv
-mUC
-lXN
+qzm
+aBh
+aBh
 idB
 coU
 coU
@@ -63238,13 +58457,13 @@ cYh
 wtC
 fcB
 xtV
-aLI
-wtz
-eas
-wSZ
-wSZ
-aLI
-wSZ
+hOg
+oNj
+bRP
+oNj
+oNj
+xCX
+bRP
 xtV
 coU
 coU
@@ -63334,16 +58553,16 @@ qbU
 euc
 qbU
 qbU
-qbU
-qbU
-qbU
-coU
-coU
 idB
-evX
+hTW
+qSd
+jJI
+qSd
+idB
+oEw
 iDP
 bpv
-ais
+idB
 nIo
 idB
 coU
@@ -63368,9 +58587,9 @@ qbU
 qbU
 coU
 idB
-kKX
-rvO
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -63439,7 +58658,7 @@ hgL
 hgL
 hgL
 hgL
-jva
+pHI
 pHI
 hgL
 hgL
@@ -63447,13 +58666,13 @@ hgL
 pHI
 hgL
 xtV
-hNR
-wSZ
-aLI
-wSZ
-eas
-coO
-wSZ
+hOg
+oNj
+ceR
+jJO
+jJO
+jJO
+aho
 xtV
 coU
 coU
@@ -63543,16 +58762,16 @@ qbU
 euc
 qbU
 qbU
-qbU
-qbU
-qbU
-qbU
-coU
 idB
-evX
-evX
-evX
-ais
+llm
+hqL
+hqL
+hqL
+uWc
+oEw
+oEw
+oEw
+idB
 hTs
 idB
 coU
@@ -63577,9 +58796,9 @@ qbU
 qbU
 coU
 idB
-pJU
-rvO
-qjP
+seX
+aBh
+ltj
 idB
 coU
 coU
@@ -63647,7 +58866,7 @@ pHI
 hgL
 xQf
 pHI
-jva
+pHI
 hgL
 lrx
 avp
@@ -63656,13 +58875,13 @@ dnC
 hgL
 wvJ
 xtV
-eBe
-aLI
-wSZ
-gfM
-aLI
-wSZ
-pTI
+qHe
+oNj
+bRP
+jJO
+jJO
+jJO
+rCV
 xtV
 coU
 coU
@@ -63752,17 +58971,17 @@ uLM
 euc
 qbU
 qbU
-qbU
-qbU
-qbU
-qbU
-coU
+idB
+qSd
+wwD
+qSd
+qSd
 oMK
-evX
+oEw
 rUI
-evX
+oEw
 wmD
-evX
+oEw
 idB
 coU
 qbU
@@ -63786,9 +59005,9 @@ qbU
 qbU
 coU
 idB
-kKX
-mUC
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -63856,8 +59075,8 @@ ggb
 dnC
 hgL
 pHI
-pHI
-pHI
+ofK
+ofK
 hgL
 jnq
 hgL
@@ -63865,13 +59084,13 @@ pHI
 hgL
 wvJ
 xtV
-wSZ
-wSZ
-hNR
-wSZ
-wSZ
-wSZ
-aLI
+qHe
+oNj
+riv
+xCX
+oNj
+oNj
+hyA
 xtV
 coU
 coU
@@ -63961,17 +59180,17 @@ ugY
 euc
 qbU
 qbU
-qbU
-qbU
-qbU
-qbU
-coU
+idB
+idB
+idB
+idB
+idB
 idB
 wbE
 nvJ
-evX
-evX
-evX
+oEw
+oEw
+oEw
 idB
 coU
 coU
@@ -63995,9 +59214,9 @@ qbU
 qbU
 coU
 idB
-lXN
-bzx
-lXN
+aBh
+uet
+aBh
 idB
 coU
 coU
@@ -64074,13 +59293,13 @@ hgL
 hgL
 wvJ
 xtV
-hmx
-ech
-wSZ
-aLI
-aLI
-hNR
-wSZ
+tyL
+oNj
+pXi
+pXi
+pXi
+xZn
+pXi
 xtV
 coU
 coU
@@ -64178,8 +59397,8 @@ coU
 idB
 hKu
 hQw
-evX
-evX
+oEw
+oEw
 tAn
 idB
 coU
@@ -64204,9 +59423,9 @@ qbU
 qbU
 coU
 idB
-lXN
-mUC
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -64283,13 +59502,13 @@ hox
 hgL
 gAk
 xtV
-uCV
-glZ
-cOt
-glZ
-glZ
-glZ
-cOt
+vFk
+bRP
+pXi
+izA
+izA
+izA
+pXi
 xtV
 coU
 coU
@@ -64413,9 +59632,9 @@ qbU
 qbU
 coU
 idB
-lXN
-mUC
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -64489,16 +59708,16 @@ tgr
 pHI
 hgL
 hgL
-jva
+pHI
 pHI
 tCZ
-hgL
-hgL
-avp
-jgj
-pHI
-hgL
-hgL
+ttU
+bRP
+pXi
+aWi
+izA
+izA
+pXi
 xtV
 coU
 coU
@@ -64605,13 +59824,13 @@ oGU
 oGU
 oGU
 ekp
-iiJ
-hpw
+oJK
+aBh
 naB
-hpw
-hpw
-bAJ
-kck
+aBh
+aBh
+oJK
+oJK
 xbs
 oGU
 sZr
@@ -64622,9 +59841,9 @@ qbU
 qbU
 coU
 idB
-kKX
-mUC
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -64687,8 +59906,8 @@ coU
 coU
 xtV
 hgL
-utC
-pHI
+hgL
+gfM
 pHI
 hgL
 pHI
@@ -64697,17 +59916,17 @@ dnC
 hgL
 aNV
 dpI
+ces
+pHI
 hgL
-oxg
-hgL
-xtV
-ehe
-qjc
-hgL
-hgL
+szl
+oNj
+lpc
+xmM
+jrF
 mZo
-hgL
-ngA
+dzj
+pXi
 xtV
 coU
 coU
@@ -64815,12 +60034,12 @@ xLo
 byT
 eOo
 rBp
-thk
-tPR
-nhS
-nhS
-nhS
-sem
+aBh
+ttt
+aBh
+aBh
+aBh
+oJK
 byT
 cju
 idB
@@ -64831,9 +60050,9 @@ qbU
 qbU
 coU
 idB
-kKX
-rvO
-kKX
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -64898,26 +60117,26 @@ xtV
 vsV
 pHI
 pHI
-jva
+pHI
 xty
 hgL
 hgL
 hgL
 hgL
 jcD
-utC
+hgL
 hgL
 lrx
-rLO
-xtV
+hgL
+szl
 byy
 hgL
-wtC
+xmM
 ojC
 dpI
-vHs
-axV
-uHr
+hgL
+xmM
+xtV
 coU
 coU
 coU
@@ -65019,19 +60238,19 @@ qbU
 qbU
 coU
 idB
-diE
+ekp
 aRH
 aRH
-pqO
-nhS
-ayn
+aRH
+aBh
+qVL
 tvk
 bis
 ttt
-hpw
+aBh
 oJK
-cdY
-sno
+eOo
+oJK
 idB
 idB
 coU
@@ -65040,9 +60259,9 @@ qbU
 qbU
 coU
 idB
-kKX
-rvO
-kKX
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -65107,26 +60326,26 @@ xtV
 aHN
 szl
 wsa
-aHN
-aHN
-aHN
-aHN
-aHN
-aHN
-aHN
-aHN
-szl
-szl
-aHN
 xtV
-lOU
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+szl
+szl
+xtV
+xtV
 hgL
 hgL
+xmM
 hgL
 jgj
-vJM
-uHr
-uHr
+umz
+xmM
+xtV
 coU
 coU
 coU
@@ -65229,18 +60448,18 @@ coU
 coU
 idB
 idB
-hpw
-hpw
-jCD
+aBh
+aBh
+aBh
 lNG
 coZ
 idB
 idB
 coZ
 gbp
-eYX
-hpw
-hpw
+oJK
+aBh
+aBh
 idB
 idB
 coU
@@ -65249,9 +60468,9 @@ coU
 coU
 coU
 idB
-lXN
-rvO
-lXN
+aBh
+aBh
+aBh
 idB
 coU
 coU
@@ -65313,29 +60532,29 @@ nxY
 coU
 coU
 xtV
-oNj
+eci
 snd
 oNj
-oNj
-iip
-tiB
+qTm
+xtV
+jQS
 dez
 bHO
 bHO
 jQS
-nQY
+oNj
 oNj
 oNj
 hTF
 xtV
-cEx
+hgL
 dpI
-hgL
-hgL
-vJM
-vJM
-axV
-uHr
+xmM
+xmM
+xmM
+xmM
+xmM
+xtV
 coU
 coU
 coU
@@ -65438,18 +60657,18 @@ idB
 idB
 idB
 sXw
-hpw
-hpw
-jCD
+aBh
+aBh
+aBh
 coZ
 fdQ
 djX
 dzt
 upP
 coZ
-fDb
-hpw
-qXS
+oJK
+aBh
+ltj
 idB
 idB
 idB
@@ -65459,7 +60678,7 @@ idB
 idB
 idB
 seX
-mUC
+aBh
 nsu
 idB
 coU
@@ -65522,15 +60741,15 @@ nxY
 coU
 coU
 xtV
-hOw
-aDy
-thh
-pFf
-snd
+ddc
+ckM
+hgL
+fqV
+wsa
 dGD
 nJu
 bRP
-blC
+oNj
 snd
 oNj
 cFk
@@ -65543,8 +60762,8 @@ ape
 jgj
 hgL
 hgL
-axV
-uHr
+hyA
+xtV
 coU
 coU
 coU
@@ -65640,36 +60859,36 @@ coU
 oGU
 iiu
 iiu
-mTV
-mTV
+nxJ
+nxJ
 aJT
-hpw
+aBh
 mEc
 jim
-hpw
-hpw
-hpw
-eUU
+aBh
+aBh
+aBh
+ltj
 idB
 dgA
 kHB
 aYQ
 upP
 coZ
-jCD
-hpw
-bMK
-aOH
-aOH
-kKX
-fda
-kKX
-lXN
-lXN
-fda
-lXN
-tdv
-iKV
+aBh
+aBh
+aBh
+aBh
+aBh
+aBh
+naB
+aBh
+aBh
+aBh
+naB
+aBh
+aBh
+ejz
 oGU
 coU
 coU
@@ -65730,12 +60949,12 @@ nxY
 nxY
 coU
 coU
-xtV
-aFi
-oNj
-aDy
-oNj
-aWi
+tCZ
+lOU
+hgL
+hgL
+hYL
+wsa
 oNj
 oNj
 hTF
@@ -65748,9 +60967,9 @@ snd
 xtV
 ufe
 pHI
-pHI
+gAf
 hgL
-avp
+eUU
 pHI
 chw
 xtV
@@ -65849,16 +61068,16 @@ coU
 oGU
 iiu
 cJL
-nhS
-nhS
-nhS
-nhS
-kao
-mMx
-nhS
-nhS
-nhS
-eBR
+aBh
+aBh
+aBh
+aBh
+gTN
+dCV
+aBh
+aBh
+aBh
+aBh
 eLh
 kHB
 kHB
@@ -65867,15 +61086,15 @@ qrL
 coZ
 aBh
 uet
-nhS
-hdR
-ovW
-dzn
-mOC
-mOC
-dzn
-dzn
-lcE
+aBh
+aBh
+aBh
+aBh
+aBh
+aBh
+aBh
+aBh
+uet
 bOU
 ejz
 oGU
@@ -65940,11 +61159,11 @@ nxY
 coU
 coU
 xtV
-snd
-cgh
-snd
-oNj
-snd
+kjp
+hox
+ydI
+pHI
+tCZ
 edP
 oNj
 iiZ
@@ -65955,13 +61174,13 @@ bTz
 aFi
 nJu
 xtV
-ubp
-ima
-ubp
-ubp
-utC
-hgL
-pHI
+xtV
+mED
+xtV
+xtV
+xtV
+xtV
+xtV
 xtV
 coU
 coU
@@ -66056,17 +61275,17 @@ qbU
 qbU
 coU
 oGU
-mTV
-jCD
-hpw
-hpw
+nxJ
+aBh
+aBh
+aBh
 lCM
-hpw
+aBh
 mEc
 jim
-hpw
-bMK
-hpw
+aBh
+aBh
+aBh
 ltj
 idB
 hAQ
@@ -66075,17 +61294,17 @@ gjB
 upP
 coZ
 ttt
-hpw
-hpw
-aOH
-aOH
-lXN
+aBh
+aBh
+aBh
+aBh
+aBh
 etY
-kKX
-kKX
-lXN
-lXN
-dkE
+aBh
+aBh
+aBh
+aBh
+ejz
 oGU
 oGU
 oGU
@@ -66149,12 +61368,12 @@ nxY
 coU
 coU
 xtV
-aHN
-aHN
-aHN
-aHN
-aHN
-aHN
+kjp
+hgL
+hgL
+nrW
+xtV
+oNj
 oTT
 snd
 aHN
@@ -66163,14 +61382,14 @@ aHN
 aHN
 aHN
 aHN
-aHN
 xtV
-xtV
-xtV
-xtV
-xtV
-fLF
-fRD
+eHy
+vbn
+vHY
+wJm
+wJm
+wqX
+xhW
 xtV
 coU
 coU
@@ -66265,18 +61484,18 @@ qbU
 qbU
 coU
 idB
-mTV
-jCD
-hpw
+nxJ
+aBh
+aBh
 idB
 idB
 idB
 idB
 idB
 sXw
-bMK
-hpw
-hpw
+aBh
+aBh
+aBh
 coZ
 upP
 fdQ
@@ -66284,7 +61503,7 @@ oIt
 upP
 coZ
 bis
-hpw
+aBh
 ltj
 idB
 idB
@@ -66358,28 +61577,28 @@ nxY
 coU
 coU
 xtV
-xrC
-nld
-nPJ
-azg
-kLe
-aHN
-snd
+tWQ
+hgL
+pHI
+gFS
+xtV
+oNj
+oNj
 opq
 aHN
 gcp
-fyX
+fWQ
 rgT
 jmx
 fBt
-cGo
-aHN
-cUA
-rRO
+wZW
+tFv
+vbn
+tqb
 qPt
-qgn
-hgL
-utC
+vbn
+wqX
+gQn
 xtV
 coU
 coU
@@ -66474,27 +61693,27 @@ qbU
 qbU
 coU
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 sZr
 sZr
 idB
 idB
-bMK
-bMK
-hpw
+aBh
+aBh
+aBh
 ogw
 coZ
 idB
 idB
 coZ
 gbp
-nuy
+rBp
 huK
-hpw
+aBh
 idB
 idB
 sZr
@@ -66566,29 +61785,29 @@ nxY
 nxY
 coU
 coU
-tCZ
-uHr
-pMT
-oNj
+xtV
+lgv
+hgL
+hgL
 xTs
+szl
 oNj
-aHN
 kZp
-blC
+oNj
 hwy
 eAc
 oNj
 fmc
 oNj
 tPN
-snd
-aHN
-hoF
-dpI
-pHI
-utC
-hgL
-utC
+xtV
+eut
+wqX
+tqb
+vbn
+vbn
+hjc
+jnl
 xtV
 coU
 coU
@@ -66683,8 +61902,8 @@ qbU
 qbU
 coU
 idB
-hpw
-jCD
+aBh
+aBh
 eTv
 idB
 sZr
@@ -66693,17 +61912,17 @@ sZr
 idB
 idB
 idB
-bMK
-hpw
-hpw
-hpw
+aBh
+aBh
+aBh
+aBh
 jGH
 cGT
 bis
 lUG
-hAJ
+aRH
 msB
-hpw
+aBh
 idB
 idB
 coU
@@ -66775,29 +61994,29 @@ nxY
 nxY
 coU
 coU
-uHr
-uHr
-uHr
-pzz
+xtV
+jkv
+gid
+hgL
+czs
+xtV
+hyA
 oNj
-oNj
-aHN
-hOw
 oNj
 aHN
 myt
 fHd
-oNj
-bRP
-oNj
-snd
-aHN
-iAz
-sXz
-hgL
-hgL
-pHI
-hyA
+ppl
+qPV
+vZw
+tCZ
+kUs
+wqX
+tqb
+phk
+wqX
+fGF
+fkD
 xtV
 coU
 coU
@@ -66892,9 +62111,9 @@ sZr
 sZr
 sZr
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 oGU
@@ -66903,16 +62122,16 @@ sZr
 sZr
 idB
 idB
-hpw
-hpw
-hpw
+aBh
+aBh
+aBh
 huK
 cGT
-hka
-hpw
-jbf
-jbf
-hpw
+uet
+aBh
+aBh
+aBh
+aBh
 idB
 idB
 coU
@@ -66984,29 +62203,29 @@ nxY
 nxY
 coU
 coU
-uHr
-uHr
-uHr
-tIm
-rgT
-oNj
-aHN
-snd
-bRP
-aHN
-uOI
-jyM
-rgT
-bRP
-jpT
-kSE
-aHN
-iAz
-hgL
-dnC
-qjc
-rWf
-tnh
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+szl
+szl
+xtV
+xtV
+xtV
+vqZ
+xtL
+xtV
+xtV
+xtV
+xtV
+mED
+xtV
+nGW
+xtV
+xtV
 xtV
 coU
 coU
@@ -67101,9 +62320,9 @@ idB
 idB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 oGU
@@ -67112,16 +62331,16 @@ oGU
 sZr
 idB
 idB
-hpw
-hpw
-hpw
+aBh
+aBh
+aBh
 plV
 huK
 huK
-hpw
-hpw
-jFt
-cQc
+aBh
+aBh
+mqB
+mqB
 idB
 coU
 coU
@@ -67194,28 +62413,28 @@ nxY
 coU
 coU
 xtV
-tIm
-uHr
-tIm
-iHb
-qvg
-aHN
-pFf
-bRP
-aHN
-fBt
-pFf
-tPN
-oNj
-uOi
-qio
-aHN
-vsV
-jgj
-dpI
+iYP
+suV
+kSt
+mNF
+wtC
+wtC
 hgL
-kzu
-yhY
+hgL
+fZu
+wvJ
+tAF
+knp
+pHI
+dVv
+ssP
+hyA
+mOu
+bsR
+eFP
+wvJ
+vHs
+jjD
 xtV
 coU
 coU
@@ -67311,8 +62530,8 @@ rVv
 idB
 idB
 eTv
-jCD
-hpw
+aBh
+aBh
 idB
 sZr
 oGU
@@ -67403,28 +62622,28 @@ nxY
 coU
 coU
 xtV
-uep
-tIm
-mjb
-bRP
-bRP
-tQp
-bCY
-sNe
-aHN
-ftz
-oNj
-oNj
-xCX
-oNj
-dWp
-aHN
+umz
+hgL
 pHI
+hgL
+pJu
+hgL
+hgL
+ssP
+dnC
+hgL
+lrx
+hgL
+hgL
 pHI
-eCv
-wvi
-ssO
-wmo
+hgL
+xNJ
+pHI
+gUa
+hgL
+wvJ
+jjD
+axV
 xtV
 coU
 coU
@@ -67520,7 +62739,7 @@ jem
 idB
 idB
 jJt
-jCD
+aBh
 ckd
 idB
 sZr
@@ -67612,28 +62831,28 @@ nxY
 coU
 coU
 xtV
-aHN
-aHN
-aHN
-aHN
-aHN
-aHN
-oNj
-ucC
-aHN
-aHN
-szl
-aHN
-aHN
-aHN
-aHN
-aHN
-pAW
-ofK
-aHN
-aHN
-aHN
-kAK
+dyP
+pHI
+hgL
+hgL
+hdo
+pHI
+pnU
+sEk
+hgL
+aGn
+pHI
+hgL
+bmh
+hgL
+hgL
+hgL
+ikF
+ika
+hgL
+phC
+vJM
+yhY
 xtV
 qbU
 qbU
@@ -67728,9 +62947,9 @@ bCS
 hOe
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 oGU
@@ -67821,29 +63040,29 @@ nxY
 coU
 coU
 xtV
-dKT
-oNj
-nJu
-fvE
-oNj
-wsa
-bRP
-bRP
-oNj
-cZS
-eGQ
-qcp
-bvs
-snd
-oNj
-wsa
-oNj
-oNj
-aHN
-nMq
-iDM
+rEF
+pHI
+jnq
+dpI
 hgL
-xtV
+mWP
+rVZ
+pHI
+jXa
+sXz
+hgL
+hcu
+tyf
+dpI
+byy
+dnC
+hgL
+sEk
+hgL
+hgL
+jjD
+hgL
+uHr
 ugY
 euc
 hBa
@@ -67937,9 +63156,9 @@ nLz
 nLz
 hRI
 hRI
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 oGU
@@ -68030,29 +63249,29 @@ nxY
 coU
 coU
 xtV
-dyP
-oNj
-fHd
-bRP
-opq
-aHN
-mng
-oNj
-pfV
-oPF
-oNj
-hva
-nJu
-mUI
-oNj
-szl
-snd
-hcF
-aHN
-qts
+rEF
+pHI
 hgL
-ubp
-tCZ
+hgL
+qVz
+pHI
+ugr
+jnq
+reX
+qjc
+sEk
+hgL
+hdo
+pHI
+fcX
+jnq
+hgL
+dpI
+ssP
+umz
+vJM
+jjD
+uHr
 qbU
 qbU
 qbU
@@ -68146,9 +63365,9 @@ syA
 xHf
 idB
 erU
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 oGU
@@ -68239,28 +63458,28 @@ nxY
 coU
 coU
 xtV
-gia
-bRP
-oDU
-ybJ
-bRP
-aHN
-obJ
-aHN
-pve
-aHN
-aHN
-obJ
-aHN
-aHN
-aHN
-aHN
-snd
-qvg
-aHN
-nZp
-iDM
-eLD
+gHH
+hgL
+hgL
+kVv
+dpI
+hgL
+gHH
+wnh
+kQA
+xiC
+pBg
+stv
+hgL
+pBg
+xBs
+pHI
+hgL
+bqC
+gHH
+hgL
+gHH
+xiC
 xtV
 coU
 coU
@@ -68355,9 +63574,9 @@ qGy
 tjA
 idB
 nDu
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 oGU
@@ -68448,28 +63667,28 @@ nxY
 coU
 coU
 xtV
-fVt
-oNj
-ksu
-nuW
-bRP
-aHN
-pFf
-pmY
+gHH
+pHI
+gHH
+vEb
+pHI
+kQA
+lrL
+hgL
 vic
-ice
-aHN
-oNj
-ppl
-epY
-ice
-aHN
-sNe
-bRP
-aHN
-bCs
+pHI
+pHI
+dgV
+hQJ
+hgL
+vEb
+kQA
+gHH
 hgL
 hgL
+srt
+gLy
+gIS
 xtV
 coU
 coU
@@ -68564,9 +63783,9 @@ lOb
 oZS
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 sZr
@@ -68657,28 +63876,28 @@ nxY
 coU
 coU
 xtV
-kVt
-oNj
-aQr
-hQX
-opq
-hwy
-hOw
-jNt
-oNj
-kfH
-aHN
-fIb
-beH
-pFf
-kdd
-hwy
-oPF
-oNj
-aHN
-kAK
-vjc
-hjc
+nCC
+pHI
+hgL
+lrx
+ssP
+dpI
+pHI
+nGT
+pHI
+pHI
+iDM
+nuB
+dnC
+dnC
+hgL
+ouu
+exc
+ydI
+hXM
+scg
+ckM
+rww
 xtV
 qbU
 coU
@@ -68774,7 +63993,7 @@ idB
 idB
 idB
 qVL
-jCD
+aBh
 bis
 idB
 sZr
@@ -68866,28 +64085,28 @@ nxY
 coU
 coU
 xtV
-ebi
-oNj
-oNj
-bRP
-dnv
-aHN
-miU
-dTV
-osM
-cEA
-aHN
-oXO
-qvM
-ahL
-cEA
-aHN
-iey
-qGH
-oNj
-kEO
-oNj
-oNj
+kQA
+pHI
+kQA
+hgL
+bqC
+hgL
+hgL
+hJW
+hgL
+kXX
+ljm
+eLL
+kQA
+xiC
+wvJ
+pBg
+wvJ
+gHH
+gGm
+gHH
+gHH
+wvJ
 xtV
 qbU
 coU
@@ -68983,8 +64202,8 @@ idB
 sZr
 idB
 ttt
-jCD
-hpw
+aBh
+aBh
 idB
 sZr
 sZr
@@ -69075,28 +64294,28 @@ nxY
 coU
 coU
 xtV
-xtV
-xtV
-xtV
-mED
-mED
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-mED
-xtV
-xtV
-xtV
-xtV
-oel
-bRP
-snd
-hva
-vBH
-afk
+kQA
+hgL
+uDS
+bqC
+wvJ
+wvJ
+wvJ
+wvJ
+hgL
+gyo
+rBT
+gHH
+gHH
+fuq
+jsO
+wvJ
+wvJ
+jsO
+wvJ
+wvJ
+wvJ
+wvJ
 xtV
 qbU
 coU
@@ -69192,7 +64411,7 @@ idB
 sZr
 idB
 fWS
-dbo
+ttt
 ckd
 idB
 sZr
@@ -69284,28 +64503,28 @@ nxY
 coU
 coU
 xtV
-hnP
-oNj
-cMR
-dbi
-ctv
-hAV
-sNe
-cEZ
-tFS
-cLV
-oKr
-fXg
-ydw
-bRP
-bTz
-tQp
-bRP
-hva
-oNj
-bRP
-koI
-oNj
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+tCZ
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 xtV
 qbU
 coU
@@ -69401,12 +64620,12 @@ idB
 sZr
 idB
 bis
-dbo
-hpw
+ttt
+aBh
 idB
 idB
 aDV
-qzm
+wMW
 mFH
 nQk
 mFH
@@ -69492,31 +64711,31 @@ nxY
 nxY
 coU
 coU
-eci
-qzT
-kfS
-bRP
-oNj
-oNj
-xCX
-bRP
-bRP
-oNj
-oNj
-szl
-oNj
-crF
-oNj
-bRP
-cTi
-snd
-oNj
-thh
-snd
-bRP
-bwE
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -69610,8 +64829,8 @@ idB
 idB
 bsT
 ttt
-jCD
-hpw
+aBh
+aBh
 idB
 idB
 hym
@@ -69701,31 +64920,31 @@ nxY
 nxY
 coU
 coU
-xtV
-hOg
-kfS
-ceR
-pFf
-oNj
-oNj
-aho
-oNj
-xav
-oNj
-wsa
-bRP
-kNe
-oNj
-qvg
-xtV
-uhF
-snd
-oNj
-dbE
-bRP
-nBK
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -69818,9 +65037,9 @@ eGc
 wpC
 kVg
 kVg
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 idB
 rPC
@@ -69910,31 +65129,31 @@ nxY
 nxY
 coU
 coU
-xtV
-qHe
-kfS
-bRP
-jJO
-jJO
-jJO
-rCV
-jJO
-jJO
-pGP
-xtV
-jlf
-oNj
-bRP
-pRo
-xtV
-xRl
-mbY
-axL
-igW
-lPa
-fWQ
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -70027,9 +65246,9 @@ dwj
 idB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 idB
 xMK
@@ -70119,31 +65338,31 @@ nxY
 nxY
 coU
 coU
-tCZ
-qHe
-oNj
-riv
-xCX
-oNj
-oNj
-oNj
-oNj
-nhe
-opq
-tCZ
-ipS
-kaq
-bRP
-oNj
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -70236,8 +65455,8 @@ sHM
 idB
 sZr
 idB
-hpw
-jCD
+aBh
+aBh
 ckd
 dwm
 idB
@@ -70328,31 +65547,31 @@ nxY
 nxY
 coU
 coU
-tAf
-tyL
-oNj
-pXi
-pXi
-pXi
-xZn
-pXi
-pNG
-pXi
-xZn
-xtV
-amQ
-bRP
-uWM
-nlD
-xtV
-kBi
-pZG
-aIM
-aIM
-bly
-oWB
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -70445,9 +65664,9 @@ mgx
 idB
 sZr
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 mEc
 jim
 rPC
@@ -70537,31 +65756,31 @@ nxY
 nxY
 coU
 coU
-xtV
-vFk
-bRP
-pXi
-izA
-izA
-izA
-pXi
-oNj
-izA
-izA
-xtV
-ufW
-bRP
-bRP
-sdu
-cTi
-hgL
-hgL
-hgL
-hgL
-llF
-qhe
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -70654,9 +65873,9 @@ idB
 idB
 sZr
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 gTN
 dCV
 rPC
@@ -70746,31 +65965,31 @@ nxY
 nxY
 coU
 coU
-xtV
-ttU
-bRP
-pXi
-aWi
-izA
-izA
-pXi
-oNj
-oNj
-oNj
-xtV
-uhF
-oNj
-pMm
-bRP
-qJt
-aqy
-hgL
-hgL
-ces
-hgL
-aME
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -70863,9 +66082,9 @@ sZr
 sZr
 sZr
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 mEc
 jim
 rPC
@@ -70955,31 +66174,31 @@ nxY
 nxY
 coU
 coU
-xtV
-oNj
-lpc
-xmM
-jrF
-plG
-dzj
-pXi
-jrF
-woR
-vnE
-xtV
-aOF
-bRP
-pRo
-kts
-xtV
-lNk
-nYl
-lQj
-pAv
-sZH
-tTP
-xtV
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -71072,8 +66291,8 @@ qbU
 qbU
 coU
 idB
-hpw
-jCD
+aBh
+aBh
 ckd
 dwm
 idB
@@ -71164,30 +66383,30 @@ nxY
 nxY
 coU
 coU
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-pRo
-nxU
-xtV
-xtV
-mED
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -71281,8 +66500,8 @@ coU
 coU
 coU
 idB
-hpw
-jCD
+aBh
+aBh
 bis
 idB
 idB
@@ -71374,29 +66593,29 @@ nxY
 coU
 coU
 coU
-xtV
-ddc
-kPt
-kEX
-fqV
-xtV
-jgj
-lJy
-xTT
-uyY
-uea
-xtV
-oNj
-bRP
-xtV
-eHy
-vbn
-vHY
-wJm
-wJm
-wqX
-xhW
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -71490,9 +66709,9 @@ idB
 idB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 idB
 rPC
@@ -71583,29 +66802,29 @@ nxY
 coU
 coU
 coU
-tCZ
-dhV
-hgL
-pHI
-hYL
-xtV
-aXQ
-dHR
-fyp
-pHI
-vQG
-xtV
-hyw
-oNj
-wZW
-tFv
-vbn
-tqb
-wqX
-vbn
-wqX
-gQn
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -71700,8 +66919,8 @@ kHB
 idB
 idB
 eTv
-jCD
-hpw
+aBh
+aBh
 idB
 idB
 rPC
@@ -71792,29 +67011,29 @@ nxY
 coU
 coU
 coU
-xtV
-kjp
-hox
-ydI
-hgL
-tCZ
-hgL
-nAW
-hgL
-hgL
-fsd
-xtV
-snd
-oNj
-xtV
-eut
-wqX
-tqb
-vbn
-vbn
-vbn
-jnl
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -71908,9 +67127,9 @@ iUP
 kHB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 idB
 rPC
@@ -72001,29 +67220,29 @@ nxY
 coU
 coU
 coU
-xtV
-kjp
-hgL
-hgL
-hgL
-xtV
-ugC
-pHI
-cDT
-hgL
-iwU
-xtV
-laf
-hDc
-tCZ
-kUs
-wqX
-tqb
-phk
-wqX
-fGF
-fkD
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -72117,9 +67336,9 @@ cYx
 jiE
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 idB
 aDV
@@ -72210,29 +67429,29 @@ nxY
 coU
 coU
 coU
-xtV
-tWQ
-hgL
-pHI
-mqX
-xtV
-fQG
-jnq
-lrx
-hgL
-ima
-xtV
-szl
-xEH
-xtV
-xtV
-xtV
-mED
-xtV
-nGW
-xtV
-xtV
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -72326,9 +67545,9 @@ kHB
 kHB
 cDl
 euN
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 idB
@@ -72419,29 +67638,29 @@ nxY
 coU
 coU
 coU
-xtV
-lgv
-hgL
-hgL
-pHI
-szl
-oNj
-oNj
-bRP
-fET
-bRP
-hDc
-oNj
-oNj
-bRP
-cco
-dbE
-cqX
-bRP
-oNj
-bRP
-aOF
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -72536,7 +67755,7 @@ jiE
 idB
 idB
 jJt
-jCD
+aBh
 ckd
 idB
 sZr
@@ -72628,29 +67847,29 @@ nxY
 coU
 coU
 coU
-xtV
-jkv
-gid
-hgL
-pZG
-xtV
-laf
-sNe
-oNj
-oNj
-oNj
-bRP
-bRP
-snc
-qxH
-pRo
-mKd
-bTz
-bRP
-bRP
-xSJ
-lIh
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -72745,8 +67964,8 @@ kHB
 idB
 idB
 bis
-jCD
-hpw
+aBh
+aBh
 idB
 sZr
 idB
@@ -72837,29 +68056,29 @@ nxY
 coU
 coU
 coU
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-mED
-oNj
-bRP
-nlD
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -72954,8 +68173,8 @@ kHB
 idB
 idB
 bis
-jCD
-hpw
+aBh
+aBh
 idB
 sZr
 idB
@@ -73046,29 +68265,29 @@ nxY
 coU
 coU
 coU
-xtV
-bMw
-xCH
-fDD
-shr
-uao
-gyS
-xtV
-bRR
-srx
-bRP
-dup
-aOF
-bRP
-jfz
-gAf
-sHB
-syp
-jlL
-oNj
-oNj
-wdn
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -73162,9 +68381,9 @@ kHB
 qnU
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 idB
@@ -73255,34 +68474,34 @@ nxY
 coU
 coU
 coU
-xtV
-nle
-pHI
-pHI
-pHI
-cLU
-ydI
-xtV
-oNj
-kaq
-oNj
-aqi
-xav
-xcF
-bRP
-aWi
-oNj
-xav
-jlL
-oNj
-dbE
-rhr
-xtV
-bZw
-bZw
-bZw
-bZw
-bZw
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -73371,9 +68590,9 @@ kHB
 kHB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 idB
@@ -73464,34 +68683,34 @@ nxY
 coU
 coU
 coU
-tCZ
-rEF
-fQu
-hgL
-pHI
-pHI
-hgL
-cjK
-mng
-rdH
-oNj
-bTz
-bRP
-bRP
-wdn
-oNj
-bRP
-bRP
-jlL
-laf
-fsF
-nob
-xtV
-bZw
-wqu
-sjS
-sBI
-bZw
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -73580,9 +68799,9 @@ kHB
 kHB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 idB
@@ -73673,34 +68892,34 @@ nxY
 coU
 coU
 coU
-xtV
-nrW
-hgL
-hgL
-dnC
-hgL
-hgL
-xtV
-tQp
-qTm
-xtV
-oNj
-nPm
-mED
-sDd
-oNj
-bRP
-oNj
-bRP
-xav
-bRP
-fqQ
-xtV
-bZw
-sBI
-sBI
-sBI
-bZw
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -73789,9 +69008,9 @@ gPq
 idB
 idB
 idB
-hpw
-swp
-hpw
+aBh
+eTv
+aBh
 idB
 sZr
 idB
@@ -73882,34 +69101,34 @@ nxY
 coU
 coU
 coU
-eci
-gFS
-oJL
-hgL
-dpI
-iDM
-hgL
-blx
-ydI
-hgL
-uJW
-cam
-snd
-xtV
-oRj
-pRo
-oNj
-cZS
-jgN
-oNj
-xCX
-oRQ
-xtV
-bZw
-sBI
-kVE
-sBI
-bZw
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -73999,7 +69218,7 @@ dTd
 idB
 idB
 jJt
-jCD
+aBh
 ckd
 idB
 sZr
@@ -74091,34 +69310,34 @@ nxY
 coU
 coU
 coU
-xtV
-wEw
-pHI
-lrx
-hgL
-urD
-pHI
-iDM
-hgL
-hgL
-xtV
-hOw
-cLc
-xtV
-ngB
-bRP
-pky
-olN
-bRP
-bRP
-rAJ
-lMF
-xtV
-bZw
-ayt
-sBI
-sBI
-bZw
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -74207,9 +69426,9 @@ kHB
 kHB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 idB
@@ -74300,34 +69519,34 @@ nxY
 coU
 coU
 coU
-xtV
-czs
-hgL
-bam
-aVm
-hyA
-pHI
-vkM
-vkM
-vkM
-xtV
-oNj
-oNj
-tCZ
-uEi
-bRP
-kNe
-oNj
-oNj
-cEk
-heK
-lMF
-xtV
-bZw
-bZw
-bZw
-bZw
-bZw
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -74416,9 +69635,9 @@ pwy
 kHB
 idB
 idB
-hpw
-jCD
-hpw
+aBh
+aBh
+aBh
 idB
 sZr
 idB
@@ -74509,29 +69728,29 @@ nxY
 coU
 coU
 coU
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-vqZ
-xtL
-xtV
-uIZ
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -74625,9 +69844,9 @@ nKs
 kHB
 idB
 idB
-hpw
-swp
-hpw
+aBh
+eTv
+aBh
 idB
 sZr
 idB
@@ -74718,29 +69937,29 @@ nxY
 coU
 coU
 coU
-xtV
-iYP
-kSt
-mNF
-wtC
-wtC
-suV
-vZw
-fZu
-wvJ
-tAF
-knp
-pHI
-dVv
-ssP
-hyA
-mOu
-bsR
-eFP
-wvJ
-vHs
-jjD
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -74834,9 +70053,9 @@ iAT
 mfT
 idB
 idB
-hpw
-jCD
-mTV
+aBh
+aBh
+nxJ
 oGU
 sZr
 idB
@@ -74927,29 +70146,29 @@ nxY
 coU
 coU
 coU
-xtV
-umz
-pHI
-hgL
-pJu
-hgL
-hgL
-ssP
-dnC
-hgL
-lrx
-hgL
-hgL
-pHI
-hgL
-xNJ
-pHI
-gUa
-hgL
-wvJ
-jjD
-axV
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -75043,9 +70262,9 @@ idB
 idB
 idB
 idB
-hpw
-jCD
-mTV
+aBh
+aBh
+nxJ
 oGU
 sZr
 idB
@@ -75136,29 +70355,29 @@ nxY
 coU
 coU
 coU
-xtV
-vsV
-hgL
-hgL
-hdo
-pHI
-pnU
-sEk
-hgL
-aGn
-pHI
-hgL
-bmh
-hgL
-hgL
-hgL
-ikF
-ika
-hgL
-phC
-vJM
-yhY
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -75253,7 +70472,7 @@ coU
 coU
 idB
 jJt
-mrJ
+nxJ
 iiu
 oGU
 sZr
@@ -75345,29 +70564,29 @@ nxY
 coU
 coU
 coU
-xtV
-wvJ
-jnq
-dpI
-hgL
-mWP
-rVZ
-pHI
-jXa
-sXz
-hgL
-hcu
-tyf
-dpI
-byy
-dnC
-hgL
-sEk
-hgL
-xvh
-jjD
-hgL
-uHr
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -75461,8 +70680,8 @@ idB
 idB
 coU
 idB
-hpw
-mrJ
+aBh
+nxJ
 iiu
 oGU
 sZr
@@ -75554,29 +70773,29 @@ nxY
 coU
 coU
 coU
-mED
-jsO
-hgL
-hgL
-qVz
-pHI
-ugr
-jnq
-reX
-qjc
-sEk
-hgL
-hdo
-pHI
-fcX
-jnq
-hgL
-dpI
-ssP
-umz
-vJM
-jjD
-uHr
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -75670,8 +70889,8 @@ vjl
 idB
 coU
 idB
-hpw
-mrJ
+aBh
+nxJ
 iiu
 oGU
 sZr
@@ -75763,29 +70982,29 @@ nxY
 coU
 coU
 coU
-xtV
-gHH
-wvJ
-kVv
-ljm
-wvJ
-gHH
-wnh
-kQA
-xiC
-pBg
-stv
-llF
-pBg
-xBs
-jsO
-wvJ
-bqC
-gHH
-wvJ
-gHH
-xiC
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -75879,8 +71098,8 @@ clN
 idB
 coU
 idB
-hpw
-mrJ
+aBh
+nxJ
 iiu
 oGU
 sZr
@@ -75972,29 +71191,29 @@ nxY
 coU
 coU
 coU
-xtV
-vss
-gHH
-vEb
-jsO
-kQA
-lrL
-wvJ
-ljm
-jsO
-jsO
-dgV
-hQJ
-wvJ
-vEb
-kQA
-gHH
-wvJ
-wvJ
-srt
-gLy
-gIS
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -76088,7 +71307,7 @@ rUd
 idB
 coU
 idB
-thk
+aBh
 nxJ
 iiu
 oGU
@@ -76181,29 +71400,6 @@ nxY
 coU
 coU
 coU
-xtV
-nCC
-hgL
-lrx
-ssP
-dpI
-pHI
-nGT
-pHI
-pHI
-iDM
-nuB
-dnC
-dnC
-hgL
-ouu
-exc
-ydI
-hXM
-scg
-ckM
-rww
-xtV
 coU
 coU
 coU
@@ -76215,6 +71411,29 @@ coU
 coU
 coU
 coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 qbU
 qbU
 qbU
@@ -76287,6 +71506,7 @@ qbU
 qbU
 qbU
 coU
+idB
 idB
 idB
 idB
@@ -76294,12 +71514,11 @@ idB
 idB
 idB
 idB
-idB
 coU
 idB
-jCD
-hpw
-mTV
+aBh
+nxJ
+nxJ
 idB
 scc
 idB
@@ -76390,29 +71609,29 @@ nxY
 coU
 coU
 coU
-xtV
-kQA
-kQA
-wvJ
-bqC
-wvJ
-wvJ
-hJW
-hgL
-kXX
-ljm
-eLL
-kQA
-xiC
-wvJ
-pBg
-wvJ
-gHH
-gGm
-gHH
-gHH
-wvJ
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -76506,8 +71725,8 @@ coU
 coU
 coU
 idB
-saF
-nhS
+aBh
+aBh
 mex
 uaR
 lFo
@@ -76599,29 +71818,29 @@ nxY
 coU
 coU
 coU
-xtV
-kQA
-uDS
-bqC
-wvJ
-wvJ
-wvJ
-wvJ
-xvh
-gyo
-rBT
-gHH
-gHH
-fuq
-jsO
-wvJ
-wvJ
-jsO
-wvJ
-wvJ
-wvJ
-wvJ
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -76715,9 +71934,9 @@ qbU
 qbU
 coU
 oGU
-mTV
-hpw
-hpw
+nxJ
+aBh
+aBh
 idB
 scc
 idB
@@ -76808,29 +72027,29 @@ nxY
 coU
 coU
 coU
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-tCZ
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
-xtV
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -76925,8 +72144,8 @@ qbU
 coU
 oGU
 iiu
-mTV
-hpw
+nxJ
+aBh
 oGU
 coU
 oGU
@@ -116960,9 +112179,9 @@ xjR
 tAp
 tAp
 tAp
-mgk
+kVE
 eWk
-mgk
+pMT
 jGK
 tAp
 rHY
@@ -117381,7 +112600,7 @@ tAp
 kpT
 jtc
 nHb
-mgk
+pMT
 tAp
 rHY
 rHY
@@ -117590,15 +112809,15 @@ tAp
 ikD
 nHb
 oKx
-mgk
+pMT
 tAp
 rHY
 rHY
 rHY
-tAp
-tAp
-tAp
-tAp
+kAK
+kAK
+kAK
+kAK
 tAp
 tPs
 nHb
@@ -117608,9 +112827,9 @@ cJQ
 nHb
 adi
 tAp
-tAp
-tAp
-tAp
+kAK
+kAK
+kAK
 tAp
 ucq
 mLs
@@ -118005,7 +113224,7 @@ jeF
 epQ
 flU
 tAp
-mgk
+xEH
 cJQ
 cJQ
 cSa
@@ -118872,7 +114091,7 @@ unD
 uTy
 unD
 coa
-coa
+rHY
 coa
 aap
 uTy
@@ -119070,7 +114289,7 @@ oab
 nTI
 wpR
 tAp
-coa
+rHY
 coa
 qvn
 unD
@@ -119081,7 +114300,7 @@ uTy
 uTy
 wiC
 coa
-coa
+rHY
 coa
 sFk
 uTy
@@ -119279,7 +114498,7 @@ oab
 nTI
 nTI
 tAp
-coa
+rHY
 coa
 vyy
 unD
@@ -119290,7 +114509,7 @@ bAQ
 uBp
 unD
 coa
-coa
+rHY
 coa
 sFk
 uTy
@@ -119488,7 +114707,7 @@ oab
 jSr
 wpR
 tAp
-coa
+rHY
 coa
 vyy
 uBp
@@ -119499,7 +114718,7 @@ hwl
 uTy
 sRG
 coa
-coa
+rHY
 coa
 coa
 coa
@@ -119697,7 +114916,7 @@ qYn
 wpR
 utY
 tAp
-coa
+rHY
 coa
 vyy
 unD
@@ -119708,7 +114927,7 @@ uTy
 fUM
 unD
 coa
-coa
+rHY
 coa
 coa
 coa
@@ -119891,9 +115110,9 @@ nHb
 nHb
 jyY
 tAp
-tml
-tml
-tml
+rHY
+rHY
+rHY
 tAp
 fwG
 mgk
@@ -119906,7 +115125,7 @@ wpR
 utY
 wpR
 tAp
-coa
+rHY
 coa
 bgd
 unD
@@ -119917,7 +115136,7 @@ unD
 uTy
 unD
 coa
-coa
+rHY
 coa
 rHY
 rHY
@@ -120100,9 +115319,9 @@ nHb
 nHb
 oPJ
 tAp
-tml
-tml
-tml
+rHY
+rHY
+rHY
 tAp
 ajQ
 mgk
@@ -120115,7 +115334,7 @@ npR
 npR
 qOl
 tAp
-coa
+rHY
 coa
 bgd
 sMl
@@ -120126,7 +115345,7 @@ oEI
 oEI
 oEI
 coa
-coa
+rHY
 rHY
 rHY
 rHY
@@ -120309,9 +115528,9 @@ nHb
 nHb
 hHO
 tAp
-tml
-tml
-tml
+rHY
+rHY
+rHY
 tAp
 exl
 mgk
@@ -120324,6 +115543,7 @@ tAp
 tAp
 tAp
 tAp
+rHY
 coa
 coa
 coa
@@ -120334,8 +115554,7 @@ coa
 coa
 coa
 coa
-coa
-coa
+rHY
 rHY
 rHY
 rHY
@@ -120518,9 +115737,9 @@ nHb
 tQZ
 oPJ
 tAp
-tml
-tml
-tml
+rHY
+rHY
+rHY
 tAp
 elL
 mgk
@@ -120529,21 +115748,21 @@ cZG
 ttR
 sep
 tAp
-tml
-tml
-tml
-tml
-tml
-coa
-coa
-coa
-coa
-coa
-coa
-coa
-coa
-coa
-coa
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
 rHY
 rHY
 rHY
@@ -120727,9 +115946,9 @@ tAp
 tAp
 tAp
 tAp
-tml
-tml
-tml
+rHY
+rHY
+rHY
 tAp
 tAp
 tAp
@@ -120738,21 +115957,21 @@ tAp
 tAp
 tAp
 tAp
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
-tml
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
+rHY
 rHY
 rHY
 rHY

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -842,12 +842,6 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
-"aHN" = (
-/turf/simulated/wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "aHX" = (
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -8147,14 +8141,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"fZu" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "fZK" = (
 /obj/machinery/papershredder,
 /obj/item/oddity/common/paper_bundle,
@@ -10286,13 +10272,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
-"hwy" = (
-/obj/structure/sign/faction/excelsior_old,
-/turf/simulated/wall,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "hwD" = (
 /obj/item/trash/tray,
 /obj/random/traps,
@@ -11845,13 +11824,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"izA" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "izC" = (
 /obj/structure/lift/button{
 	icon_state = "button_fire";
@@ -20760,13 +20732,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"oTT" = (
-/obj/structure/flora/pottedplant/redshoot,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "oUc" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -21450,9 +21415,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "ptw" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
+/obj/structure/flora/pottedplant/redshoot,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pty" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -25145,15 +25113,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rVZ" = (
-/obj/item/trash/material/metal,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "rWg" = (
 /obj/structure/morgue{
 	dir = 1
@@ -27381,7 +27340,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -28263,13 +28221,6 @@
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/greengrid,
 /area/nadezhda/dungeon/outside/prepper/delta)
-"ugr" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "ugx" = (
 /obj/structure/table,
 /obj/item/stack/material/wood/random,
@@ -28784,11 +28735,6 @@
 /obj/structure/railing/grey,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"uCn" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "uCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures,
@@ -33465,14 +33411,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"xZn" = (
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/nadezhda/dungeon/outside/prepper/vault{
-	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
-	name = "Abandoned Bunker"
-	})
 "xZx" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -56156,7 +56094,7 @@ dpk
 dpk
 iET
 uVX
-uCn
+dpk
 dpk
 dpk
 qbU
@@ -57195,8 +57133,8 @@ qbU
 qbU
 tnz
 dpk
-ptw
-ptw
+uVX
+uVX
 baC
 iFU
 qbU
@@ -57822,12 +57760,12 @@ qbU
 qbU
 qbU
 qbU
-mNA
+rKz
 lEJ
 kcL
 iFU
 iFU
-mNA
+rKz
 coU
 coU
 coU
@@ -58031,12 +57969,12 @@ coU
 coU
 coU
 coU
-hwy
+tCZ
 oSA
 gBK
 tun
 gkh
-hwy
+tCZ
 coU
 coU
 coU
@@ -58240,12 +58178,12 @@ xtV
 xtV
 xtV
 xtV
-aHN
+xtV
 pdh
 kfA
 kfA
 pdh
-aHN
+xtV
 xtV
 xtV
 xtV
@@ -59093,7 +59031,7 @@ riv
 xCX
 oNj
 oNj
-hyA
+oNj
 xtV
 coU
 coU
@@ -59301,7 +59239,7 @@ oNj
 pXi
 pXi
 pXi
-xZn
+pXi
 pXi
 xtV
 coU
@@ -59493,7 +59431,7 @@ xtV
 aHK
 fTh
 hox
-hyA
+hgL
 nZN
 vPo
 lXM
@@ -59508,9 +59446,9 @@ xtV
 vFk
 bRP
 pXi
-izA
-izA
-izA
+oNj
+oNj
+oNj
 pXi
 xtV
 coU
@@ -59718,8 +59656,8 @@ ttU
 bRP
 pXi
 aWi
-izA
-izA
+oNj
+oNj
 oNj
 xtV
 coU
@@ -60326,7 +60264,7 @@ nxY
 coU
 coU
 xtV
-aHN
+xtV
 szl
 wsa
 xtV
@@ -60765,7 +60703,7 @@ ape
 snd
 oNj
 oNj
-hyA
+oNj
 xtV
 coU
 coU
@@ -61377,14 +61315,14 @@ hgL
 nrW
 xtV
 oNj
-oTT
+oNj
 snd
-aHN
-aHN
-aHN
-aHN
-aHN
-aHN
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 xtV
 eHy
 vbn
@@ -61588,7 +61526,7 @@ xtV
 oNj
 oNj
 opq
-aHN
+xtV
 gcp
 fWQ
 rgT
@@ -61797,7 +61735,7 @@ xtV
 oNj
 kZp
 oNj
-hwy
+tCZ
 eAc
 oNj
 fmc
@@ -62003,10 +61941,10 @@ gid
 hgL
 czs
 xtV
-hyA
+ptw
 oNj
 oNj
-aHN
+xtV
 myt
 fHd
 ppl
@@ -62424,7 +62362,7 @@ wtC
 wtC
 hgL
 hgL
-fZu
+pHI
 wvJ
 tAF
 knp
@@ -63049,7 +62987,7 @@ jnq
 dpI
 hgL
 mWP
-rVZ
+byy
 pHI
 jXa
 sXz
@@ -63258,7 +63196,7 @@ hgL
 hgL
 qVz
 pHI
-ugr
+hgL
 jnq
 reX
 qjc


### PR DESCRIPTION
Commie Bunker in the underground has been cut in half with size
Lima-09 Has been shrinked

Deletes **many** decals in ruins and replaces them with maints flooring
Lockers now on spawn dont populate contents, rather any interactions with them will do so now, this should reduce item amounts by a lot

Removes some walls from zoo and gives zoo more loot in the old viro lab