### PR TITLE
Church fixes and flavour rephrasing

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -62,7 +62,7 @@
 	name = "halberd"
 	desc = "This weapon of ancient design appears to be a spear-axe hybrid. \
 	It saw a lot of use back in the Dark Ages back on Earth - in more recent times, sablekyne hunters use a similar weapon \
-	on their homeworlds, the weapons practical use taking down huge and heavily armored wildlife lead to the church adopting its own design."
+	on their homeworlds, the weapon's practical use in taking down huge and heavily armored wildlife lead to the church adopting its own design."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_halberd"
 	item_state = "nt_halberd"
@@ -79,7 +79,7 @@
 
 /obj/item/tool/sword/nt/scourge
 	name = "scourge"
-	desc = "A saintly looking scourge, extreme punishment in handheld form. Can be extended to hurt more. \
+	desc = "A saintly looking whip sword, extreme punishment in handheld form. Can be extended to inflict even more pain. \
 	It bears a tau cross marking it as produced by the Church of Absolute's New Testament weapons division."
 	icon_state = "nt_scourge"
 	item_state = "nt_scourge"
@@ -137,8 +137,8 @@
 
 /obj/item/tool/sword/nt/spear
 	name = "spear"
-	desc = "A saint looking short spear, designed for use with a shield or as a throwing weapon. \
-	The spear-tip usually breaks after being thrown at a target, but it can be hammered into shape again."
+	desc = "A saintly looking short spear to be used with a shield. It's even deadlier when thrown. \
+	The tip usually breaks after being thrown at a target. Can be hammered into shape again."
 	icon_state = "nt_spear"
 	item_state = "nt_spear"
 	wielded_icon = "nt_spear_wielded"
@@ -239,7 +239,7 @@
 	icon_state = "nt_warhammer"
 	item_state = "nt_warhammer"
 	wielded_icon = "nt_warhammer_wielded"
-	force = WEAPON_FORCE_BRUTAL - 3 //Naturally weaker do to knockbacking are targets (can stun lock)
+	force = WEAPON_FORCE_BRUTAL - 3 //Naturally weaker due to knocking back targets (can stun lock)
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	armor_divisor = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_BULKY
@@ -261,7 +261,7 @@
 
 /obj/item/tool/sword/nt/power
 	name = "\"Vexilar\" forceblade"
-	desc = "A hefty greatsword with golden wiring embedded into its handle and blade, designed to channel the power of a cruciform to project an ultra-sharp energy blade. \
+	desc = "A sleek and heavy bastard-sword with golden wiring embedded into its handle and blade, designed to channel the power of a cruciform to project an ultra-sharp energy blade. \
 	It bears a tau cross marking it as produced by the Church of Absolute's New Testament weapons division."
 	icon_state = "nt_force"
 	item_state = "nt_force"
@@ -317,10 +317,10 @@
 		return heat
 
 /obj/item/shield/riot/nt
-	name = "shield"
-	desc = "A saintly looking shield, let the God protect you. \
+	name = "NT Greatshield"
+	desc = "A saintly looking shield, let the Absolute protect you. \
 	It bears a tau cross marking it as produced by the Church of Absolute's New Testament weapons division. \
-	Has several leather straps on the back to hold melee weapons."
+	Has several leather straps on the inside to hold melee weapons."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_shield"
 	item_state = "nt_shield"
@@ -392,7 +392,7 @@
 
 /obj/item/shield/buckler/nt
 	name = "NT Parma"
-	desc = "A round shield with a golden trim. Has several biomatter-leather straps on the back to hold melee weapons."
+	desc = "A round shield with a golden trim. Has several biomatter-leather straps on the inside to hold melee weapons."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_buckler" //by CeUvi we thx thy
 	item_state = "nt_buckler"
@@ -407,7 +407,7 @@
 	var/max_w_class = ITEM_SIZE_HUGE
 	var/list/can_hold = list(
 		/obj/item/tool/sword/nt/shortsword,
-		/obj/item/tool/sword/nt/spear, //Romans would have these with their shield to ware down their foe
+		/obj/item/tool/sword/nt/spear, //Romans would have these with their shield to wear down their foe // Storing your spears and throwing them like a pilum is viable with this
 		/obj/item/tool/knife/dagger/nt,
 		/obj/item/tool/knife/neotritual,
 		/obj/item/book/ritual/cruciform,
@@ -459,13 +459,16 @@
 	force = WEAPON_FORCE_LETHAL
 	armor_divisor = ARMOR_PEN_HALF
 	matter = list(MATERIAL_DURASTEEL = 25, MATERIAL_GOLD = 3)
+	tool_qualities = list(QUALITY_CUTTING = 10, QUALITY_SAWING = 10)
+	effective_faction = list("psi_monster", "hive") // The Vexilar Forceblade has this quality and since crusaders are usually only called against a hivemind, the sword should reflect that
+	damage_mult = 1.2 //20% damage buff when purging the ABOMINATION
 	price_tag = 10000
 
 //Throwables
 
 /obj/item/stack/thrown/nt
 	name = "Faithful Throwing knife"
-	desc = "A saintly-looking sword forged to do God\'s distant work."
+	desc = "A saintly-looking knife delivering the Absolute's word over distance."
 	icon_state = "nt_shortsword"
 	item_state = "nt_shortsword"
 	force = WEAPON_FORCE_DANGEROUS

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -940,7 +940,7 @@
 		if(choice == "prime saint")
 			flags_inv = HIDEEARS
 		else
-			flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|
+			flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
 		to_chat(M, "You adjusted your helmet's style into [choice] mode.")
 		update_icon()
 		update_wear_icon()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -940,7 +940,7 @@
 		if(choice == "prime saint")
 			flags_inv = HIDEEARS
 		else
-			flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
+			flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|
 		to_chat(M, "You adjusted your helmet's style into [choice] mode.")
 		update_icon()
 		update_wear_icon()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -637,7 +637,7 @@
 //Church
 /obj/item/clothing/head/helmet/botanist
 	name = "botanist hood"
-	desc = "Don't want anything getting in your eyes."
+	desc = "Design frequently used by hydroponicists and floral caretakers of New Byzantine. Protection is paramount when working with dangerous plants."
 	icon_state = "botanist"
 	action_button_name = "Toggle Helmet Light"
 	light_overlay = "helmet_light"
@@ -674,7 +674,7 @@
 
 /obj/item/clothing/head/helmet/acolyte
 	name = "vector hood"
-	desc = "Even the most devout deserve head protection."
+	desc = "Helmet for every faithful of the Absolute. Even the most devout need protection."
 	icon_state = "acolyte"
 	action_button_name = "Toggle Helmet Light"
 	light_overlay = "helmet_light"
@@ -725,7 +725,7 @@
 
 /obj/item/clothing/head/helmet/path/divisor
 	name = "Divisor Plate Greathelm"
-	desc = "An great helm with large red wings with latin engravings that lets it know the user is an enlightened Vector with it's vibrant colours."
+	desc = "A greathelm with latin engravings that let everyone know the user is an enlightened Divisor, sworn protector and soldier."
 	icon_state = "divisor_plate_greathelm"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 
@@ -783,7 +783,7 @@
 
 /obj/item/clothing/head/helmet/path/lemniscate
 	name = "Lemniscate Hat"
-	desc = "The incredibly wide hat of Lemniscates only ensures it's fanciness- at it is the biggest among the other hats there is, this design follows the need to prevent sunburns while staying well suited on the head. There is the presence of inner layer of chain-mail and an slim, yet sturdy bowl-like amount of steel protecting the skull, hidden under the layers of smooth silk."
+	desc = "The incredibly wide hat of Lemniscates exude radiance as it is the biggest amongst hats there is. The design ensures a comfortable fit along with the prevention of sunburn. Hidden beneath the smooth silk of the hat is a layer of chainmail."
 	icon_state = "lemniscate_hat"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 
@@ -813,7 +813,7 @@
 
 /obj/item/clothing/head/helmet/path/monomial
 	name = "Monomial Kabuto"
-	desc = "An old helmet piece with minor plates overlapping and keeping the skull of it's user completely secure from damage. It allows attacks to glance down and spread the impact across the entire helmet instead of only one point, providing the capacity of survival of whoever keeps it on it's head."
+	desc = "An archaic helmet design with minor overlapping plates, keeping the skull of it's user mostly safe from damage. It disperses the impact of an attack across the entire helmet instead of only one point, adding to the survival of the wearer."
 	icon_state = "monomial_kabuto"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 
@@ -842,7 +842,7 @@
 
 /obj/item/clothing/head/helmet/path/factorial
 	name = "Factorial Powerhood"
-	desc = "An indespensable headwear of any combat behicle operator, well used by the mechanics who served under the banner of the New Byzantine and even to this day, it's design is used for pilots."
+	desc = "An indespensable headwear of any combat vehicle operator, mostly used by the mechanics and factorials who served under the banner of New Byzantine. Even to this day the design is used by absolutist pilots."
 	icon_state = "factorial_powerhood"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 
@@ -871,7 +871,7 @@
 
 /obj/item/clothing/head/helmet/rosaria
 	name = "rosaria great helm"
-	desc = "The rosaria protects. Deus Vult."
+	desc = "The rosaria protects. The Absolute wills it!"
 	icon_state = "rosaria_helm"
 	action_button_name = "Toggle Helmet Light"
 	light_overlay = "helmet_light"
@@ -906,7 +906,7 @@
 
 /obj/item/clothing/head/helmet/prime
 	name = "prime hood"
-	desc = "A visored helmet with a cloth hood covering it."
+	desc = "A visored helmet with a cloth hood covering it. The craftsmanship and decorations are only fit for a Prime of the Absolute"
 	icon_state = "prime"
 	action_button_name = "Toggle Helmet Light"
 	light_overlay = "helmet_light"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -783,7 +783,7 @@
 
 /obj/item/clothing/head/helmet/path/lemniscate
 	name = "Lemniscate Hat"
-	desc = "The incredibly wide hat of Lemniscates exude radiance as it is the biggest amongst hats there is. The design ensures a comfortable fit along with the prevention of sunburn. Hidden beneath the smooth silk of the hat is a layer of chainmail."
+	desc = "The incredibly wide hat of Lemniscates exudes radiance as it is the biggest amongst hats there is. The design ensures a comfortable fit along with the prevention of sunburn. Hidden beneath the smooth silk of the hat is a layer of chainmail."
 	icon_state = "lemniscate_hat"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -813,7 +813,7 @@
 
 /obj/item/clothing/head/helmet/path/monomial
 	name = "Monomial Kabuto"
-	desc = "An archaic helmet design with minor overlapping plates, keeping the skull of it's user mostly safe from damage. It disperses the impact of an attack across the entire helmet instead of only one point, adding to the survival of the wearer."
+	desc = "An archaic helmet design with small overlapping plates, keeping the skull of its user mostly safe from damage. It disperses the impact of an attack across the entire helmet instead of only one point, adding to the survival of the wearer."
 	icon_state = "monomial_kabuto"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -65,7 +65,7 @@
 
 /obj/item/clothing/head/preacher
 	name = "preacher hat"
-	desc = "Useful for hiding disdainful eyes from the godless masses."
+	desc = "A Prime's headdress that comes in many forms. It also serves to hide their distain for the faithless."
 	armor_list = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 100, rad = 0)
 	icon_state = "church_hat"
 
@@ -515,7 +515,7 @@ obj/item/clothing/head/beret/syndicate/verb/toggle_style()
 
 /obj/item/clothing/head/rank/divisor
 	name = "divisor cap"
-	desc = "A styled black divisor cap for showing everyone you are so steadfast in the name of god you don't need a helmet."
+	desc = "A black divisor cap for leisure. Who needs protection if the Absolute is your shield?"
 	icon_state = "divisor_cap"
 	item_state = "divisor_cap"
 

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -20,12 +20,12 @@
 /obj/item/clothing/head/laurel/silver
 	name = "silver Laurel wreath"
 	icon_state = "laurel_s"
-	desc = "A round wreath made of connected branches and leaves of the bay laurel. This one appears to be formed  silver."
+	desc = "A round silver wreath made of connected branches and leaves of the bay laurel."
 
 /obj/item/clothing/head/laurel/gold
 	name = "golden Laurel wreath"
 	icon_state = "laurel_g"
-	desc = "A round wreath made of connected branches and leaves of the bay laurel. This one appears to be formed of gold."
+	desc = "A round gold wreath made of connected branches and leaves of the bay laurel."
 
 /obj/item/clothing/head/hairflower
 	name = "red flower pin"
@@ -363,7 +363,7 @@ obj/item/clothing/head/ribbon/red
 /obj/item/clothing/head/leather_hat
 	name = "leather hat"
 	icon_state = "field_numerical_hat"
-	desc = "A tall hat for followers of the faith. Can be turned inside out to turn from red to purple or vice versa"
+	desc = "A hat for followers of the faith. Can be turned inside out to turn from red to purple or vice versa"
 	armor_list = list( //same as the garb
 		melee = 2,
 		bullet = 0,

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -52,7 +52,7 @@
 	options["Aquatic Welding"] = "norah_briggs_1"
 	options["Rustic Welding"] = "yuki_matsuda_1"
 	options["Flame Welding"] = "alice_mccrea_1"
-	options["Technomancer Welding"] = "engiewelding"
+	options["Artificer Welding"] = "engiewelding"
 
 	var/choice = input(M,"What kind of style do you want?","Adjust Style") as null|anything in options
 

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -137,7 +137,7 @@
 		)
 
 /obj/item/clothing/head/welding/technomancer
-	name = "technomancer welding helmet"
+	name = "artificer welding helmet"
 	desc = "A welding helmet painted in artificer guild colors."
 	icon_state = "engiewelding"
 	item_state_slots = list(

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -195,7 +195,7 @@
 
 /obj/item/clothing/mask/gas/germanmask
 	name = "church gas mask"
-	desc = "A close-fitting tactical mask that can be connected to an air supply. This one bears a small tau cross, noting it as a church branded design."
+	desc = "A close-fitting tactical mask that can be connected to an air supply. This one bears a small tau cross, denoting it as a church branded design."
 	icon_state = "germangasmask"
 	siemens_coefficient = 0.7
 	price_tag = 50

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -195,7 +195,7 @@
 
 /obj/item/clothing/mask/gas/germanmask
 	name = "church gas mask"
-	desc = "A close-fitting tactical mask that can be connected to an air supply. Best for when you need to get out of here. This one bears a small tau cross, noting it as a church branded design."
+	desc = "A close-fitting tactical mask that can be connected to an air supply. This one bears a small tau cross, noting it as a church branded design."
 	icon_state = "germangasmask"
 	siemens_coefficient = 0.7
 	price_tag = 50

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -117,7 +117,7 @@
 
 /obj/item/clothing/shoes/hermes_shoes
 	name = "Hermes Boots"
-	desc = "Boots used by the faithful to spread the word of God more affectively with bulky items by small hidden wheels under the heels. Sadly not all that good at protecting your feet as other more robust boots."
+	desc = "Boots used by the faithful to spread the word of the Absolute more effectively by having hidden small wheels in the soles. Sadly not all that good at protecting your feet as other more robust boots."
 	armor_list = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GOLD = 2)
 	icon_state = "hermes"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -117,7 +117,7 @@
 
 /obj/item/clothing/shoes/hermes_shoes
 	name = "Hermes Boots"
-	desc = "Boots used by the faithful to spread the word of the Absolute more effectively by having hidden small wheels in the soles. Sadly not all that good at protecting your feet as other more robust boots."
+	desc = "Boots used by the faithful to spread the word of the Absolute more effectively by having hidden small wheels under the heel. Sadly not all that good at protecting your feet as other more robust boots."
 	armor_list = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GOLD = 2)
 	icon_state = "hermes"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -585,7 +585,7 @@
 
 /obj/item/clothing/suit/armor/vest/prime
 	name = "prime armor"
-	desc = "The Armor of a Prime, adorned with different markings and decorations only fit for the most devout."
+	desc = "The armor of a Prime, adorned with different markings and decorations only fit for the most devout."
 	icon_state = "prime"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -328,7 +328,7 @@
 
 /obj/item/clothing/suit/armor/vest/acolyte
 	name = "vector armor"
-	desc = "Worn, heavy, steadfast in the name of God."
+	desc = "Worn, heavy, steadfast in the name of the Absolute."
 	icon_state = "acolyte"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
@@ -370,7 +370,7 @@
 
 /obj/item/clothing/suit/armor/vest/path //No path ?
 	name = "vinculum cassock"
-	desc = "A heavy Cassock meant for the Vectors that possess no vows. This sturdy armor is made entirely out of biomatter and have no metal inner layer, but at the same time this sturdy armor is the thickest of any other armor made out of cloth, even thicker than a gambeson. But this armor is often used for rituals more than it is using for fighting, keeping the defensive properties only for emergencies."
+	desc = "A heavy Cassock meant for the Vectors that possess no vows. This garb has no armor plating but the sturdy fabric offers more protection than a gambeson. Usually worn for ceremonial purposes, it can save a life in an emergency."
 	icon_state = "vinculum_cassock"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
@@ -379,7 +379,7 @@
 
 /obj/item/clothing/suit/armor/vest/path/divisor
 	name = "Divisor's Guardsmen Armor"
-	desc = "The armour of the church arms forces of old - coming from the now extinct military of New Byzantine. The inner layers has plates of biomatter-infused steel and chainmail, together with shoulder protection that elevates to protect the neck and fix it with the helmet of the same design."
+	desc = "The armour of the church arms forces of old - coming from the now extinct military of New Byzantine. The inner layer has plates of biomatter-infused steel and chainmail, together with shoulder protection that elevates to protect the neck and fix it with the helmet of the same design."
 	icon_state = "divisor_guardsmen_armor"
 
 /obj/item/clothing/suit/armor/vest/path/divisor/verb/toggle_style()
@@ -407,7 +407,7 @@
 
 /obj/item/clothing/suit/armor/vest/path/tessallate
 	name = "Tessellate Riding Habit"
-	desc = "The Tessellate Habit is an mixture of an well protective, efficient gambeson with inner chainmail that ensures the protection of it's user."
+	desc = "The Tessellate Habit is an mixture of a well protective, efficient gambeson with inner chainmail that ensures the protection of it's user."
 	icon_state = "tessellate_riding_habit"
 
 /obj/item/clothing/suit/armor/vest/path/tessallate/verb/toggle_style()
@@ -435,7 +435,7 @@
 
 /obj/item/clothing/suit/armor/vest/path/lemniscate
 	name = "Lemniscate Garbs"
-	desc = "The well suited lemniscates garbs of new, made for the highest quality ceremonies by looking absurdly fancy.  It's protective values are quite close to the design of an pourpoint with inner chainmail with golden ridges and lines that only reinforces it's fanciness value."
+	desc = "The well suited lemniscates garbs of new, made for the highest quality ceremonies by looking absurdly fancy.  It's protective values are quite close to the design of a pourpoint with inner chainmail and golden ridges and lines that only reinforces it's fanciness value."
 	icon_state = "lemniscate_garbs"
 
 /obj/item/clothing/suit/armor/vest/path/lemniscate/verb/toggle_style()
@@ -463,7 +463,7 @@
 
 /obj/item/clothing/suit/armor/vest/path/monomial
 	name = "Monomial Kasaya"
-	desc = "An old design of armor, often repainted, pieced together with minor plates overlapping on the shoulders, waist and legs, with an large plate protecting the chest and belly."
+	desc = "An archaic armor design, often repainted, pieced together with small plates overlapping on the shoulders, waist and legs, with a large plate protecting the chest and belly."
 	icon_state = "monomial_kasaya"
 
 /obj/item/clothing/suit/armor/vest/path/monomial/verb/toggle_style()
@@ -491,7 +491,7 @@
 
 /obj/item/clothing/suit/armor/vest/path/factorial
 	name = "Factorial powergarb"
-	desc = "A Factorial's best protection well working their duties on the colony and back in its day on New Byzantine, tends to have different attachments for a more personalized garb."
+	desc = "A Factorial's best protection while doing their duty on the colony and back then on New Byzantine. Tends to have different attachments for a more personalized garb."
 	icon_state = "factorial_powergarb"
 
 /obj/item/clothing/suit/armor/vest/path/factorial/verb/toggle_style()
@@ -585,7 +585,7 @@
 
 /obj/item/clothing/suit/armor/vest/prime
 	name = "prime armor"
-	desc = "Trust in god, but keep your armor on."
+	desc = "The Armor of a Prime, adorned with different markings and decorations only fit for the most devout."
 	icon_state = "prime"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -379,7 +379,7 @@
 
 /obj/item/clothing/suit/armor/vest/path/divisor
 	name = "Divisor's Guardsmen Armor"
-	desc = "The armour of the church arms forces of old - coming from the now extinct military of New Byzantine. The inner layer has plates of biomatter-infused steel and chainmail, together with shoulder protection that elevates to protect the neck and fix it with the helmet of the same design."
+	desc = "The armor of the armed forces of the now extinct military of New Byzantine. The inner layer has plates of biomatter-infused steel and chainmail, together with shoulder protection that reaches up to protect the neck and affix it  to the helmet of the same design. Now Divisors give it a new purpose."
 	icon_state = "divisor_guardsmen_armor"
 
 /obj/item/clothing/suit/armor/vest/path/divisor/verb/toggle_style()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -435,7 +435,7 @@
 
 /obj/item/clothing/suit/armor/vest/path/lemniscate
 	name = "Lemniscate Garbs"
-	desc = "The well suited lemniscates garbs of new, made for the highest quality ceremonies by looking absurdly fancy.  It's protective values are quite close to the design of a pourpoint with inner chainmail and golden ridges and lines that only reinforces it's fanciness value."
+	desc = "The well suited lemniscate garbs of new, made for the highest quality ceremonies by looking absurdly fancy.  It's protective values are quite close to the design of a pourpoint with inner chainmail and golden ridges and lines that only reinforces it's fanciness value."
 	icon_state = "lemniscate_garbs"
 
 /obj/item/clothing/suit/armor/vest/path/lemniscate/verb/toggle_style()

--- a/code/modules/clothing/suits/greatcoat.dm
+++ b/code/modules/clothing/suits/greatcoat.dm
@@ -60,7 +60,7 @@
 
 /obj/item/clothing/suit/greatcoat/absolutecoat
 	name = "absolutist greatcoat"
-	desc = "A comfortable, decorated coat for the Absolutist faith and its supporters. Not as armored but just as ostentatious"
+	desc = "A comfortable, decorated coat for the absolutists and their supporters. Not as armored but just as ostentatious"
 	icon_state = "absolutecoat"
 	item_state = "absolutecoat"
 	blood_overlay_type = "coat"

--- a/code/modules/clothing/suits/greatcoat.dm
+++ b/code/modules/clothing/suits/greatcoat.dm
@@ -80,7 +80,7 @@
 
 /obj/item/clothing/suit/greatcoat/nt_wintercoat //Sprite recolour from a Civ13 open github skyrim hidden piece with a few change ups to match our pallet -Dongels
 	name = "absolutist wintercoat"
-	desc = "A comfortably warm and thick decorated wintercoat for the Absolutist faith and its supporters. Keeping the faithful warm in the Amethyn heat since 2652."
+	desc = "A comfortably warm and thick decorated wintercoat for the absolutists and their supporters. Keeping the faithful warm in the Amethyn heat since 2652."
 	icon_state = "nt_wintercoat"
 	item_state = "nt_wintercoat"
 	blood_overlay_type = "coat"

--- a/code/modules/clothing/suits/greatcoat.dm
+++ b/code/modules/clothing/suits/greatcoat.dm
@@ -59,7 +59,7 @@
 	stiffness = LIGHT_STIFFNESS
 
 /obj/item/clothing/suit/greatcoat/absolutecoat
-	name = "absolutist coat"
+	name = "absolutist greatcoat"
 	desc = "A comfortable, decorated coat for the Absolutist faith and its supporters. Not as armored but just as ostentatious"
 	icon_state = "absolutecoat"
 	item_state = "absolutecoat"
@@ -80,7 +80,7 @@
 
 /obj/item/clothing/suit/greatcoat/nt_wintercoat //Sprite recolour from a Civ13 open github skyrim hidden piece with a few change ups to match our pallet -Dongels
 	name = "absolutist wintercoat"
-	desc = "A comfortably warm, and thick decorated wintercoat for the Absolutist faith and its supporters. Keeping the faithfull warm in the Amethyn heat since 2652."
+	desc = "A comfortably warm and thick decorated wintercoat for the Absolutist faith and its supporters. Keeping the faithful warm in the Amethyn heat since 2652."
 	icon_state = "nt_wintercoat"
 	item_state = "nt_wintercoat"
 	blood_overlay_type = "coat"

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -201,7 +201,7 @@
 
 /obj/item/clothing/suit/storage/chaplain/coat
 	name = "preacher coat"
-	desc = "A snugly fitting, lightly armoured brown coat."
+	desc = "The Prime's vestments come in many different forms, all of them regal and richly adorned."
 	icon_state = "church_coat"
 	item_state = "church_coat"
 


### PR DESCRIPTION
Rephrases some church item descriptions to declutter them and have proper phrasing/explanation.

Adds the damage modifier against psionic mobs and hivemind from the vexilar forceblade to the crusader sword as well.

Fixes the prime hood alternate style "saint" laurel from turning you bald (being bald in exchange for being a saint is a bad tradeoff).

