### PR TITLE
Task typo corrections

### DIFF
--- a/modular_sojourn/task_master/tasks.dm
+++ b/modular_sojourn/task_master/tasks.dm
@@ -127,7 +127,7 @@
 /datum/task_master/task/dr_floor
 	name = "Dr. Floor"
 	key = "DR_FLOOR"
-	desc = "Either do to drug withdraw, or hope, its hard to denie that this helps build up resistance."
+	desc = "Either due to drug withdraw, or hope, its hard to deny that this helps build up resistance."
 	gain_text = "Self prescription..."
 	level_thresholds = 5 //Tons of wallet/floor pills
 
@@ -206,8 +206,8 @@
 /datum/task_master/task/slab_clearer
 	name = "Mining Skill"
 	key = "SLAB_CLEARER"
-	desc = "Do to being able to fully restock a mining slab you can visualize better the most mineral-effective ways to break rocks and dig."
-	gain_text = "A fully cleared slab allows insight into maxizing mineral gains."
+	desc = "Due to being able to fully restock a mining slab you can visualize better the most mineral-effective ways to break rocks and dig."
+	gain_text = "A fully cleared slab allows insight into maximizing mineral gains."
 	level_thresholds = 1 // 1->2->3
 	unlocked = TRUE
 


### PR DESCRIPTION
Finding some idle time means I felt like touching up a few typos in the Tasks folder. There's still a few sentences overall that could stand to be rephrased, but for the meantime, this just polishes what's already there.





While we were still recovering from the book burning of Supper to Super Majority, someone lit the library on fire.

It's been blow after blow, how will we ever recover?

Maybe we won't. 
![image](https://github.com/user-attachments/assets/9461d1c3-dc6c-4aec-889b-e8004e831aaf)
