### PR TITLE
way more random and more items

### DIFF
--- a/code/game/objects/random/booze.dm
+++ b/code/game/objects/random/booze.dm
@@ -19,9 +19,83 @@
 				/obj/item/reagent_containers/food/drinks/bottle/wine = 1,
 				/obj/item/reagent_containers/food/drinks/bottle/cognac = 1,
 				/obj/item/reagent_containers/food/drinks/bottle/vermouth = 1,
-				/obj/item/reagent_containers/food/drinks/bottle/pwine = 1))
+				/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 0.1,
+				/obj/item/reagent_containers/food/drinks/bottle/pwine = 0.5))
 
 /obj/random/booze/low_chance
 	name = "low chance random booze"
+	icon_state = "cannister-red-low"
+	spawn_nothing_percentage = 60
+
+/obj/random/soft_drink
+	name = "random soft drink"
+	icon_state = "cannister-red"
+
+/obj/random/soft_drink/item_to_spawn()
+	return pickweight(list(
+	/obj/item/reagent_containers/food/drinks/cans/cola = 1,
+	/obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 1,
+	/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 1,
+	/obj/item/reagent_containers/food/drinks/cans/starkist = 1,
+	/obj/item/reagent_containers/food/drinks/cans/space_up = 1,
+	/obj/item/reagent_containers/food/drinks/cans/lemon_lime = 1,
+	/obj/item/reagent_containers/food/drinks/cans/iced_tea = 1,
+	/obj/item/reagent_containers/food/drinks/cans/grape_juice = 1,
+	/obj/item/reagent_containers/food/drinks/cans/tonic = 1,
+	/obj/item/reagent_containers/food/drinks/cans/waterbottle = 1,
+	/obj/item/reagent_containers/food/drinks/cans/sodawater = 1,
+	/obj/item/reagent_containers/food/drinks/cans/melonsoda = 1))
+
+/obj/random/soft_drink/low_chance
+	name = "low chance soft drink"
+	icon_state = "cannister-red-low"
+	spawn_nothing_percentage = 60
+
+/obj/random/drinking_glasses
+	name = "random drinking glass (no reagents)"
+	icon_state = "cannister-red"
+
+/obj/random/drinking_glasses/item_to_spawn()
+	return pickweight(list(
+	/obj/item/reagent_containers/food/drinks/drinkingglass = 1,
+	/obj/item/reagent_containers/food/drinks/drinkingglass/shot = 1,
+	/obj/item/reagent_containers/food/drinks/drinkingglass/mug = 1,
+	/obj/item/reagent_containers/food/drinks/drinkingglass/pint = 1,
+	/obj/item/reagent_containers/food/drinks/drinkingglass/doble = 1,
+	/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass = 1,
+	/obj/item/reagent_containers/food/drinks/pitcher = 1,
+	/obj/item/reagent_containers/food/drinks/carafe = 1,
+	/obj/item/reagent_containers/food/drinks/flask/shiny = 1,
+	/obj/item/reagent_containers/food/drinks/flask/lithium = 1,
+	/obj/item/reagent_containers/food/drinks/flask = 1,
+	/obj/item/reagent_containers/food/drinks/flask/barflask = 1,
+	/obj/item/reagent_containers/food/drinks/flask/vacuumflask = 1,
+	/obj/item/reagent_containers/food/drinks/mug = 1,
+	/obj/item/reagent_containers/food/drinks/mug/black = 1,
+	/obj/item/reagent_containers/food/drinks/mug/red = 1,
+	/obj/item/reagent_containers/food/drinks/mug/green = 1,
+	/obj/item/reagent_containers/food/drinks/mug/blue = 1,
+	/obj/item/reagent_containers/food/drinks/mug/heart = 1,
+	/obj/item/reagent_containers/food/drinks/mug/one = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/metal = 1,
+	/obj/item/reagent_containers/food/drinks/mug/rainbow = 1,
+	/obj/item/reagent_containers/food/drinks/mug/brit = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/moebius = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/gold = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/old_nt = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/new_nt = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/syndie = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/serb = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/ironhammer = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/league = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/moe = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/aster = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/guild = 0.1,
+	/obj/item/reagent_containers/food/drinks/mug/white = 1,
+	/obj/item/reagent_containers/food/drinks/mug/teacup = 1,
+	/obj/item/reagent_containers/food/drinks/teapot = 0.01))
+
+/obj/random/drinking_glasses/low_chance
+	name = "low chance soft drink (no reagents)"
 	icon_state = "cannister-red-low"
 	spawn_nothing_percentage = 60

--- a/code/game/objects/random/cloth.dm
+++ b/code/game/objects/random/cloth.dm
@@ -282,15 +282,10 @@
 				/obj/item/clothing/head/welding = 5,
 				/obj/item/clothing/head/ranger = 3,
 				/obj/item/clothing/head/inhaler = 1,
-				/obj/random/cloth/bikehelms = 1))
+				/obj/item/clothing/head/helmet/biker = 1))
 
 /obj/random/cloth/head/low_chance
 	name = "low chance random head"
-	icon_state = "armor-grey-low"
-	spawn_nothing_percentage = 60
-
-/obj/random/cloth/bikehelms/low_chance
-	name = "low chance random biker helmet"
 	icon_state = "armor-grey-low"
 	spawn_nothing_percentage = 60
 

--- a/code/game/objects/random/food.dm
+++ b/code/game/objects/random/food.dm
@@ -29,9 +29,9 @@
 				/obj/item/reagent_containers/food/snacks/openable/spacetwinkie = 3,
 				/obj/item/reagent_containers/food/drinks/dry_ramen = 2,
 				/obj/item/reagent_containers/food/snacks/hotdog = 1,
-				/obj/item/reagent_containers/food/snacks/openable/liquidfood = 2,
 				/obj/item/reagent_containers/food/snacks/pie = 1,
-				/obj/item/reagent_containers/food/snacks/sandwich = 1))
+				/obj/item/reagent_containers/food/snacks/sandwich = 1,
+				/obj/random/rations/crayon = 0.1))
 
 /obj/random/junkfood/low_chance
 	name = "low chance junkfood"

--- a/code/game/objects/random/junk.dm
+++ b/code/game/objects/random/junk.dm
@@ -81,7 +81,17 @@
 	return pickweight(items - exclusions)
 
 /obj/random/junk/nondense
-	exclusions = list(/obj/random/scrap/moderate_weighted, /obj/item/remains/robot)
+	exclusions = list(/obj/random/scrap/moderate_weighted,
+	/obj/item/remains/robot,
+	/obj/effect/decal/cleanable/blood/gibs/robot,
+	/obj/effect/decal/cleanable/blood/oil,
+	/obj/effect/decal/cleanable/blood/oil/streak,
+	/obj/effect/decal/cleanable/molten_item,
+	/obj/effect/decal/cleanable/spiderling_remains,
+	/obj/effect/decal/cleanable/vomit,
+	/obj/effect/decal/cleanable/blood/splatter,
+	/obj/effect/spider/stickyweb
+	)
 
 /obj/random/junk/low_chance
 	name = "low chance random junk"

--- a/code/game/objects/random/packs.dm
+++ b/code/game/objects/random/packs.dm
@@ -25,7 +25,8 @@ They generally give more random result and can provide more divercity in spawn.
 					/obj/random/cloth/shoes = 6,
 					/obj/random/cloth/backpack = 4,
 					/obj/random/cloth/belt = 4,
-					/obj/random/cloth/holster = 4
+					/obj/random/cloth/holster = 4,
+					/obj/random/cloth/bells = 0.1 //Rare do to being useless
 				))
 
 /obj/random/pack/cloth/low_chance
@@ -210,7 +211,6 @@ They generally give more random result and can provide more divercity in spawn.
 	name = "random deepmaint machine"
 	icon_state = "machine-orange"
 
-
 /obj/random/pack/deep_machine/item_to_spawn()
 	return pickweight(list(
 					/obj/random/structures = 28, //That one have MUCH MORE important objects for maints inside, that's why the number is hight
@@ -228,17 +228,20 @@ They generally give more random result and can provide more divercity in spawn.
 	icon_state = "machine-orange-low"
 	spawn_nothing_percentage = 70
 
-/obj/random/prothesis
+// prosthesis
+/obj/random/pack/prosthesis
 	name = "random prosthesis"
-	icon_state = "meds-green"
+	icon_state = "machine-orange"
 
-/obj/random/prothesis/one_star
-	name = "random one star prosthesis"
+/obj/random/pack/prosthesis/item_to_spawn()
+	return pickweight(list(
+					/obj/random/prothesis/junk_tech = 5,
+					/obj/random/prothesis/combat_prosthesis = 0.1, //Has real armor
+					/obj/random/prothesis/random_external_basic = 5
+				))
 
-/obj/random/prothesis/one_star/item_to_spawn()
-	return pick(list(
-	/obj/item/organ/external/robotic/one_star/l_arm,\
-	/obj/item/organ/external/robotic/one_star/r_arm,\
-	/obj/item/organ/external/robotic/one_star/l_leg,\
-	/obj/item/organ/external/robotic/one_star/r_leg
-	))
+/obj/random/pack/prosthesis/low_chance
+	name = "low chance prosthesis"
+	icon_state = "machine-orange-low"
+	spawn_nothing_percentage = 70
+

--- a/code/game/objects/random/prosthesis.dm
+++ b/code/game/objects/random/prosthesis.dm
@@ -1,0 +1,60 @@
+/obj/random/prothesis
+	name = "random prosthesis"
+	icon_state = "meds-green"
+
+/obj/random/prothesis/one_star
+	name = "random one star prosthesis"
+
+/obj/random/prothesis/one_star/item_to_spawn()
+	return pick(list(
+	/obj/item/organ/external/robotic/one_star/l_arm,\
+	/obj/item/organ/external/robotic/one_star/r_arm,\
+	/obj/item/organ/external/robotic/one_star/l_leg,\
+	/obj/item/organ/external/robotic/one_star/r_leg
+	))
+
+/obj/random/prothesis/junk_tech
+	name = "random junk tech prosthesis"
+	icon_state = "meds-green"
+
+/obj/random/prothesis/junk_tech/item_to_spawn()
+	return pick(list(
+	/obj/item/organ/external/robotic/junktech/l_arm,\
+	/obj/item/organ/external/robotic/junktech/r_arm,\
+	/obj/item/organ/external/robotic/junktech/l_leg,\
+	/obj/item/organ/external/robotic/junktech/r_leg
+	))
+
+/obj/random/prothesis/combat_prosthesis
+	name = "random advanced prosthesis (has excelsior spawns)"
+	icon_state = "meds-green"
+
+/obj/random/prothesis/combat_prosthesis/item_to_spawn()
+	return pick(list(
+	/obj/item/organ/external/robotic/moebius/l_arm,\
+	/obj/item/organ/external/robotic/moebius/r_arm,\
+	/obj/item/organ/external/robotic/moebius/l_leg,\
+	/obj/item/organ/external/robotic/moebius/r_leg,\
+
+	/obj/item/organ/external/robotic/blackshield/l_arm,\
+	/obj/item/organ/external/robotic/blackshield/r_arm,\
+	/obj/item/organ/external/robotic/blackshield/l_leg,\
+	/obj/item/organ/external/robotic/blackshield/r_leg,\
+
+	/obj/item/organ/external/robotic/excelsior/l_arm,\
+	/obj/item/organ/external/robotic/excelsior/r_arm,\
+	/obj/item/organ/external/robotic/excelsior/l_leg,\
+	/obj/item/organ/external/robotic/excelsior/r_leg
+	))
+
+/obj/random/prothesis/random_external_basic
+	name = "random prosthesis"
+	icon_state = "meds-green"
+
+/obj/random/prothesis/junk_tech/item_to_spawn()
+	return pick(list(
+	/obj/item/organ/external/robotic/l_arm,\
+	/obj/item/organ/external/robotic/r_arm,\
+	/obj/item/organ/external/robotic/l_leg,\
+	/obj/item/organ/external/robotic/r_leg
+	))

--- a/code/game/objects/random/purerandom.dm
+++ b/code/game/objects/random/purerandom.dm
@@ -88,7 +88,6 @@
 				/obj/random/cloth/masks = 1,
 				/obj/random/cloth/under = 1,
 				/obj/random/cloth/head = 1,
-				/obj/random/cloth/bikehelms = 1,
 				/obj/random/cloth/gloves = 1,
 				/obj/random/cloth/glasses = 1,
 				/obj/random/cloth/shoes = 1,
@@ -136,6 +135,8 @@
 				/obj/random/gun_cheap = 1,
 				/obj/random/gun_parts/low = 1,
 				/obj/random/gun_parts/frames = 1,
+				/obj/random/soft_drink = 0.1,
+				/obj/random/drinking_glasses = 0.1,
 				//obj/item/clothing/accessory/badge/marshal = 0.1, //Antag item
 				/obj/item/stash_spawner = 12))
 

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -355,7 +355,8 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		/obj/item/stack/rods/random,
 		/obj/item/material/shard,
 		/obj/random/junk/nondense,
-		/obj/random/pack/rare = 0.3
+		/obj/random/pack/rare = 0.3,
+		/obj/random/pack/prosthesis/low_chance = 0.05
 	)
 
 /obj/structure/scrap/vehicle
@@ -374,7 +375,8 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		/obj/random/material_ore,
 		/obj/random/pack/rare = 0.3,
 		/obj/random/tool_upgrade = 1,
-		/obj/random/mecha_equipment = 2
+		/obj/random/mecha_equipment = 2,
+		/obj/random/pack/prosthesis/low_chance = 0.05
 	)
 
 /obj/structure/scrap/food
@@ -384,8 +386,8 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 	parts_icon = 'icons/obj/structures/scrap/food_trash.dmi'
 	loot_list = list(
 		/obj/random/junkfood = 5,
-		/obj/random/junkfood,
 		/obj/random/booze,
+		/obj/random/soft_drink,
 		/obj/item/material/shard,
 		/obj/random/junk/nondense,
 		/obj/random/pack/rare = 0.3
@@ -396,19 +398,20 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 	name = "armaments refuse pile"
 	desc = "A pile of military supply refuse. Who thought it was a clever idea to throw that out?"
 	parts_icon = 'icons/obj/structures/scrap/guns_trash.dmi'
-	loot_min = 7
-	loot_max = 10
+	loot_min = 9
+	loot_max = 13
 	loot_list = list(
 		/obj/random/pack/gun_loot = 8,
 		/obj/random/powercell,
 		/obj/random/mecha_equipment = 2,
-		/obj/item/material/shard,
-		/obj/item/stack/material/steel/random,
+		/obj/item/material/shard = 0.2,
+		/obj/item/stack/material/steel/random = 0.4,
 		/obj/item/stack/material/plasteel/random = 0.6,
 		/obj/random/junk/nondense,
 		/obj/random/pack/rare = 0.3,
-		/obj/random/gun_parts/frames = 1,
-		/obj/random/gun_parts = 2
+		/obj/random/gun_parts/frames = 2,
+		/obj/random/gun_parts = 1,
+		/obj/random/pouch/hardcase_ammo = 0.3 //Can spawn some really good ammo.
 	)
 
 /obj/structure/scrap/science
@@ -432,12 +435,15 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 	name = "cloth pile"
 	desc = "A pile of ruined and discarded clothing."
 	parts_icon = 'icons/obj/structures/scrap/cloth.dmi'
-	loot_list = list(/obj/random/pack/cloth,
-		/obj/random/pack/rare = 0.2,
-		/obj/random/gun_parts/frames = 0.2,
-		/obj/random/gun_parts = 0.5,
+	loot_list = list(/obj/random/pack/cloth = 4,
+		/obj/random/cigarettes = 0.5,
+		/obj/random/pack/rare = 0.1,
+		/obj/random/gun_parts/frames = 0.1,
+		/obj/random/gun_parts = 0.3,
 		/obj/item/storage/wallet = 0.2,
-		/obj/item/storage/wallet/random = 0.1)
+		/obj/item/storage/wallet/random = 0.1,
+		/obj/random/pack/prosthesis/low_chance = 0.2,
+		/obj/random/pouch/hardcase = 0.2)
 
 /obj/structure/scrap/poor
 	icontype = "poor"
@@ -452,7 +458,9 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		/obj/random/cigarettes = 0.3,
 		/obj/random/material_ore,
 		/obj/item/material/shard,
-		/obj/random/pack/rare = 0.3
+		/obj/random/pack/rare = 0.3,
+		/obj/random/pack/prosthesis/low_chance = 0.05,
+		/obj/random/pouch/hardcase = 0.8 //Can be quite good
 	)
 
 /obj/structure/scrap/poor/large

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -388,6 +388,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 		/obj/random/junkfood = 5,
 		/obj/random/booze,
 		/obj/random/soft_drink,
+		/obj/random/drinking_glasses = 0.5,
 		/obj/item/material/shard,
 		/obj/random/junk/nondense,
 		/obj/random/pack/rare = 0.3

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1394,6 +1394,7 @@
 #include "code\game\objects\random\packs.dm"
 #include "code\game\objects\random\pouches.dm"
 #include "code\game\objects\random\powercells.dm"
+#include "code\game\objects\random\prosthesis.dm"
 #include "code\game\objects\random\psi_loot.dm"
 #include "code\game\objects\random\purerandom.dm"
 #include "code\game\objects\random\random.dm"


### PR DESCRIPTION
Allow canned drinks to spawn (not department drinks) Allows mugs/glasses/ect to spawn
Tweaks cloth/weapons pile spawns to be more in line with what they are Tweaks spawns of food stuffs
Allows robotic lims to more naturally spawn in piles

increases gun piles loot spawn amount (i.e how many items are inside them)
