### PR TITLE
fixes slime gun and makes feeding less exploitable

### DIFF
--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -21,7 +21,8 @@
 		return "I cannot feed on other slimes..."
 	if (!Adjacent(M))
 		return "This subject is too far away..."
-	if (iscarbon(M) && M.getFireLoss() >= M.maxHealth * 1.5 || isanimal(M) && M.stat == DEAD)
+		//Dead things dont have life also overly burned do not as well, walking corps
+	if (M.getFireLoss() >= M.maxHealth * 1.5 || M.stat == DEAD)
 		return "This subject does not have an edible life energy..."
 	for(var/mob/living/carbon/slime/met in view())
 		if(met.Victim == M && met != src)
@@ -44,9 +45,10 @@
 
 			if(iscarbon(M))
 				Victim.adjustFireLoss(rand(5,6))
-				Victim.adjustToxLoss(rand(1,2))
+				Victim.adjustCloneLoss(rand(6,8))
 				if(Victim.health <= 0)
-					Victim.adjustToxLoss(rand(2,4))
+					Victim.adjustCloneLoss(rand(8,12))
+					Victim.adjustFireLoss(rand(10,12))
 
 			else if(isanimal(M))
 				Victim.adjustBruteLoss(is_adult ? rand(7, 15) : rand(4, 12))

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -172,6 +172,10 @@
 /mob/living/carbon/slime/bullet_act(var/obj/item/projectile/Proj)
 	if (!(Proj.testing))
 		attacked += 10
+	//Fast return for this as we always hit and always kill
+	if(istype(Proj, /obj/item/projectile/slime_death))
+		death() //We just die
+		return TRUE
 	..(Proj)
 	if (!(Proj.testing))
 		handle_regular_status_updates()

--- a/code/modules/projectiles/guns/energy/misc/slimegun.dm
+++ b/code/modules/projectiles/guns/energy/misc/slimegun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/slimegun
 	name = "\"Ranch\" core stopper gun"
-	desc = "A gun suited for dealing with slime outbreaks, due to many safety innovations the beam will be harmless for anything other than slime lifeforms. \
+	desc = "A gun suited for dealing with slime outbreaks, due to many safety innovations the beam will be harmless for anything other than simple slime lifeforms. \
 	When hitting a slime, the beam will directly attack its core, shutting it down for an instantaneous death while keeping it intact for harvesting. Due to its small design it only takes small cells."
 	icon = 'icons/obj/guns/energy/slimegun.dmi'
 	icon_state = "slimepistol"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -143,14 +143,6 @@
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	hitscan = FALSE
 
-/obj/item/projectile/slime_death/on_impact(atom/target)//These two could likely check temp protection on the mob
-	if (!testing)
-		if(isliving(target))
-			if(isslime(target))
-				var/mob/living/carbon/slime/cute = target
-				nodamage = FALSE
-				cute.death() // The cute slime dies.
-
 /obj/item/projectile/meteor
 	name = "meteor"
 	icon = 'icons/obj/meteor.dmi'


### PR DESCRIPTION
Slimes when shot with slime gun, now die again
Slimes now cant feed on dead bodies at all
Slimes deal clone damage rather then toxins to make them a little less lethal but more lasting in harm
Increases Slime feeding burn and clone damage 
Updates the slime gun desc to say "simple" slime lifeforms to hint that it infact dosnt harm slime players.