### PR TITLE
shrapnel tweaks

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -21,7 +21,7 @@
 #define ARMOR_PEN_MASSIVE			3
 #define ARMOR_PEN_MAX				10
 
-//Wounding Multiplier: Increases damage taken, applied after armor.
+//Wounding Multiplier: Increases damage taken, applied after armor. Also increases odds of sharpnal embeds see human_defence.dm
 #define WOUNDING_HARMLESS			0.25
 #define WOUNDING_TINY				0.5
 #define WOUNDING_SMALL				0.75

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -982,6 +982,8 @@ var/list/rank_prefix = list(\
 		if(organ.status & ORGAN_SPLINTED) //Splints prevent movement.
 			continue
 
+		//Small pity system to half the amount of damage done by stacks of sharpnal. Has to be exstreamly unlucky to use it.
+		var/pity = FALSE
 		for(var/obj/item/O in organ.implants)
 			// Shrapnel hurts when you move, and implanting knives is a bad idea
 			if(prob(5) && is_sharp(O))
@@ -1001,7 +1003,11 @@ var/list/rank_prefix = list(\
 					if(species.reagent_tag == IS_SYNTHETIC && istype(organ, /obj/item/organ/external/chest))
 						continue
 
-					organ.take_damage(3, BRUTE, organ.max_damage, 6.7, TRUE, TRUE)	// When the limb is at 60% of max health, internal organs start taking damage.
+					if(!pity)
+						organ.take_damage(3, BRUTE, organ.max_damage, 1.3, TRUE, TRUE)
+						pity = TRUE
+					else
+						pity = FALSE
 					if(organ.setBleeding())
 						organ.take_damage(2, BRUTE) //Extra 2 damage
 					if(species.reagent_tag == IS_CHTMANT)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -38,7 +38,7 @@ uniquic_armor_act
 		//Shrapnel
 		if(P.can_embed() && (check_absorb < 2) && !src.stats.getPerk(PERK_IRON_FLESH))
 			var/armor = getarmor_organ(organ, ARMOR_BULLET)
-			if(prob((20 + max(P.damage_types[BRUTE] - (armor * 4), -10) * P.embed_mult)))
+			if(prob((10 + max(P.damage_types[BRUTE] - (armor * (3 - P.wounding_mult)), -10) * P.embed_mult))) //Good/high armor can fully protect against sharpnal
 				if(!P.shrapnel_type)
 					var/obj/item/material/shard/shrapnel/SP = new()
 					SP.name = (P.name != "shrapnel")? "[P.name] shrapnel" : "shrapnel"

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -50,6 +50,7 @@
 	sharp = FALSE
 	step_delay = 0.65
 	recoil = 5
+	embed_mult = 1.5
 
 /obj/item/projectile/bullet/pistol_35/rubber
 	name = "rubber bullet"
@@ -182,6 +183,7 @@
 	sharp = FALSE
 	step_delay = 0.5
 	recoil = 7
+	embed_mult = 1.5
 
 /obj/item/projectile/bullet/magnum_40/rubber
 	name = "rubber bullet"
@@ -321,6 +323,7 @@
 	can_ricochet = FALSE
 	step_delay = 0.8
 	recoil = 14
+	embed_mult = 2
 
 /obj/item/projectile/bullet/kurtz_50/hv
 	name = "AV bullet"
@@ -386,6 +389,7 @@
 	step_delay = 0.9
 	recoil = 4
 	ignition_source = FALSE
+	embed_mult = 1.5
 
 /obj/item/projectile/bullet/light_rifle_257/rubber/pepperball
 	name = "pepperball"
@@ -418,6 +422,7 @@
 	sharp = FALSE
 	step_delay = 0.6
 	recoil = 5
+	embed_mult = 2 //We suck and get blocked by must armor
 
 /obj/item/projectile/bullet/light_rifle_257/incend
 	name = "incendiary bullet"
@@ -489,6 +494,7 @@
 	step_delay = 0.9
 	recoil = 6
 	ignition_source = FALSE
+	embed_mult = 1.25
 
 /obj/item/projectile/bullet/rifle_75/rubber/soporific
 	name = "soporific coated rubber bullet"
@@ -519,6 +525,7 @@
 	sharp = FALSE
 	step_delay = 0.8
 	recoil = 10
+	embed_mult = 1.5
 
 /obj/item/projectile/bullet/rifle_75/incend
 	name = "incendiary bullet"
@@ -565,6 +572,7 @@
 	step_delay = 0.9
 	recoil = 14
 	ignition_source = FALSE
+	embed_mult = 1.5
 
 /obj/item/projectile/bullet/heavy_rifle_408/practice
 	name = "practice bullet"
@@ -600,6 +608,7 @@
 	sharp = FALSE
 	step_delay = 0.5
 	recoil = 16
+	embed_mult = 2
 
 /obj/item/projectile/bullet/heavy_rifle_408/incend
 	name = "incendiary bullet"
@@ -678,6 +687,7 @@
 	affective_ap_range = 9
 	penetrating = -5
 	recoil = 20
+	embed_mult = 3 //this round is designed for this.
 
 /obj/item/projectile/bullet/antim/incend
 	damage_types = list(BURN = 45)
@@ -758,6 +768,7 @@
 	affective_damage_range = 8
 	affective_ap_range = 8 //Anti-Air
 	recoil = 2
+	embed_mult = 1.5
 
 /obj/item/projectile/bullet/pellet/mech_flak/military //Scatter-Shot Autocannon
 	damage_types = list(BRUTE = 22)
@@ -1186,6 +1197,7 @@
 	affective_ap_range = 7
 	create_type = null
 	recoil = 10
+	embed_mult = 1.5
 
 
 /obj/item/projectile/bullet/reusable/rod_bolt/rcd
@@ -1212,6 +1224,7 @@
 	affective_damage_range = 7
 	affective_ap_range = 7
 	create_type = null
+	embed_mult = 2
 
 
 /obj/item/projectile/bullet/reusable/arrow

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -389,7 +389,6 @@
 	step_delay = 0.9
 	recoil = 4
 	ignition_source = FALSE
-	embed_mult = 1.5
 
 /obj/item/projectile/bullet/light_rifle_257/rubber/pepperball
 	name = "pepperball"
@@ -494,7 +493,6 @@
 	step_delay = 0.9
 	recoil = 6
 	ignition_source = FALSE
-	embed_mult = 1.25
 
 /obj/item/projectile/bullet/rifle_75/rubber/soporific
 	name = "soporific coated rubber bullet"
@@ -572,7 +570,6 @@
 	step_delay = 0.9
 	recoil = 14
 	ignition_source = FALSE
-	embed_mult = 1.5
 
 /obj/item/projectile/bullet/heavy_rifle_408/practice
 	name = "practice bullet"


### PR DESCRIPTION
Lowers sharpnal embed odds by 10%
shrapnel now deals way less organ damage
shrapnel now has a internal pity system that every other same action jostle that triggers it will nullify another trigger affectively halfling to 2/3s unlucky shrapnel movements
shrapnel now can be fully blocked by using good armor
projectiles wound mult now affect how likely you are to get shrapnel
Raises HP embed mult to be more able to embed

this heavily incentives waring real armor