### PR TITLE
removes blacksilk boots from loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -113,7 +113,3 @@
 /datum/gear/shoes/winterboots
 	display_name = "winter boots"
 	path = /obj/item/clothing/shoes/winter
-
-/datum/gear/shoes/blacksilk_boots
-	display_name ="Absolutist Blacksilk boots"
-	path = /obj/item/clothing/shoes/church_blacksilk_boots


### PR DESCRIPTION
I thought the boots fucked but after seeing them ingame, I get why they were removed. This codersprite would need a due makeover.

Removing for aesthetic reasons.