### PR TITLE
adds empty implant case to loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/general.dm
+++ b/code/modules/client/preference_setup/loadout/lists/general.dm
@@ -80,6 +80,11 @@
 	path = /obj/item/implanter
 	cost = 0
 
+/datum/gear/implantcase
+	display_name = "implant case"
+	path = /obj/item/implantcase
+	cost = 0
+
 /datum/gear/implant_tracking
 	display_name = "implant (tracking)"
 	path = /obj/item/implant/tracking


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this adds an empty glass case to the loadout so you have something to put your implants in. previously, you could spawn with 3 generic implants, an implanter and a tracking implant on top of that, but not the case. enjoy your gimmicks without having to hunt a vendor down
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	


## Changelog
:cl:
add: empty implant case in loadout selection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
