### PR TITLE
Auto Doc Fix and Ore Box UI

### DIFF
--- a/nano/templates/autodoc_capitalism.tmpl
+++ b/nano/templates/autodoc_capitalism.tmpl
@@ -30,7 +30,7 @@
         <div class="itemLabel">Blood level: <div style="float:right; margin-right:6px"><b>{{:helper.round(data.blood_amount)}}</b></div></div>
         <div class="itemContent">
 			{{:helper.displayBar(	data.blood_amount, 0, 100, 	(data.blood_amount >= 85) ? 'good' : (data.blood_amount >= 60) ? 'average' : 'bad')}}</div>
-			
+
         {{:helper.link('Toxin kelation: '+data.toxin_cost,  data.antitox_picked?'check':null,	{'toggle':'antitox', 	'id':1},	(data.antitox && !data.active)?	null:'disabled')}}
         {{:helper.link('Replenish blood: '+data.blood_cost, data.blood_picked?'check':null,		{'toggle':'blood', 		'id':1},	(data.blood && !data.active)? 	null:'disabled')}}
         {{:helper.link('Dialysis: '+data.dialysis_cost,     data.dialysis_picked?'check':null,	{'toggle':'dialysis', 	'id':1},	(data.dialysis && !data.active)? null:'disabled')}}
@@ -43,7 +43,7 @@
 			<div class="itemContent" style="color:red">
 			<b>Organ damage: {{:helper.round(value.inner_damage)}}</b>
 			</div><br>
-			{{:helper.link('Fix damage: '+data.damage_cost,         value.damage_picked?'check':null,	{'toggle':'damage',	 'id':value.id},    (value.damage && !data.active)? 	 null:'disabled')}}
+			{{:helper.link('Treat Internal Damage: '+data.damage_cost,         value.damage_picked?'check':null,	{'toggle':'internal_wound',	 'id':value.id},    (value.damage && !data.active)? 	 null:'disabled')}}
 		{{else}}
 			<div class="itemLabel"><b>{{:value.name}}</b></div>
 			<div class="itemContent">
@@ -52,7 +52,6 @@
 			</div><br>
 			{{:helper.link('Fix damage: '+data.damage_cost,         value.damage_picked?'check':null,	{'toggle':'damage',	 'id':value.id},    (value.damage && !data.active)?		null:'disabled')}}
 			{{:helper.link('Close wounds: '+data.wound_cost,        value.wound_picked?'check':null,	{'toggle':'wound',	 'id':value.id},    (value.wound && !data.active)?		null:'disabled')}}
-			{{:helper.link('Mend Internal Damage: '+data.ib_cost,               value.ib_picked?'check':null,		{'toggle':'ib',		 'id':value.id},    (value.ib && !data.active)?			null:'disabled')}}
 			{{:helper.link('Shrapnel removal: '+data.shrapnel_cost, value.shrapnel_picked?'check':null,	{'toggle':'shrapnel','id':value.id},    (value.shrapnel && !data.active)?	null:'disabled')}}
 			{{:helper.link('Mend Fracture: '+data.fracture_cost,    value.fracture_picked?'check':null,	{'toggle':'fracture','id':value.id},    (value.fracture && !data.active)?	null:'disabled')}}
 		{{/if}}

--- a/tgui/packages/tgui/interfaces/OreBox.tsx
+++ b/tgui/packages/tgui/interfaces/OreBox.tsx
@@ -1,53 +1,59 @@
+import { toTitleCase } from 'common/string';
 import { useState } from 'react';
-import { useBackend } from 'tgui/backend';
-import { Button } from 'tgui/components';
-import { Window } from 'tgui/layouts';
-import { Box, NumberInput, Section, Stack } from 'tgui-core/components';
-import { toTitleCase } from 'tgui-core/string';
+
+import { useBackend } from '../backend';
+import { Box, Button, NumberInput, Section, Stack } from '../components';
+import { Window } from '../layouts';
 
 type Data = {
-  materials: Material[];
-};
+  materials: Material[]
+}
 
 type Material = {
-  type: string;
-  name: string;
-  amount: number;
-};
+  type: string
+  name: string
+  amount: number
+}
 
-export const OreBox = (props) => {
+export const OreBox = props => {
   const { act, data } = useBackend<Data>();
   const { materials } = data;
 
+  materials.sort((a, b) => {
+    if (a.name < b.name) { return -1; }
+    if (a.name > b.name) { return 1; }
+    return 0;
+  });
+
   return (
-    <Window width={460} height={265}>
+    <Window width={600} height={265}>
       <Window.Content>
         <Section
           fill
           scrollable
-          title="Ores"
+          title='Ores'
           buttons={
             <Button
-              content="Eject All Ores"
+              content='Eject All Ores'
               onClick={() => act('ejectallores')}
             />
           }
         >
-          <Stack direction="column">
+          <Stack direction='column'>
             <Stack.Item>
               <Section>
                 <Stack vertical>
-                  <Stack align="start">
-                    <Stack.Item basis="30%">
+                  <Stack align='start'>
+                    <Stack.Item basis='30%'>
                       <Box bold>Ore</Box>
                     </Stack.Item>
-                    <Stack.Item basis="20%">
-                      <Section align="center">
+                    <Stack.Item basis='20%'>
+                      <Section align='center'>
                         <Box bold>Amount</Box>
                       </Section>
                     </Stack.Item>
                   </Stack>
-                  {materials.map((material) => (
+                  {materials.map(material => (
                     <OreRow
                       key={material.type}
                       material={material}
@@ -57,7 +63,7 @@ export const OreBox = (props) => {
                           qty: amount,
                         })
                       }
-                      onReleaseAll={(type) =>
+                      onReleaseAll={type =>
                         act('ejectall', {
                           type: type,
                         })
@@ -74,7 +80,7 @@ export const OreBox = (props) => {
   );
 };
 
-const OreRow = (props) => {
+const OreRow = props => {
   const { material, onRelease, onReleaseAll } = props;
 
   const [amount, setAmount] = useState(1);
@@ -82,31 +88,35 @@ const OreRow = (props) => {
   const amountAvailable = Math.floor(material.amount);
   return (
     <Stack.Item>
-      <Stack align="center">
-        <Stack.Item basis="30%">{toTitleCase(material.name)}</Stack.Item>
-        <Stack.Item basis="20%">
-          <Section align="center">
-            <Box mr={0} color="label" inline>
+      <Stack align='center'>
+        <Stack.Item basis='30%'>{toTitleCase(material.name)}</Stack.Item>
+        <Stack.Item basis='20%'>
+          <Section align='center'>
+            <Box mr={0} color='label' inline>
               {amountAvailable}
             </Box>
           </Section>
         </Stack.Item>
-        <Stack.Item basis="50%">
+        <Stack.Item basis='50%'>
           <NumberInput
-            width="32px"
+            width='32px'
             step={1}
             stepPixelSize={5}
             minValue={1}
-            maxValue={100}
+            maxValue={600}
             value={amount}
-            onChange={(value) => setAmount(value)}
+            onChange={value => setAmount(value)}
           />
           <Button
-            content="Eject Amount"
+            content='Eject Amount'
             onClick={() => onRelease(material.type, amount)}
           />
           <Button
-            content="Eject All"
+            content='Eject 120'
+            onClick={() => onRelease(material.type, 120)}
+          />
+          <Button
+            content='Eject All'
             onClick={() => onReleaseAll(material.type)}
           />
         </Stack.Item>


### PR DESCRIPTION
By WeNeedMorePhoron
fix: Non-Excelsior Autodoc no longer try to fix non-existent internal damage on external organs and will fix internal damage on internal organs properly now.
tweak: Orebox can accept custom ejection amount up to 600 (5 stacks), has a eject 120 (full stack) short cut, has a wider window and now sorts the minerals alphabetically to minimize unnecessary UI shift when you eject any ores from it.