### PR TITLE
Mob-exclusive catalyst drop changes

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -229,10 +229,14 @@
 /obj/effect/decal/cleanable/psi_ash/ponderous
 	name = "strange ashes of ponderous"
 	catalyst_drop = /obj/random/psi_catalyst/ponderous
+	psion_chance = 35
+	normie_chance = 15
 
 /obj/effect/decal/cleanable/psi_ash/flesh_behemoth
 	name = "strange ashes of flesh behemoth"
 	catalyst_drop = /obj/random/psi_catalyst/flesh_behemoth
+	psion_chance = 45
+	normie_chance = 20
 
 /obj/effect/decal/cleanable/psi_ash/king
 	name = "ashes of the throne bound tyrant"

--- a/code/modules/psionics/psionic_items/psi_catalysts.dm
+++ b/code/modules/psionics/psionic_items/psi_catalysts.dm
@@ -293,10 +293,10 @@
 
 /obj/random/psi_catalyst/ponderous/item_to_spawn()
 	return pickweight(list(
-				/obj/random/psi_catalyst = 20,
-				/obj/item/device/psionic_catalyst/summan_trash_pile = 10,
-				/obj/item/device/psionic_catalyst/trash_pile_compress = 10,
-				/obj/item/device/psionic_catalyst/trash_pile_exploid = 10))
+				/obj/random/psi_catalyst = 5,
+				/obj/item/device/psionic_catalyst/summan_trash_pile = 15,
+				/obj/item/device/psionic_catalyst/trash_pile_compress = 15,
+				/obj/item/device/psionic_catalyst/trash_pile_exploid = 15))
 
 /obj/random/psi_catalyst/flesh_behemoth
 	name = "random flesh behemoth psi_catalyst"
@@ -304,10 +304,10 @@
 
 /obj/random/psi_catalyst/flesh_behemoth/item_to_spawn()
 	return pickweight(list(
-				/obj/random/psi_catalyst = 20,
-				/obj/item/device/psionic_catalyst/needle_n_thread = 10,
-				/obj/item/device/psionic_catalyst/purify = 10,
-				/obj/item/device/psionic_catalyst/temp_regulate = 10))
+				/obj/random/psi_catalyst = 5,
+				/obj/item/device/psionic_catalyst/needle_n_thread = 15,
+				/obj/item/device/psionic_catalyst/purify = 15,
+				/obj/item/device/psionic_catalyst/temp_regulate = 15))
 
 
 // Psi-related lore paperwork. Not really a good place to put this so here it is. -Kaz

--- a/code/modules/psionics/psionic_items/psi_catalysts.dm
+++ b/code/modules/psionics/psionic_items/psi_catalysts.dm
@@ -293,7 +293,7 @@
 
 /obj/random/psi_catalyst/ponderous/item_to_spawn()
 	return pickweight(list(
-				/obj/random/psi_catalyst = 5,
+				/obj/random/psi_catalyst = 15,
 				/obj/item/device/psionic_catalyst/summan_trash_pile = 15,
 				/obj/item/device/psionic_catalyst/trash_pile_compress = 15,
 				/obj/item/device/psionic_catalyst/trash_pile_exploid = 15))
@@ -304,7 +304,7 @@
 
 /obj/random/psi_catalyst/flesh_behemoth/item_to_spawn()
 	return pickweight(list(
-				/obj/random/psi_catalyst = 5,
+				/obj/random/psi_catalyst = 15,
 				/obj/item/device/psionic_catalyst/needle_n_thread = 15,
 				/obj/item/device/psionic_catalyst/purify = 15,
 				/obj/item/device/psionic_catalyst/temp_regulate = 15))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
Makes small changes here and there to increase the odds of getting the fancy catalysts from ponderous and flesh behemoth. As someone who spent HOURS hunting for these silly-ass cubes, it's currently very infuriating with how rare these can be, ESPECIALLY the flesh behemoth ones. I tried to stay within reason while tweaking the values, and I'll be sure to see if they're fair next excursion.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: drop rates of mob-exclusive catalysts
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
