### PR TITLE
update Eurolang and Kriosan with more filler words for more a coherent reading experience

### DIFF
--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -31,5 +31,4 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
-					 "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp" )
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -32,4 +32,4 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
-					 "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp" )

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -32,4 +32,4 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
-					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz","stopp")
+					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -32,4 +32,4 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
-					 "braver, "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -31,4 +31,4 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -32,4 +32,4 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
-					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz","stopp")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -18,7 +18,7 @@
 					 "und", "ja", "nein", "vielleicht", "ob", "man", "Faust", "Auto", "fliegen", "Asteroid", "Hose", "laufen", "fahren","Raumschiff", \
  					 "Serbien", "Eisenhammer", "Soteria", "Atmosphaere", "Generator", "Ingenieur", "Religion", "Ratte", "Priester", "Käfer", "Armee", "Regierung", "neu", \
  					 "alt", "verfallen", "Hoffnung", "schauen", "sterben", "elektrisch", "Teufel", "kurieren", "Fleisch", "trinken", "Auftrag", "Hilfe", "Medizin", "zeppelin", \
- 					 "verfallen", "Verfall", "National", "Laser", "Strom", "Gruppe", "Verteidigung", "verteidigen", "suche", "Auge", "Hand", "Bein", "Kopf", \
+ 					 "verfallen", "Verfall", "National", "Laser", "Strom", "Gruppe", "Verteidigung", "verteidigen", "Suche", "Auge", "Hand", "Bein", "Kopf", \
  					 "Flucht", "Wahrheit", "Ritter", "Einfluss", "Einfall", "Muesli", "Wand", "Fenster", "Metall", "Holz", "Glas", "Sand",  \
  					 "Computer", "mikro", "Planet", "Universum", "Weltraum", "Turbine", "Treibstoff", "platt", "dunkel", "hell", "tauchen", "Licht", "scheinen", \
  					 "Kaiser", "bekaempfen", "Tastatur", "Augenlicht", "verwerfen", "analysieren", "verschieben", \
@@ -26,5 +26,9 @@
 					 "Unterhaltung", "Platituede", "Pferd", "Poker", "spielen", "Radio", "Baum", "Raumschlacht", "Kolonie", "kolonisieren", \
  					 "Gas", "Schaltung", "umstuerzen", "Umsturz", "Wissenschaft", "erforschen", "Forschung", "Psychologe", "Schmerz", \
  					 "Schmerzen", "gebrochen", "brechen", "alle", "Musik", "also", "Interesse", "Pruegel", "Alkohol", "Getraenk", \
- 					 "dynamisch", "Dynamik", "Organisation", "hauptsache", "Radio", "ueberhaupt", "weil", "denn", "deshalb", "mir", "dir", \
- 					 "dein", "mein", "ihr", "eure", "seine", "meine", "Granate", "Katze", "Hund", "Fisch", "Ziege")
+ 					 "dynamisch", "Dynamik", "Organisation", "hauptsache", "Radio", "ueberhaupt", "weil", "deshalb", "mir", "dir", \
+ 					 "dein", "mein", "ihr", "eure", "seine", "meine", "Granate", "Katze", "Hund", "Fisch", "Ziege", "aber", "dennoch", "weshalb", "deshalb", \
+					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
+					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
+					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -31,5 +31,4 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
-					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -32,4 +32,4 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
-					 "braver", "Teufel", "Platz“, "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -31,4 +31,5 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
+					 "braver", "Teufel", "Platz“, "bleib", "gib laut", "Hunde", "sitz", "stopp")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -32,4 +32,4 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
-					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -31,4 +31,5 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
+					 "braver, "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -136,7 +136,7 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
-					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -135,7 +135,7 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -135,7 +135,8 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
+					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -135,8 +135,7 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß" \
-					 "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -135,8 +135,7 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
-					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -118,20 +118,24 @@
 		LANGUAGE_COMMON = 10
 	)
 	shorthand = "KO"
-	syllables = list("Frau", "Mann", "Waffe", "Schiff", "Bombe", "Explosion", "Grenze", "Strasse", "Halle", "Pistole", "Gewehr", "Uniform", "Kind", "Arzt", \
-					 "und", "ja", "nein", "vielleicht", "ob", "Hund", "Hundt", "katse", "Rüde", "Pleite", "Schreckschraube", "Klammer", "fahren","Raumschiff", \
+	syllables = list(("Frau", "Mann", "Waffe", "Schiff", "Bombe", "Explosion", "Grenze", "Strasse", "Halle", "Pistole", "Gewehr", "Uniform", "Kind", "Arzt", \
+					 "und", "ja", "nein", "vielleicht", "ob", "man", "Faust", "Auto", "fliegen", "Asteroid", "Hose", "laufen", "fahren","Raumschiff", \
  					 "Serbien", "Eisenhammer", "Soteria", "Atmosphaere", "Generator", "Ingenieur", "Religion", "Ratte", "Priester", "Käfer", "Armee", "Regierung", "neu", \
- 					 "fuß", "braver", "Hoffnung", "schauen", "sterben", "elektrisch", "Teufel", "kurieren", "Fleisch", "trinken", "Auftrag", "Hilfe", "Medizin", "zeppelin", \
- 					 "verfallen", "Verfall", "National", "Laser", "Strom", "Gruppe", "Verteidigung", "verteidigen", "suche", "Auge", "Hand", "Bein", "Kopf", \
- 					 "Flucht", "teufel", "Ritter", "Einfluss", "Einfall", "Muesli", "Wand", "Fenster", "Metall", "Holz", "Glas", "platz",  \
- 					 "Bleib", "gib laut", "hunden", "sitz", "Weltraum", "Turbine", "Treibstoff", "platt", "dunkel", "hell", "tauchen", "Licht", "scheinen", \
+ 					 "alt", "verfallen", "Hoffnung", "schauen", "sterben", "elektrisch", "Teufel", "kurieren", "Fleisch", "trinken", "Auftrag", "Hilfe", "Medizin", "zeppelin", \
+ 					 "verfallen", "Verfall", "National", "Laser", "Strom", "Gruppe", "Verteidigung", "verteidigen", "Suche", "Auge", "Hand", "Bein", "Kopf", \
+ 					 "Flucht", "Wahrheit", "Ritter", "Einfluss", "Einfall", "Muesli", "Wand", "Fenster", "Metall", "Holz", "Glas", "Sand",  \
+ 					 "Computer", "mikro", "Planet", "Universum", "Weltraum", "Turbine", "Treibstoff", "platt", "dunkel", "hell", "tauchen", "Licht", "scheinen", \
  					 "Kaiser", "bekaempfen", "Tastatur", "Augenlicht", "verwerfen", "analysieren", "verschieben", \
  					 "Flammen", "Feuer", "Batterie", "laser", "Unwetter", "Abflug", "behandeln", "Roboter", "Regierung", \
-					 "Unterhaltung", "Platituede", "Pferd", "Poker", "spielen", "Stopp", "Baum", "Raumschlacht", "Kolonie", "kolonisieren", \
+					 "Unterhaltung", "Platituede", "Pferd", "Poker", "spielen", "Radio", "Baum", "Raumschlacht", "Kolonie", "kolonisieren", \
  					 "Gas", "Schaltung", "umstuerzen", "Umsturz", "Wissenschaft", "erforschen", "Forschung", "Psychologe", "Schmerz", \
  					 "Schmerzen", "gebrochen", "brechen", "alle", "Musik", "also", "Interesse", "Pruegel", "Alkohol", "Getraenk", \
- 					 "dynamisch", "Dynamik", "Organisation", "hauptsache", "ueberhaupt", "weil", "denn", "deshalb", "mir", "dir", \
- 					 "dein", "mein", "ihr", "eure", "seine", "meine", "Hier", "Fisch", "Ziege")
+ 					 "dynamisch", "Dynamik", "Organisation", "hauptsache", "Radio", "ueberhaupt", "weil", "deshalb", "mir", "dir", \
+ 					 "dein", "mein", "ihr", "eure", "seine", "meine", "Granate", "Katze", "Hund", "Fisch", "Ziege", "aber", "dennoch", "weshalb", "deshalb", \
+					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
+					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
+					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -136,7 +136,7 @@
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
 					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
-					 "braver", "Teufel", "Platz“, "bleib", "gib laut", "Hunde", "sitz", "stopp")
+					 "braver", "Teufel", "Platz", "bleib", "gib laut", "Hunde", "sitz", "stopp")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -118,7 +118,7 @@
 		LANGUAGE_COMMON = 10
 	)
 	shorthand = "KO"
-	syllables = list(("Frau", "Mann", "Waffe", "Schiff", "Bombe", "Explosion", "Grenze", "Strasse", "Halle", "Pistole", "Gewehr", "Uniform", "Kind", "Arzt", \
+	syllables = list("Frau", "Mann", "Waffe", "Schiff", "Bombe", "Explosion", "Grenze", "Strasse", "Halle", "Pistole", "Gewehr", "Uniform", "Kind", "Arzt", \
 					 "und", "ja", "nein", "vielleicht", "ob", "man", "Faust", "Auto", "fliegen", "Asteroid", "Hose", "laufen", "fahren","Raumschiff", \
  					 "Serbien", "Eisenhammer", "Soteria", "Atmosphaere", "Generator", "Ingenieur", "Religion", "Ratte", "Priester", "Käfer", "Armee", "Regierung", "neu", \
  					 "alt", "verfallen", "Hoffnung", "schauen", "sterben", "elektrisch", "Teufel", "kurieren", "Fleisch", "trinken", "Auftrag", "Hilfe", "Medizin", "zeppelin", \
@@ -135,7 +135,8 @@
 					 "doch", "wieso", "denn", "ja", "halt", "auch", "schon", "denn", "etwa", "nur", "bloß", "eben", "mal", "gar", "ruhig", "eigentlich", \
 					 "eh", "nun", "erstmal", "gleich", "zumindest", "wohl", "durchaus", "sicher", "anscheinend", "eigentlich", "folgendermaßen", \
 					 "ausnahmslos", "bisschen", "fortwaehrend", "augenscheinlich", "einfach", "fraglos", "ausdruecklich", "einigermaßen", "freilich", \
-					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich")
+					 "weitem", "einmal", "ganz", "gewiss", "besonders", "endlich", "Hund", "Hund", "Katze", "Rüde", "Pleite", "Schreckschraube", "Klammer", "Fuß", \ 
+					 "braver", "Teufel", "Platz“, "bleib", "gib laut", "Hunde", "sitz", "stopp")
 
 //Aqula racial language. Lore: Long history of indpendence from Sol, therefor their language did not intergrate much. Somewhat physical language due to showing of force, akin to grunts, posturing or facial expressions providing context to wording (I.e akin to a tonal language style but with body language instead).
 /datum/language/akula


### PR DESCRIPTION
Back when I made the german language for eris (my very first coding contribution to SS13 ever) I had no real idea about quality standards and how languages will be perceived ingame over a long time.

When I saw people speaking eurolang/kriosan a while back i physically cringed on how hard it was to read because I added way too many nouns. For a more fluent and coherent reading experience when someone speaks eurolang, i added a lot more german filler words to offset the capitalized and incoherent words and added and corrected the animal specific things from Kriosan and Eurolang and vice-versa.

The next person I see writing "Hundt", "Hunden" (fuck you "Teufelhunden" propagandists for making that word up and coining it for future generations to spell "Teufelshunde" or "Höllenhunde" wrong) or "Katse" will get slapped to brazil.