### PR TITLE
increases medtek's speed by .1 (im coping)

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -441,7 +441,7 @@ Technomancer RIG
 	)
 	req_access = list(access_cmo)
 	seal_delay = 4 //built for speed
-	slowdown = -0.3 //we get a bit more speed than the baseline recovery rig as this is a unique item with exactly 0 armor. This is for zipping around medical, rather than getting in the weeds
+	slowdown = -0.4 //we get a bit more speed than the baseline recovery rig as this is a unique item with exactly 0 armor. This is for zipping around medical, rather than getting in the weeds
 	ablative_armor = 0
 	ablative_max = 0 //no armor, none.
 	helm_type = /obj/item/clothing/head/helmet/space/rig/cmo


### PR DESCRIPTION

## About The Pull Request
<details>
<summary>
	salt PR over the incoming jani rigs being basically medteks, need muh value
</summary>
<hr>

buffs medtek ever so slightly 

whys it good for the server? ensures that a head of staff unique item is kept as a valuable thing as opposed to a resprite of a janitor RIGsuit, the janitor RIGsuit has nearly the same movement speed but has noslips and better RAD armor, making it technically more valuable than the medtek, doesn't make too much sense to make the medtek basically a resprited and nerfed janiRIG
<hr>
</details>

## Changelog
:cl:
tweak: gives medtek -0.4 from -0.3
:cl:

