### PR TITLE
Labcoat overwrites own armor stats

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -13,9 +13,7 @@
 		bullet = 0,
 		bomb = 0,
 		bio = 50,
-		bomb = 0,
-		bio = 0,
-		rad = 0
+		bomb = 0
 	)
 
 /obj/item/clothing/suit/storage/toggle/labcoat/poofy

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -54,7 +54,6 @@
 		bullet = 0,
 		bomb = 0,
 		bio = 75,
-		bomb = 0,
 		rad = 0
 	)
 
@@ -87,7 +86,6 @@
 		bullet = 0,
 		bomb = 0,
 		bio = 50,
-		bomb = 0,
 		rad = 0
 	)
 

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -55,7 +55,6 @@
 		bomb = 0,
 		bio = 75,
 		bomb = 0,
-		bio = 0,
 		rad = 0
 	)
 
@@ -89,7 +88,6 @@
 		bomb = 0,
 		bio = 50,
 		bomb = 0,
-		bio = 0,
 		rad = 0
 	)
 


### PR DESCRIPTION
The armor stats of bio and bomb are instantly overwritten in the lab coat.