### PR TITLE
Gun Fixes & Misc Stuff (Second Attempt)

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -309,7 +309,7 @@
 	result = /obj/item/gun/energy/laser/railgun/gauss
 	icon_state = "gun"
 	steps = list(
-		list(CRAFT_MATERIAL, 40, MATERIAL_PLASTEEL, "time" = 60),
+		list(CRAFT_MATERIAL, 30, MATERIAL_PLASTEEL, "time" = 60),
 		list(CRAFT_MATERIAL, 8, MATERIAL_GOLD, "time" = 20),
 		list(CRAFT_MATERIAL, 10, MATERIAL_SILVER, "time" = 20),
 		list(CRAFT_MATERIAL, 4, MATERIAL_PLATINUM, "time" = 20),

--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -160,7 +160,7 @@
 				//Armor
 				/obj/item/clothing/suit/crimsoncross_regaloutfit = 0.1, //Little rarer then even soap
 				//Misc - things that are not a "gun" but still good for this
-				/obj/item/oddity/nt/seal = 1,
+				/obj/item/oddity/nt/seal = 0.5,
 				/obj/item/soap/bluespase = 0.5,
 				/obj/item/oddity/rare/moon_fragment = 0.2))
 

--- a/code/modules/projectiles/guns/energy/laser/abdicator.dm
+++ b/code/modules/projectiles/guns/energy/laser/abdicator.dm
@@ -23,7 +23,7 @@ It also has more matterals then it takes to craft as a way to have a sunk cost.
 	w_class = ITEM_SIZE_HUGE
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 10, MATERIAL_URANIUM = 1, MATERIAL_PLASMAGLASS = 1, MATERIAL_WOOD = 8)
 	origin_tech = list(TECH_COMBAT = 6, TECH_MAGNET = 8, TECH_ENGINEERING = 8) //With how hard it is to make? High value.
-	fire_delay = 20
+	fire_delay = 18
 	charge_cost = 150
 	init_recoil = CARBINE_RECOIL(1)
 	damage_multiplier = 1 //already quite a bit lethal and dangerous with the burn damage and 'close range spray'.

--- a/code/modules/projectiles/guns/energy/laser/sunrise.dm
+++ b/code/modules/projectiles/guns/energy/laser/sunrise.dm
@@ -19,9 +19,9 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 4, MATERIAL_GLASS = 10, MATERIAL_URANIUM = 2)
 	init_recoil = CARBINE_RECOIL(0.1)
-	damage_multiplier = 0.75
+	damage_multiplier = 0.7
 	penetration_multiplier = 1
-	max_upgrades = 1 //You can have 1 as a treat
+	max_upgrades = 2 //You can have 2 as a treat since no upgrade port.
 	price_tag = 1500
 	charge_cost = 20
 	gun_tags = list(GUN_LASER, GUN_ENERGY)
@@ -30,6 +30,9 @@
 		FULL_AUTO_600
 		)
 	serial_type = "NM"
+
+	//Blacklisted so you can't make the gun take more than 2 attachments.
+	blacklist_upgrades = list(/obj/item/tool_upgrade/augment/expansion = TRUE)
 
 /obj/item/gun/energy/sunrise/update_icon()
 	..()

--- a/code/modules/projectiles/guns/energy/projectile/railgun.dm
+++ b/code/modules/projectiles/guns/energy/projectile/railgun.dm
@@ -173,9 +173,9 @@
 	item_state = "gauss"
 	fire_sound = 'sound/weapons/guns/fire/gaussrifle.ogg'
 	w_class = ITEM_SIZE_HUGE
-	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_SILVER = 10, MATERIAL_GOLD = 8, MATERIAL_PLATINUM = 4)
-	charge_cost = 750
-	fire_delay = 20
+	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_SILVER = 10, MATERIAL_GOLD = 8, MATERIAL_PLATINUM = 4)
+	charge_cost = 500
+	fire_delay = 20		//Boo-womp
 	init_recoil = HMG_RECOIL(1)
 	zoom_factors = list(1.8)
 	extra_damage_mult_scoped = 0.4
@@ -189,9 +189,9 @@
 	)
 	serial_type = "AG"
 	consume_cell = FALSE
-	price_tag = 6000
+	price_tag = 5000
 
-	var/max_stored_matter = 6
+	var/max_stored_matter = 10
 	var/stored_matter = 0
 	var/matter_type = "refined scrap pieces"
 

--- a/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
@@ -76,6 +76,7 @@
 	gun_parts = null
 	price_tag = 2000
 	damage_multiplier = 1.2
+	extra_damage_mult_scoped = 0.2
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/guns/interact/sfrifle_cock.ogg'
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/dp.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dp.dm
@@ -8,24 +8,24 @@
 	force = WEAPON_FORCE_PAINFUL
 	slot_flags = 0
 	max_shells = 1
-	damage_multiplier = 1.0
-	penetration_multiplier = 0.9
+	damage_multiplier = 1.2			//Same as the AK, plus it's rarer than an AK. (Takeshi is also 1.2)
+	penetration_multiplier = 1.1	//More than AK, which has 1.0. Rarer than AK.
 	caliber = CAL_RIFLE
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BACK
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PAN
 	tac_reloads = FALSE
-	matter = list(MATERIAL_PLASTEEL = 50, MATERIAL_PLASTIC = 15, MATERIAL_WOOD = 10, MATERIAL_STEEL = 20)
+	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_WOOD = 15, MATERIAL_STEEL = 20)
 	price_tag = 1600
 	unload_sound 	= 'sound/weapons/guns/interact/lmg_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/lmg_cock.ogg'
 	fire_sound = 'sound/weapons/guns/fire/dp_fire.ogg'
 	twohanded = TRUE
-	init_recoil = LMG_RECOIL(1.1)
-	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)
-	slowdown_hold = 0.5
+	init_recoil = LMG_RECOIL(1.0)	//Takeshi has 0.8, Maxim is 0.5. So, 1.0 fits I guess. Heroic has HMG recoil anyway vs this gun with LMG.
+	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_INTERNAL_MAG)	//Can take a scope like modern bubbas. Why.. is it and the Maxim 'internal' mag?
+	slowdown_hold = 0.5				//Half the slowdown of a normal LMG; it is meant to be used by automatic-riflemen.
 	init_firemodes = list(
 		FULL_AUTO_300,
 		list(mode_name="short bursts", mode_desc = "Short, rapid 5 round bursts", burst=5,    burst_delay=2, move_delay=6,  icon="burst"),

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -202,7 +202,7 @@
 	damage_multiplier = 1.2 // With full auto penalties in mind (20%) this becomes a normal x1 damage modifier.
 	penetration_multiplier = 1
 	init_recoil = HMG_RECOIL(0.6) // Better slap a bipod on this one! Impossible to fire steady if not braced.
-	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE) // Believe it or not, an LMG that CAN be silenced.
+	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_SILENCABLE) // Believe it or not, an LMG that CAN be silenced. Added scope since it's an HMG, it would benifit form it.
 	serial_type = "NM"
 
 	init_firemodes = list(

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -1033,7 +1033,7 @@
 	armor_divisor = 0.6
 	wounding_mult = WOUNDING_SMALL //lotta relatively smaller pellets.
 	pellets = 4
-	range_step = 1
+	range_step = 2	//Range step of 1 includes base-tile..
 	spread_step = 10
 	knockback = 0 //We do not knockback do to issues with bullet douping
 	step_delay = 0.9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Got too lazy fixing prior PR's chemistry sprite port, because it would require adding new sprites to get it to work with code and all. Plus didn't seem wanted.

Anyway, does basically the same thing as this PR minus the chemistry sprite change.
https://github.com/sojourn-13/sojourn-station/pull/5773

Only other changes done that are new:
- Made DP-27 able to be scoped.
- Made DP-27 on-par with the AK-47 damage wise, and raised it's pen by 0.1. Its recoil was also lowered by 0.1
- Lowered DP-27 cost by 15 plasteel, raised wood cost. It no longer costs more than a Takeshi or other LMG to print by over 10 plasteel.
- Heroic is now able to be scoped; it's an HMG benefiting from bracing so I see no reason it shouldn't be allowed to benefit from it.

DP-27 fixes were prompted by hearing feedback when someone asked me 'how do i make the DP-27 good' and noticing the gun's stats were not upkept to compensate for new systems and changes. Heroic was changed due to Blackshield saying 'why can't this clearly mounted HMG, used to hold positions, take a scope?' - which seemed like a fair request.
	
<hr>
</details>

## Changelog
:cl:
fixes: Buckshot pellet falloff
tweak: Adjusted DP-27 recoil, pen, damage, and overall cost to produce.
tweak: Gave DP-27 and Heroic ability to take a scope.
tweak: adjusts Sunrise attachment slots
tweak: adjusts abdicator firedelay
tweak: adjusts bat'ko cost to make and cell charge
tweak: church oddity bluecross spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
