### PR TITLE
Costume Box Addition: Live Action Roleplay Roman Gear

### DIFF
--- a/code/game/machinery/vendor/cloathing.dm
+++ b/code/game/machinery/vendor/cloathing.dm
@@ -42,6 +42,7 @@
 					/obj/item/storage/box/costume/plaguedoctor = 2,
 					/obj/item/storage/box/costume/rando = 2,
 					/obj/item/storage/box/costume/randoarmy = 5, // For your own personal army
+					/obj/item/storage/box/costume/roman = 2,
 					/obj/item/storage/box/costume/owl = 2,
 					/obj/item/storage/box/costume/rando = 2,
 					/obj/item/storage/box/costume/santa = 2,

--- a/code/game/objects/items/weapons/storage/costume.dm
+++ b/code/game/objects/items/weapons/storage/costume.dm
@@ -508,6 +508,16 @@
 	new /obj/item/tool/sword/saber(src)
 	new /obj/item/clothing/accessory/holster/saber(src)
 
+/obj/item/storage/box/costume/roman
+	name = "roman outfit box"
+	desc = "A box containing the full set of roman live action roleplaying gear."
+	icon_state = "box_of_doom_big"
+
+/obj/item/storage/box/costume/roman/populate_contents()
+	new /obj/item/clothing/under/costume/history/centurion(src)
+	new /obj/item/clothing/shoes/costume/history/centurion(src)
+	new /obj/item/toy/weapon/sword(src)
+
 /obj/item/storage/box/costume/rando
 	name = "warlord costume box"
 	desc = "A box containing a large costume for a post-apocalyptic warlord."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR just basically adds the centurion gear into a box just incase if someone wants to larp as space centurion / roman for halloween.
![image](https://github.com/user-attachments/assets/7f5065b2-7aed-41d0-ba33-6ab53746d49d)



## Changelog
:cl:
add: LARP roman box to vending and loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
