### PR TITLE
Mac and Texan buffs

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1184,6 +1184,8 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 		weapon_stats += list(list("name" = "Projectile Damage Multiplier", "type" = "AnimatedNumber", "value" = damage_multiplier, "unit" = "x"))
 	if(pierce_multiplier != 0)
 		weapon_stats += list(list("name" = "Projectile Wall Penetration", "type" = "AnimatedNumber", "value" = pierce_multiplier, "unit" = " walls"))
+	if(wound_mult_addition != 0)
+		weapon_stats += list(list("name" = "Projectile Post-Armor Damage Mult Addition", "type" = "AnimatedNumber", "value" = wound_mult_addition, "unit" = "+"))
 	if(penetration_multiplier != 1)
 		weapon_stats += list(list("name" = "Projectile AP Multiplier", "type" = "AnimatedNumber", "value" = penetration_multiplier, "unit" = "x"))
 	if(proj_agony_multiplier != 1)

--- a/code/modules/projectiles/guns/projectile/automatic/mac.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/mac.dm
@@ -1,6 +1,10 @@
+//A combat classifed in gun loot pools weapon that deals more damage to less armored
 /obj/item/gun/projectile/automatic/mac
 	name = "\"MAC\" SMG"
-	desc = "A conceptual replica of an old and incredibly simple SMG. However, ergonomics were never good on the original, and recoil is rather significant. Essentially disposable. Uses 9mm."
+	desc = "A conceptual replica of an old and incredibly simple SMG. \
+	Designed to be used against unarmored threats. \
+	However, ergonomics were never good on the original, and recoil is rather significant. \
+	Essentially disposable. Uses 9mm."
 	icon = 'icons/obj/guns/projectile/mac.dmi'
 	icon_state = "mac"
 	item_state = "mac"
@@ -15,6 +19,8 @@
 	price_tag = 700
 	gun_parts = null
 	damage_multiplier = 0.9
+	penetration_multiplier = 0.8
+	wound_mult_addition = 0.75
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE, GUN_CALIBRE_9MM, GUN_MAGWELL)
 	init_recoil = SMG_RECOIL(0.7)
 

--- a/code/modules/projectiles/guns/projectile/automatic/texan.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/texan.dm
@@ -1,3 +1,4 @@
+//SMG that basically is meant to deal damage even against armored mobs, counts as a normal gun for spawn pool
 /obj/item/gun/projectile/automatic/texan
 	name = "\"Texan\" SMG"
 	desc = "The Texan is a reliable assault weapon, mass-produced by SD GmbH for raiding parities in tight hallways, with a moderate effectiveness against soft body armor. Uses 9mm rounds."
@@ -14,7 +15,7 @@
 	matter = list(MATERIAL_PLASTEEL = 16, MATERIAL_WOOD = 4)
 	price_tag = 800
 	damage_multiplier = 0.9
-	penetration_multiplier = 1.5
+	penetration_multiplier = 2
 	init_recoil = SMG_RECOIL(0.5)
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM, GUN_MAGWELL)
 	serial_type = "SD GmbH"

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -11,6 +11,14 @@
 				 {{:data.damage_multiplier}}x
 			</div>
 		{{/if}}
+		{{if data.wound_mult_addition != 1}}
+			<div class="itemLabel">
+				Projectile Post-Armor Damage Mult Addition:
+			</div>
+			<div class="itemContent">
+				 {{:data.wound_mult_addition}}x
+			</div>
+		{{/if}}
 
 		{{if data.pierce_multiplier != 0}}
 			<div class="itemLabel">


### PR DESCRIPTION
Texan has been giving 0.5 more armor mult to help it deal affective damage against soft-armor.
Mac has traded 0.2 armor mult for a (1).75 gain in post-armor damage mult making it affective against unarmored/low armored mobs that group up such as roaches
Basically makes the two have the use cases that they used to have before the gun rework:
Texan is meant to deal conistant but lower damage to the Mac that has more damage

Also adds the wound mult adder stat to gun UI's