### PR TITLE
Nerve buff

### DIFF
--- a/code/modules/organs/internal/nerves.dm
+++ b/code/modules/organs/internal/nerves.dm
@@ -4,7 +4,7 @@
 	desc = "Looking at this makes you feel nervous."
 	organ_efficiency = list(OP_NERVE = 100)
 	price_tag = 100
-	max_damage = IORGAN_TINY_HEALTH
+	max_damage = IORGAN_SMALL_HEALTH
 	min_bruised_damage = IORGAN_TINY_BRUISE
 	min_broken_damage = IORGAN_TINY_BREAK
 	specific_organ_size = 1


### PR DESCRIPTION
Changes the nerve health to be SMALL instead of TINY, effectively bringing it up to par with Muscles.

The damage thresholds are untouched, so theoretically they're still more likely to accumulate a wound at lesser damages, but I don't exactly know how the wound code works.

Getting unlucky with a laser shot (Especially with how most lasers punch through ablative armor anyways, or the subpar quality of ablation on DEDICATED ablation gear) can lead to frankly an incredibly frustrating death spiral of a nerve accumulating a single organ wound, and just dying within minutes, leading to necrosis and everything that follows.

So in Summary:
What?
Nerves go from 4 to 6 HP, moving them past a very important damage threshold.

Why?
Given how a SINGLE burn or bruise on a limb's nerves can render a player  floored given a few minutes followed by an organ failure death spiral, it's an overtly punishing mechanic from what potentially happens from a single laser shot.

Who?
This would primarily impact prospectors fighting GP and Voidwolves, but secondarily would impact the junkfield portals with drones.

When?
What? Whenever organ damage is sustained on the nerves, I guess.

How?
I'm getting sick of you.

![image](https://github.com/user-attachments/assets/8e797d0a-36d2-47ec-8712-3116f401717f)
