### PR TITLE
Greasegun/Texan/Giant Snake Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/mob/64x64.dmi'
 	icon_state = "snake"
 	icon_dead = "snake-dead"
-	faction = "snake"
+	faction = "pond"
 	maxHealth = 100
 	health = 100
 	melee_damage_lower = 10

--- a/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
@@ -48,7 +48,7 @@
 	desc = "A Grease Gun SMG frame. Cheap? Yes, but also effective."
 	icon_state = "frame_grease"
 	result = /obj/item/gun/projectile/automatic/greasegun
-	gripvars = list(/obj/item/part/gun/grip/wood, /obj/item/part/gun/grip/black)
+	gripvars = list(/obj/item/part/gun/grip/black, /obj/item/part/gun/grip/wood)
 	mechanismvar = /obj/item/part/gun/mechanism/smg
 	barrelvars = list(/obj/item/part/gun/barrel/pistol)
 	resultvars = list(/obj/item/gun/projectile/automatic/greasegun, /obj/item/gun/projectile/automatic/texan)


### PR DESCRIPTION
Swaps the grip order in the code to make grease guns and texans construct properly when building them.
Changes giant snake to the pond faction like all the small snakes, preventing it from going on a rampage and eating all fellow snakes at round start.