### PR TITLE
 Boots and Gloves

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -32,7 +32,7 @@
 
 /obj/item/clothing/gloves/insulated/guild
 	name = "Artificers insulated gloves"
-	desc = "A pare of insulated gloves woven into a thicker fire restant pare."
+	desc = "A pare of insulated gloves woven into a thicker fire restant pair."
 	icon_state = "guild_yellow"
 	item_state = "guild_yellow"
 	armor_list = list(melee = 5, bullet = 3, energy = 3, bomb = 10, bio = 100, rad = 100)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -32,7 +32,7 @@
 
 /obj/item/clothing/gloves/insulated/guild
 	name = "Artificers insulated gloves"
-	desc = "A pare of insulated gloves woven into a thicker fire resistant pair."
+	desc = "A pair of insulated gloves woven into a thicker fire resistant pair."
 	icon_state = "guild_yellow"
 	item_state = "guild_yellow"
 	armor_list = list(melee = 5, bullet = 3, energy = 3, bomb = 10, bio = 100, rad = 100)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -32,7 +32,7 @@
 
 /obj/item/clothing/gloves/insulated/guild
 	name = "Artificers insulated gloves"
-	desc = "A pare of insulated gloves woven into a thicker fire restant pair."
+	desc = "A pare of insulated gloves woven into a thicker fire resistant pair."
 	icon_state = "guild_yellow"
 	item_state = "guild_yellow"
 	armor_list = list(melee = 5, bullet = 3, energy = 3, bomb = 10, bio = 100, rad = 100)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -67,4 +67,12 @@
 	mag_slow = 2
 	icon_base = "mercboots"
 	action_button_name = "Toggle Magboots"
+	armor_list = list(
+		melee = 8,
+		bullet = 5,
+		energy = 6,
+		bomb = 75,
+		bio = 100,
+		rad = 75
+	)
 	price_tag = 275

--- a/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
@@ -64,7 +64,8 @@
 			/obj/item/clothing/suit/storage/vest,
 			/obj/item/clothing/head/helmet/tanker,
 			/obj/item/clothing/suit/armor/bulletproof,
-			/obj/item/clothing/suit/armor/laserproof
+			/obj/item/clothing/suit/armor/laserproof,
+			/obj/item/clothing/gloves/thick/swat
 		)
 	)
 	hidden_inventory = list(


### PR DESCRIPTION
Fixes a typo in the Artificers insulated gloves dec.

Gives the military magboots a set of protection values that differs from the standard magboots. More physical protection, less rad protection.

Adds swat gloves to the Hellcat armor tab.


![image](https://github.com/user-attachments/assets/3c18f39b-d627-431e-8770-6afdf271b4fc)
