### PR TITLE
robot restart fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1153,8 +1153,9 @@
 	icon_state = module_sprites[icontype]
 	updateicon()
 
-	if(alert(client,"Do you like this icon?",null, "No","Yes") == "No") // We lose the USR reference because this is called from a spawned proc, so we have to use client.
-		return choose_icon()
+	if(modtype != "Default")
+		if(alert(client,"Do you like this icon?",null, "No","Yes") == "No") // We lose the USR reference because this is called from a spawned proc, so we have to use client.
+			return choose_icon()
 
 	icon_selected = 1 //MEW
 	post_icon_giving()

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -34,6 +34,9 @@
 
 /obj/item/borg/upgrade/reset/action(mob/living/silicon/robot/R)
 	if(..()) return FALSE
+
+	R.has_wreck_sprite = FALSE
+
 	R.uneq_all()
 	R.modtype = initial(R.modtype)
 
@@ -49,6 +52,10 @@
 	R.old_x = 0
 	R.default_pixel_x = 0
 	R.stats.removeAllPerks() //We dont want to stack perks on perks so we remove them all, sads
+	R.allow_resting = FALSE    // Fluff action for borgs with resting icons
+	R.actively_resting = FALSE // Are we currently resting?
+	R.tall_sprites = null
+	R.updateicon()
 	qdel(src)
 	return TRUE
 
@@ -117,6 +124,9 @@
 	R.death_notified = FALSE
 	R.vtech_added_speed = 0
 	R.notify_ai(ROBOT_NOTIFICATION_NEW_UNIT)
+	for(var/obj/screen/health/cyborg/CHUD in R.HUDprocess)
+		if(CHUD)
+			CHUD.overlays.Cut()
 	qdel(src)
 	return TRUE
 


### PR DESCRIPTION
Fixes tall borgs when reset from death to become invisable
Fixes the `Do you like this icon` pop up on default borgs
Fixes resetting a dead borg health hud icon staying blue and broken. 