### PR TITLE
Makes TTS device 'Tiny' instead of small

### DIFF
--- a/code/game/objects/items/devices/text_to_speech.dm
+++ b/code/game/objects/items/devices/text_to_speech.dm
@@ -3,7 +3,7 @@
 	desc = "A device that speaks an inputted message. Given to crew which can not speak properly or at all."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "ttsdevice"
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	var/named
 
 /obj/item/device/text_to_speech/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -34,6 +34,7 @@
 		/obj/item/genetics/sample,
 		/obj/item/genetics/mut_injector,
 		/obj/item/stamp,
+		/obj/item/device/text_to_speech,
 		// All these anomalies should be small in size enough to be able to fit inside a wallet.
 		/obj/item/oddity/common/old_id, // ID's fit
 		/obj/item/oddity/common/lighter, // Zippos fit


### PR DESCRIPTION
Makes the TTS device smaller so that it can fit in a wallet

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Squeaky wheel gets the grease. Someone asked for TTS devices to fit in a wallet, so I made a PR for that
<hr>

Swaps the TTS Device size from 'small' to 'tiny'
	
<hr>
</details>

## Changelog
:cl:
tweak: Made TTS Devices tiny, instead of small.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
