### PR TITLE
Lonestar-ering 2

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1433,6 +1433,10 @@
 	desc = "A favorite amongst clerks and desk jockeys."
 	icon_state= "dippybird"
 
+/obj/item/toy/desk/dippingbird/branded
+	name = "spector brand dipping bird model"
+	desc = "A favorite amongst clerks and desk jockeys. This one has a nigh impossible to remove 'Spector Station' sticker on the bottom of the base."
+
 //Consumer!!!
 
 /obj/item/toy/consumer

--- a/code/modules/reagents/reagent_containers/food/snacks/burger.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/burger.dm
@@ -213,7 +213,7 @@
 	matter = list(MATERIAL_BIOMATTER = 60)
 
 /obj/item/reagent_containers/food/snacks/bigbiteburger/cargo
-	desc = "A large stack of parrties and toppings. It has big \"R\" stamped on it's bun."
+	desc = "A large stack of patties and toppings. It has big \"R\" stamped on it's bun."
 
 /obj/item/reagent_containers/food/snacks/superbiteburger
 	name = "super bite burger"

--- a/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
@@ -60,6 +60,7 @@
 			/obj/item/computer_hardware/hard_drive/portable/design/adv_tools = custom_good_nameprice("Artificer's IJIRO-451 Advanced Tools", list(800, 1000)),
 			/obj/item/computer_hardware/hard_drive/portable/design/circuits = custom_good_nameprice("Artificer's ESPO-830 Circuits", list(800, 1000)),
 			/obj/item/computer_hardware/hard_drive/portable/design/logistics = custom_good_nameprice("Artificer's LAT-018 Logistics", list(800, 1000)),
+			/obj/item/computer_hardware/hard_drive/portable/design/guns/cheap_guns = good_data("H&S - 9mm Economy Pack", list(800, 1000), 550),
 			/obj/item/computer_hardware/hard_drive/portable/design/exotic_ammo = good_data("Exotic Ammo Disk", list(800, 1000), 700)
 		),
 		"Printed II" = list(

--- a/code/modules/trade/datums/trade_stations_presets/1-common/ghost_kitchen.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/ghost_kitchen.dm
@@ -19,7 +19,7 @@
 		"Office Supplies" = list(
 			/obj/item/pen = good_data("Pen", list(5, 20), 25),
 			/obj/item/pen/multi = good_data("Multi Color", list(5, 20), 75),
-			/obj/item/paper_bin = good_data("Multi Color", list(5, 20), 100),
+			/obj/item/paper_bin = good_data("Paper Bin", list(5, 20), 100),
 			/obj/item/device/lighting/toggleable/lamp = good_data("Desk Lamp", list(5, 20), 100),
 			/obj/item/storage/briefcase = good_data("Briefcase", list(5, 20), 500), //Rather pricy, but it's to dissuade using them for storage reasons. It's a FASHION statement, sweaty! -Wilson
 			/obj/item/storage/secure/briefcase = good_data("Secure Briefcase", list(5, 20), 550),

--- a/code/modules/trade/datums/trade_stations_presets/1-common/ghost_kitchen.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/ghost_kitchen.dm
@@ -16,6 +16,15 @@
 	recommendation_threshold = 300
 	stations_recommended = list("mcronalds", "botany") //Alt way to get to it
 	inventory = list(
+		"Office Supplies" = list(
+			/obj/item/pen = good_data("Pen", list(5, 20), 25),
+			/obj/item/pen/multi = good_data("Multi Color", list(5, 20), 75),
+			/obj/item/paper_bin = good_data("Multi Color", list(5, 20), 100),
+			/obj/item/device/lighting/toggleable/lamp = good_data("Desk Lamp", list(5, 20), 100),
+			/obj/item/storage/briefcase = good_data("Briefcase", list(5, 20), 500), //Rather pricy, but it's to dissuade using them for storage reasons. It's a FASHION statement, sweaty! -Wilson
+			/obj/item/storage/secure/briefcase = good_data("Secure Briefcase", list(5, 20), 550),
+			/obj/item/toy/desk/dippingbird/branded = good_data("Spector Dipping Bird Model", list(5, 20), 75)
+		),
 		"Non-Meals" = list(
 			/obj/item/reagent_containers/food/snacks/rawcutlet = good_data("Raw Cutlet", list(-100, -50), 5),
 			/obj/item/reagent_containers/food/snacks/cutlet = good_data("Cooked Cutlet", list(-100, -50), 7),

--- a/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
@@ -88,6 +88,12 @@
 			/obj/item/gun/projectile/revolver/lemant,
 			/obj/item/gun/projectile/shotgun/pump/combat,
 			/obj/item/gun/projectile/grenade
+		),
+		"Clothing" = list(
+			/obj/item/clothing/under/color/black = good_data("Black Jumpsuit", list(4, 4), 80),
+			/obj/item/clothing/head/beanie/black = good_data("Black Beanie", list(4, 4), 40),
+			/obj/item/clothing/gloves/thick = good_data("Black Gloves", list(4, 4), 40),
+			/obj/item/clothing/shoes/color/black = good_data("Black Shoes", list(4, 4), 40)
 		)
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
@@ -57,7 +57,7 @@
 
 	hidden_inventory = list(
 		"Sverkhmateriya" = list(
-			/obj/machinery/power/supermatter
+			/obj/machinery/power/supermatter = good_data("supermatter", list(1, 2), 8500) //The 'unsolicited supermatter shipment' play has gone on long enough. It's time we end it. -Wilson
 		),
 
 		"Bystroye Stroitel'stvo" = list(

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
@@ -16,9 +16,9 @@
 	offer_limit = 30
 	inventory = list(
 		"Burgers" = list(
-			/obj/item/reagent_containers/food/snacks/bigbiteburger/cargo = custom_good_name("Big RBurger"),
-			/obj/item/reagent_containers/food/snacks/jellyburger/cherry = custom_good_name("JellyCherry RBurger"),
-			/obj/item/reagent_containers/food/snacks/tofuburger = custom_good_name("Tofu RBurger")
+			/obj/item/reagent_containers/food/snacks/bigbiteburger/cargo = good_data("Double RBurger", list(1, 3), 150),
+			/obj/item/reagent_containers/food/snacks/jellyburger/cherry = good_data("Cherry jelly RBurger", list(1, 3), 100),
+			/obj/item/reagent_containers/food/snacks/tofuburger = good_data("Tofu RBurger", list(1, 3), 120)
 		),
 		"Pizza" = list(
 			/obj/item/pizzabox/meat = good_data("Supreme Meatlover: Pizza Alliance", list(1, 3), 400),
@@ -27,35 +27,39 @@
 			/obj/item/pizzabox/margherita = good_data("PizzeR: autoTomato", list(1, 3), 400)
 		),
 		"Cakes" = list(
-			/obj/item/reagent_containers/food/snacks/sliceable/plaincake = good_data("Vanilla", list(1, 3), 300),
-			/obj/item/reagent_containers/food/snacks/sliceable/chocolatecake = good_data("Chocola", list(1, 3), 350),
-			/obj/item/reagent_containers/food/snacks/sliceable/carrotcake = custom_good_amount_range(list(1, 3)),
-			/obj/item/reagent_containers/food/snacks/sliceable/cheesecake = custom_good_amount_range(list(1, 3)),
-			/obj/item/reagent_containers/food/snacks/sliceable/orangecake = custom_good_amount_range(list(1, 3)),
-			/obj/item/reagent_containers/food/snacks/sliceable/limecake = custom_good_amount_range(list(1, 3)),
-			/obj/item/reagent_containers/food/snacks/sliceable/lemoncake = custom_good_amount_range(list(1, 3))
+			/obj/item/reagent_containers/food/snacks/sliceable/plaincake = good_data("Vanilla cake", list(1, 3), 500),
+			/obj/item/reagent_containers/food/snacks/sliceable/chocolatecake = good_data("Chocolate cake", list(1, 3), 550),
+			/obj/item/reagent_containers/food/snacks/sliceable/carrotcake = good_data("Carrot Cake", list(1, 3), 500),
+			/obj/item/reagent_containers/food/snacks/sliceable/cheesecake = good_data("Cheese Cake", list(1, 3), 500),
+			/obj/item/reagent_containers/food/snacks/sliceable/orangecake = good_data("Orange Cake", list(1, 3), 500),
+			/obj/item/reagent_containers/food/snacks/sliceable/limecake = good_data("Lime Cake", list(1, 3), 500),
+			/obj/item/reagent_containers/food/snacks/sliceable/lemoncake = good_data("Lemon Cake", list(1, 3), 500)
 		),
 		"Misc" = list(
-			/obj/item/reagent_containers/food/snacks/fishandchips = custom_good_name("Fishps"),
-			/obj/item/reagent_containers/food/condiment/pack/ketchup = custom_good_name("Ketchup Packet"),
-			/obj/item/reagent_containers/food/condiment/pack/hotsauce = custom_good_name("Hotsauce Packet"),
-			/obj/item/reagent_containers/food/condiment/pack/salt = custom_good_name("Salt Packet"),
-			/obj/item/reagent_containers/food/condiment/pack/pepper = custom_good_name("Prepper Packet")
+			/obj/item/reagent_containers/food/snacks/fishandchips = good_data("Carp and Chips", list(1, 3), 150),
+			/obj/item/reagent_containers/food/condiment/pack/ketchup = good_data("Ketchup Packet", list(1, 3), 5),
+			/obj/item/reagent_containers/food/condiment/pack/hotsauce = good_data("Hotsauce Packet", list(1, 3), 5),
+			/obj/item/reagent_containers/food/condiment/pack/salt = good_data("Salt Packet", list(1, 3), 5),
+			/obj/item/reagent_containers/food/condiment/pack/pepper = good_data("Pepper Packet", list(1, 3), 5)
 		)
 	)
 	hidden_inventory = list(
 		"Secret Menu" = list(
-			/obj/item/storage/box/monkeycubes = good_data("Monkey Cubes", list(1, 5), 700)
+			/obj/item/storage/box/monkeycubes = good_data("Monkey Cubes", list(1, 5), 700),
+			/obj/item/reagent_containers/food/snacks/clownburger = good_data("Funny RBurger", list(5, 10), 200),
+			/obj/item/reagent_containers/food/snacks/mimeburger = good_data("Silent RBurger", list(5, 10), 200),
+			/obj/item/reagent_containers/food/snacks/superbiteburger = good_data("Challenge RBurger", list(5, 10), 650),
+			/obj/item/reagent_containers/food/snacks/chickenburger = good_data("Fried Chicken Burger {No relation}", list(5, 10), 200)
 			// Needs funny and useful things
 		)
 	)
 	offer_types = list(
 		/obj/item/reagent_containers/food/snacks/meat = offer_data("meat", 100, 10),
 		/obj/item/reagent_containers/food/snacks/meat/corgi = offer_data("corgi meat", 1000, 2),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat = offer_data("roach meat", 200, 0),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/seuche = offer_data("seuche roach meat", 250, 0),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kraftwerk = offer_data("kraftwerk roach meat", 450, 0),
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/jager = offer_data("jager roach meat", 250, 0),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat = offer_data("roach meat", 200, 15),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/seuche = offer_data("seuche roach meat", 250, 10),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kraftwerk = offer_data("kraftwerk roach meat", 450, 10),
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/jager = offer_data("jager roach meat", 250, 10),
 		/obj/item/reagent_containers/food/snacks/meat/roachmeat/fuhrer = offer_data("fuhrer roach meat", 350, 5), //Caps it
 		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kaiser = offer_data("kaiser roach meat", 2000, 2)
 	)


### PR DESCRIPTION
Adds a dipping bird sub-item. Just a changed name and description for fluff. Adds this new item to the Ghost Kitchen station.

Adds a variety of office supplies to a new tab in the Ghost Kitchen station.

Sets a price for all the food Dionis sells, reeling in the meta of ordering 100's of 2 credit burgers for Church biomass. Also adds some novelty burgers to the Dionis secret inventory to flesh out a chronically anemic listing.

Adds the 9mm Economy disk to the Factorio expanded inventory.

Adds a basic clothing tab to the Absolute ships.

Sets a high price for Supermatters from Zarya, hopefully resulting in no more, if not heavily reduced random instances of supermatters being sent unsolicited to unsuspecting Cargotechs.

Edit, Also fixes a typo in the burger .DM

![image](https://github.com/user-attachments/assets/2117fd64-25da-454e-885c-d6da890cf8e1)
