### PR TITLE
adds shoulderboards & patches to loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -137,10 +137,10 @@
 /datum/gear/accessory/blackshieldpatch/New()
 	..()
 	var/patches = list(
-		"blackshield patch"		=	/obj/item/clothing/accessory/patches/blackshield,
-		"blackshield blank patch"	=	/obj/item/clothing/accessory/patches/blackshield_blank,
+		"blackshield patch"				=	/obj/item/clothing/accessory/patches/blackshield,
+		"blackshield blank patch"		=	/obj/item/clothing/accessory/patches/blackshield_blank,
 		"blackshield volunteer patch"	=	/obj/item/clothing/accessory/patches/blackshield_volunteer,
-		"blackshield trooper patch"	=	/obj/item/clothing/accessory/patches/blackshield_trooper,
+		"blackshield trooper patch"		=	/obj/item/clothing/accessory/patches/blackshield_trooper,
 		"blackshield corpsman patch"	=	/obj/item/clothing/accessory/patches/blackshield_corpsman,
 		"blackshield sergeant patch"	=	/obj/item/clothing/accessory/patches/blackshield_sergeant,
 		"blackshield commander patch"	=	/obj/item/clothing/accessory/patches/blackshield_commander,

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -130,8 +130,22 @@
 	flags = GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/accessory/blackshieldpatch
-	display_name = "blackshield arm patch"
-	path = /obj/item/clothing/accessory/patches/blackshield
+	display_name = "blackshield patch selection"
+	description = "A selection of Blackshield patches."
+	path = /obj/item/clothing/accessory/patches
+
+/datum/gear/accessory/blackshieldpatch/New()
+	..()
+	var/patches = list(
+		"blackshield patch"		=	/obj/item/clothing/accessory/patches/blackshield,
+		"blackshield blank patch"	=	/obj/item/clothing/accessory/patches/blackshield_blank,
+		"blackshield volunteer patch"	=	/obj/item/clothing/accessory/patches/blackshield_volunteer,
+		"blackshield trooper patch"	=	/obj/item/clothing/accessory/patches/blackshield_trooper,
+		"blackshield corpsman patch"	=	/obj/item/clothing/accessory/patches/blackshield_corpsman,
+		"blackshield sergeant patch"	=	/obj/item/clothing/accessory/patches/blackshield_sergeant,
+		"blackshield commander patch"	=	/obj/item/clothing/accessory/patches/blackshield_commander,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(patches)
 
 /datum/gear/accessory/pilotharness
 	display_name = "pilot harness"

--- a/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
@@ -122,7 +122,7 @@
 /datum/gear/factionblackshield/shoulderboardselection/New()
 	..()
 	var/shoulderboards = list(
-		"blank shoulderboards"			=	/obj/item/clothing/accessory/ranks/blank
+		"blank shoulderboards"			=	/obj/item/clothing/accessory/ranks/blank,
 		"trooper shoulderboards"		=	/obj/item/clothing/accessory/ranks/trooper,
 		"corpsman shoulderboards"		=	/obj/item/clothing/accessory/ranks/corpsman,
 		"sergeant shoulderboards"		=	/obj/item/clothing/accessory/ranks/sergeant,

--- a/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
@@ -122,10 +122,10 @@
 /datum/gear/factionblackshield/shoulderboardselection/New()
 	..()
 	var/shoulderboards = list(
-		"trooper shoulderboards"		=	/obj/item/clothing/accessory/ranks/trooper
-		"corpsman shoulderboards"		=	/obj/item/clothing/accessory/ranks/corpsman
-		"sergeant shoulderboards"		=	/obj/item/clothing/accessory/ranks/sergeant
-		"commander shoulderboards"		=	/obj/item/clothing/accessory/ranks/commander
+		"trooper shoulderboards"		=	/obj/item/clothing/accessory/ranks/trooper,
+		"corpsman shoulderboards"		=	/obj/item/clothing/accessory/ranks/corpsman,
+		"sergeant shoulderboards"		=	/obj/item/clothing/accessory/ranks/sergeant,
+		"commander shoulderboards"		=	/obj/item/clothing/accessory/ranks/commander,
 	)
 	gear_tweaks += new /datum/gear_tweak/path(shoulderboards)
 

--- a/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
@@ -117,11 +117,12 @@
 
 /datum/gear/factionblackshield/shoulderboardselection
 	display_name = "shoulderboard selection"
-	path = /obj/item/clothing/accessory/ranks
+	path = /obj/item/clothing/accessory/ranks/blank
 
 /datum/gear/factionblackshield/shoulderboardselection/New()
 	..()
 	var/shoulderboards = list(
+		"blank shoulderboards"			=	/obj/item/clothing/accessory/ranks/blank
 		"trooper shoulderboards"		=	/obj/item/clothing/accessory/ranks/trooper,
 		"corpsman shoulderboards"		=	/obj/item/clothing/accessory/ranks/corpsman,
 		"sergeant shoulderboards"		=	/obj/item/clothing/accessory/ranks/sergeant,

--- a/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
@@ -117,7 +117,7 @@
 
 /datum/gear/factionblackshield/shoulderboardselection
 	display_name = "shoulderboard selection"
-	description = "A selection of Blackshield shoulderboards.
+	description = "A selection of Blackshield shoulderboards."
 	path = /obj/item/clothing/accessory/ranks
 
 /datum/gear/factionblackshield/shoulderboardselection/New()

--- a/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
@@ -115,6 +115,20 @@
 	path = /obj/item/clothing/head/rank/fatigue/
 	flags = GEAR_HAS_TYPE_SELECTION
 
+/datum/gear/factionblackshield/shoulderboardselection
+	display_name = "shoulderboard selection"
+	path = /obj/item/clothing/accessory/ranks
+
+/datum/gear/factionblackshield/shoulderboardselection/New()
+	..()
+	var/shoulderboards = list(
+		"trooper shoulderboards"		=	/obj/item/clothing/accessory/ranks/trooper
+		"corpsman shoulderboards"		=	/obj/item/clothing/accessory/ranks/corpsman
+		"sergeant shoulderboards"		=	/obj/item/clothing/accessory/ranks/sergeant
+		"commander shoulderboards"		=	/obj/item/clothing/accessory/ranks/commander
+	)
+	gear_tweaks += new /datum/gear_tweak/path(shoulderboards)
+
 /datum/gear/factionblackshield/blackshieldbackpack
 	display_name = "green blackshield backpack"
 	path = /obj/item/storage/backpack/militia/green

--- a/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionblackshield.dm
@@ -117,7 +117,8 @@
 
 /datum/gear/factionblackshield/shoulderboardselection
 	display_name = "shoulderboard selection"
-	path = /obj/item/clothing/accessory/ranks/blank
+	description = "A selection of Blackshield shoulderboards.
+	path = /obj/item/clothing/accessory/ranks
 
 /datum/gear/factionblackshield/shoulderboardselection/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this adds shoulderboards to the blackshield loadout selection screen. they go:
- blank (cadet/volunteer)
- trooper
- corpsman
- sergeant
- commander

i have left out the larp ranks like sergeant major and major. During testing it came to my attention that the sprites are mid, but now that they're available regularly maybe they can be improved at some point. Have fun looking sharp the 1 time per year you need to use your dress uniform #Blackshield #Human #SpriteQueen #Diva #Tea

i have also added a selection of proper blackshield patches, each with their own sprite (mob sprites soonTM), to the general accessories setup. anyone can use them as they can with the normal blackshield patch, shouldn't be any different. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	


## Changelog
:cl:
add: shoulderboards added to loadout selection
add: more patches in accessories loadout selection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
