### PR TITLE
Allows marshals and blackshield TWO Secondaries

### DIFF
--- a/code/game/machinery/vendor/weapon_kit_vendors.dm
+++ b/code/game/machinery/vendor/weapon_kit_vendors.dm
@@ -84,7 +84,8 @@
 					"Duty Kit" = /obj/item/storage/box/bs_kit/duty,
 					"Cog Kit" = /obj/item/storage/box/bs_kit/cog,
 					"Ekaterina SMG Kit" = /obj/item/storage/box/bs_kit/ekaterina,
-					"Bounty Kit" = /obj/item/storage/box/bs_kit/bounty)
+					"Bounty Kit" = /obj/item/storage/box/bs_kit/bounty,
+					"Second Secondary" = /obj/item/voucher/blackshield/secondary)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Blackshield Voucher Redemption") as null|anything in items]
 	if(selection)
 		new selection(loc)
@@ -102,7 +103,8 @@
 					"Triage Kit" = /obj/item/storage/box/bs_kit/triage,
 					"Ekaterina SMG Kit" = /obj/item/storage/box/bs_kit/ekaterina,
 					"Drozd SMG Kit" = /obj/item/storage/box/bs_kit/drozd,
-					"Bounty Kit" = /obj/item/storage/box/bs_kit/bounty)
+					"Bounty Kit" = /obj/item/storage/box/bs_kit/bounty,
+					"Second Secondary" = /obj/item/voucher/blackshield/secondary)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Blackshield Voucher Redemption") as null|anything in items]
 	if(selection)
 		new selection(loc)
@@ -118,7 +120,8 @@
 					"Lascore kit" = /obj/item/storage/box/bs_kit/lascore,
 					"Warthog Omni Kit" = /obj/item/storage/box/bs_kit/rds_omnicarbine,
 					"Vintorez DMR Kit" = /obj/item/storage/box/bs_kit/vintorez,
-					"Saiga Kit" = /obj/item/storage/box/bs_kit/saiga)
+					"Saiga Kit" = /obj/item/storage/box/bs_kit/saiga,
+					"Second Secondary" = /obj/item/voucher/blackshield/secondary)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Blackshield Voucher Redemption") as null|anything in items]
 	if(selection)
 		new selection(loc)
@@ -252,7 +255,8 @@
 					"Breacher-hammer Kit" = /obj/item/storage/box/m_kit/breacher,
 					"Operator Kit" = /obj/item/storage/box/m_kit/opshotkit,
 					"Mamba Kit" = /obj/item/storage/box/m_kit/mamba,
-					"Gear Laser Carbine Kit" = /obj/item/storage/box/m_kit/gear_lasgun)
+					"Gear Laser Carbine Kit" = /obj/item/storage/box/m_kit/gear_lasgun,
+					"Second Secondary" = /obj/item/voucher/marshal/secondary)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Marshal Voucher Redemption") as null|anything in items]
 	if(selection)
 		new selection(loc)
@@ -266,7 +270,8 @@
 					"State Auto-Shotgun Kit" = /obj/item/storage/box/m_kit/state_auto,
 					"Copperhead Kit" = /obj/item/storage/box/m_kit/copperhead,
 					"Gear Laser Carbine Kit" = /obj/item/storage/box/m_kit/gear_lasgun,
-					"Sunrise Las-SMG Kit" = /obj/item/storage/box/m_kit/typewriter)
+					"Sunrise Las-SMG Kit" = /obj/item/storage/box/m_kit/typewriter,
+					"Second Secondary" = /obj/item/voucher/marshal/secondary)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Marshal Voucher Redemption") as null|anything in items]
 	if(selection)
 		new selection(loc)
@@ -280,7 +285,8 @@
 					"Spec-Op Kit" = /obj/item/storage/box/m_kit/specop,
 					"Viper Kit" = /obj/item/storage/box/m_kit/viper,
 					"Custer Kit" = /obj/item/storage/box/m_kit/custer,
-					"Peacekeeper Kit" = /obj/item/storage/box/m_kit/peacekeeper)
+					"Peacekeeper Kit" = /obj/item/storage/box/m_kit/peacekeeper,
+					"Second Secondary" = /obj/item/voucher/marshal/rangersecondary)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Marshal Voucher Redemption") as null|anything in items]
 	if(selection)
 		new selection(loc)

--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -519,6 +519,8 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 		options["SWAT - combat shotgun"] = list(/obj/item/gun/projectile/shotgun/pump/swat, /obj/item/ammo_magazine/speed_loader_shotgun, /obj/item/ammo_magazine/speed_loader_shotgun, /obj/item/ammo_magazine/speed_loader_shotgun/beanbag, /obj/item/ammo_magazine/ammobox/c10x24_small, /obj/item/storage/pouch/tubular)
 		options["Ostwind - police carbine"] = list(/obj/item/gun/projectile/automatic/ostwind, /obj/item/ammo_magazine/light_rifle_257, /obj/item/ammo_magazine/light_rifle_257, /obj/item/ammo_magazine/light_rifle_257/rubber/pepperball, /obj/item/storage/pouch/ammo)
 		options["Gleam - Assault Laser"] = list(/obj/item/gun/energy/lasercore/militia/blaster, /obj/item/cell/medium/high, /obj/item/cell/medium/high, /obj/item/cell/medium/high, /obj/item/storage/pouch/tubular)
+		options["Second Secondary"] = list(/obj/item/voucher/marshal/wosecondary)
+
 		var/choice = input(user,"What type of equipment?") as null|anything in options
 		if(src && choice)
 			var/list/things_to_spawn = options[choice]
@@ -546,6 +548,8 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 		options["\"Longarm\" - marksman rifle"] = list(/obj/item/gun/projectile/automatic/omnirifle/scoped, /obj/item/ammo_magazine/heavy_rifle_408, /obj/item/ammo_magazine/heavy_rifle_408, /obj/item/ammo_magazine/heavy_rifle_408, /obj/item/ammo_magazine/heavy_rifle_408, /obj/item/ammo_magazine/heavy_rifle_408, /obj/item/storage/pouch/ammo)
 		options["\"Hustler\" - Breacher Shotgun"] = list(/obj/item/gun/projectile/automatic/omnirifle/hustler, /obj/item/ammo_magazine/sbaw, /obj/item/ammo_magazine/sbaw, /obj/item/ammo_magazine/sbaw, /obj/item/ammo_magazine/sbaw, /obj/item/ammo_magazine/sbaw, /obj/item/storage/pouch/ammo)
 		options["\"Gleam\" - Assault Laser"] = list(/obj/item/gun/energy/lasercore/militia/blaster, /obj/item/cell/medium/high, /obj/item/cell/medium/high, /obj/item/cell/medium/high, /obj/item/cell/medium/high, /obj/item/cell/medium/high, /obj/item/storage/pouch/tubular)
+		options["Second Secondary"] = list(/obj/item/voucher/blackshield/COsecondary)
+
 		var/choice = input(user,"What type of equipment?") as null|anything in options
 		if(src && choice)
 			var/list/things_to_spawn = options[choice]


### PR DESCRIPTION
Suggested by Wilson

Allows all vouchers and kits for blackshield and marshals to pick a Second Secondary. Why would you do this is for duel wielding or if you are objectively picking wrong options.