### PR TITLE
Nerfs cargo and some anti-lag mapping

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/KriosanConfederacy.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/KriosanConfederacy.dm
@@ -32,10 +32,10 @@
 			/obj/item/ammo_magazine/ammobox/shotgun
 		),
 		"Pets" = list(
-			/mob/living/simple_animal/corgi = good_data("Noble Corgi", list(4, 5), 500),
-			/mob/living/simple_animal/corgi/puppy = good_data("Young Corgi", list(3, 5), 250),
-			/mob/living/simple_animal/lizard = good_data("Crate Pusher", list(2, 5), 100),
-			/mob/living/simple_animal/cat = good_data("Rat Slayer", list(4, 5), 150)
+			/mob/living/simple_animal/corgi = good_data("Noble Corgi", list(1, 2), 500),
+			/mob/living/simple_animal/corgi/puppy = good_data("Young Corgi", list(1, 2), 250),
+			/mob/living/simple_animal/lizard = good_data("Crate Pusher", list(1, 2), 100),
+			/mob/living/simple_animal/cat = good_data("Rat Slayer", list(1, 2), 150)
 		),
 		"Assault Armor" = list(
 			/obj/item/clothing/suit/space/void/assault = good_data("Assault Armor", list(3, 5), 20000)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/advmoe.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/advmoe.dm
@@ -9,7 +9,7 @@
 	spawn_always = TRUE
 	markup = UNCOMMON_GOODS
 	offer_limit = 1
-	base_income = 1600
+	base_income = 1200
 	wealth = 0
 	hidden_inv_threshold = 2000
 	recommendation_threshold = 3000
@@ -17,9 +17,9 @@
 	recommendations_needed = 1
 	inventory = list(
 		"Scientific Surplus" = list(
-			/obj/item/storage/deferred/slime = custom_good_amount_range(list(1, 3)),
-			/obj/item/storage/deferred/xenobotany = custom_good_amount_range(list(1, 3)),
-			/obj/item/storage/deferred/rnd = custom_good_amount_range(list(-1, 2)),
+			/obj/item/storage/deferred/slime = custom_good_amount_range(list(0, 1)),
+			/obj/item/storage/deferred/xenobotany = custom_good_amount_range(list(2, 5)),
+			/obj/item/storage/deferred/rnd = custom_good_amount_range(list(-1, 1)),
 			/obj/item/storage/part_replacer/mini,
 			/obj/item/device/geiger
 		),

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
@@ -37,22 +37,22 @@
 	)
 	hidden_inventory = list(
 		"Premium Trash" = list(
-			/obj/structure/scrap = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/large = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/medical = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/medical/large = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/vehicle = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/vehicle/large = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/food = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/food/large = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/guns = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/guns/large = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/science = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/science/large = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/cloth = custom_good_amount_range(list(2,5)),			// Could be a concern with the armor part offer, but it's locked behind discovery and a secret inventory. Something to watch for.
-			/obj/structure/scrap/cloth/large = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/poor = custom_good_amount_range(list(2,5)),
-			/obj/structure/scrap/poor/large = custom_good_amount_range(list(2,5))
+			/obj/structure/scrap = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/large = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/medical = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/medical/large = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/vehicle = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/vehicle/large = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/food = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/food/large = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/guns = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/guns/large = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/science = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/science/large = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/cloth = custom_good_amount_range(list(1,2)),			// Could be a concern with the armor part offer, but it's locked behind discovery and a secret inventory. Something to watch for.
+			/obj/structure/scrap/cloth/large = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/poor = custom_good_amount_range(list(1,2)),
+			/obj/structure/scrap/poor/large = custom_good_amount_range(list(1,2))
 		)
 	)
 	// TODO: offers

--- a/code/modules/trade/datums/trade_stations_presets/3-rare/monstertrapper.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/monstertrapper.dm
@@ -11,7 +11,7 @@
 	spawn_always = TRUE
 	markup = UNCOMMON_GOODS
 	offer_limit = 5
-	base_income = 3200
+	base_income = 800
 	hidden_inv_threshold = 2000
 	recommendation_threshold = 3500
 	stations_recommended = list("illegal2")
@@ -19,12 +19,12 @@
 	inventory = list(
 		"Roach Cubes and Eggs" = list(
 			/obj/item/storage/deferred/roacheggs,	// make egg box
-			/obj/item/reagent_containers/food/snacks/cube/roach/roachling = custom_good_amount_range(list(1, 5)),
-			/obj/item/reagent_containers/food/snacks/cube/roach = custom_good_amount_range(list(1, 5)),
-			/obj/item/reagent_containers/food/snacks/cube/roach/jager = custom_good_amount_range(list(1, 5)),
-			/obj/item/reagent_containers/food/snacks/cube/roach/seuche = custom_good_amount_range(list(1, 5)),
-			/obj/item/reagent_containers/food/snacks/cube/roach/panzer = custom_good_amount_range(list(1, 5)),
-			/obj/item/reagent_containers/food/snacks/cube/roach/grestrahlte = custom_good_amount_range(list(1, 5))
+			/obj/item/reagent_containers/food/snacks/cube/roach/roachling = custom_good_amount_range(list(1, 2)),
+			/obj/item/reagent_containers/food/snacks/cube/roach = custom_good_amount_range(list(1, 2)),
+			/obj/item/reagent_containers/food/snacks/cube/roach/jager = custom_good_amount_range(list(1, 2)),
+			/obj/item/reagent_containers/food/snacks/cube/roach/seuche = custom_good_amount_range(list(1, 2)),
+			/obj/item/reagent_containers/food/snacks/cube/roach/panzer = custom_good_amount_range(list(1, 2)),
+			/obj/item/reagent_containers/food/snacks/cube/roach/grestrahlte = custom_good_amount_range(list(1, 2))
 		),
 		"Roach Toxins" = list(
 			/obj/item/reagent_containers/glass/bottle/trade/blattedin = good_data("blattedin bottle", list(-1, 2), 600),
@@ -43,14 +43,14 @@
 	)
 	hidden_inventory = list(
 		"High-End Roach Product" = list(
-			/obj/item/reagent_containers/food/snacks/cube/roach/kraftwerk = custom_good_amount_range(list(1, 5)),
+			/obj/item/reagent_containers/food/snacks/cube/roach/kraftwerk = custom_good_amount_range(list(1, 2)),
 			/obj/item/reagent_containers/glass/bottle/trade/fuhrerole = good_data("fuhrerole bottle", list(1, 1), 900)
 //			/obj/item/reagent_containers/glass/bottle/trade/kaiseraurum = good_data("kaiseraurum bottle", list(1, 1), 1000) Kaiseraurum doesn't exist here, you just get an empty bottle
 		),
 		"Just Spiders" = list(
-			/mob/living/carbon/superior_animal/giant_spider = custom_good_amount_range(list(2, 3)),
-			/mob/living/carbon/superior_animal/giant_spider/nurse = custom_good_amount_range(list(-2, 3)),
-			/mob/living/carbon/superior_animal/giant_spider/hunter = custom_good_amount_range(list(1, 2))
+			/mob/living/carbon/superior_animal/giant_spider = custom_good_amount_range(list(0, 1)),
+			/mob/living/carbon/superior_animal/giant_spider/nurse = custom_good_amount_range(list(-2, 1)),
+			/mob/living/carbon/superior_animal/giant_spider/hunter = custom_good_amount_range(list(0, 1))
 		)
 	)
 	//Types of items bought by the station

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/bluespace_tech.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/bluespace_tech.dm
@@ -30,6 +30,6 @@
 	offer_types = list(
 		/obj/item/bluespace_crystal = offer_data("bluespace crystal", 2000, 10),
 		/obj/item/oddity/si_bluespace_scanner = offer_data("Bluespace Tuning Device", 2400, 3),	// Significantly higher material cost per piece, longer production time per piece, more diverse mat req hence increase in sale price
-		/obj/item/reagent_containers/food/snacks/csandwich = offer_data("sandwich", 400, 1),
+		/obj/item/reagent_containers/food/snacks/toastedsandwich = offer_data("toasted sandwich", 400, 1),
 		/obj/item/gun/energy/plasma/stranger = offer_data("unknown plasma gun", 5000, 1)
 	)

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -43007,6 +43007,13 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/foyer)
+"ifO" = (
+/obj/machinery/conveyor/east{
+	id = "pile ripper belt";
+	operating = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_waste)
 "ifQ" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -44184,7 +44191,7 @@
 /obj/machinery/conveyor/south{
 	id = "trash"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "irR" = (
 /turf/simulated/shuttle/wall/science{
@@ -58628,7 +58635,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/absolutism/bioreactor)
 "lij" = (
@@ -60973,7 +60979,7 @@
 /obj/machinery/conveyor/south{
 	id = "trash"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "lHU" = (
 /obj/effect/floor_decal/industrial/warningwhite/full,
@@ -74280,6 +74286,9 @@
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/structure/railing,
+/obj/machinery/conveyor_switch{
+	id = "pile ripper belt"
+	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
 "odM" = (
@@ -80116,7 +80125,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "pic" = (
 /obj/structure/plasticflaps,
@@ -100964,6 +100973,11 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tgo" = (
 /obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder";
+	operating = 1
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/engineering/engine_waste)
 "tgt" = (
@@ -103878,7 +103892,7 @@
 	output_side = 4;
 	refuse_output_side = 2
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "tIG" = (
 /obj/structure/flora/small/trailrockb2,
@@ -105806,7 +105820,7 @@
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "uar" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -111304,7 +111318,7 @@
 /obj/machinery/conveyor/south{
 	id = "trash"
 	},
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "uZT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -111519,11 +111533,8 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/rnd/xenobiology)
 "vcf" = (
-/obj/machinery/conveyor/south{
-	id = "trash"
-	},
 /obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "vch" = (
 /turf/unsimulated/mask,
@@ -197739,7 +197750,7 @@ sOw
 sVn
 hgO
 odF
-jYT
+ifO
 mQR
 cXt
 tip
@@ -200520,7 +200531,7 @@ uFd
 jZv
 sKG
 ebW
-ebW
+iCw
 gPC
 vqw
 tRJ


### PR DESCRIPTION

## About The Pull Request
Guild has regained its Recycler to help crush down unrefrined scrap into blah blah delete items
Guild belt has been adjusted to account for self-made smelters, with a belt section to be turned off to help reduce item movement lag
Reduces many cargo trade stations budget and spawn amounts for trash, roach cubes, and other animals including xenobio spawn crates.
