### PR TITLE
Embed Chance Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -38,7 +38,7 @@ uniquic_armor_act
 		//Shrapnel
 		if(P.can_embed() && (check_absorb < 2) && !src.stats.getPerk(PERK_IRON_FLESH))
 			var/armor = getarmor_organ(organ, ARMOR_BULLET)
-			if(prob((20 + max(P.damage_types[BRUTE] - armor, -10) * P.embed_mult)))
+			if(prob((20 + max(P.damage_types[BRUTE] - (armor * 4), -10) * P.embed_mult)))
 				if(!P.shrapnel_type)
 					var/obj/item/material/shard/shrapnel/SP = new()
 					SP.name = (P.name != "shrapnel")? "[P.name] shrapnel" : "shrapnel"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, remember how the armor system and armor values got reworked?

Embed chance calculation was not reworked with that. So, this meant you were FAR more likely than before to have shrapnel embed. While I do actually kinda like that shrapnel is a bit deadly now, it was really silly that even 9mm had a decently high chance to shrapnel even though some of the best armor.

## Changelog
:cl:
fixes: Shrapnel calculation
/:cl:
