### PR TITLE
Re-enables telekinetic hydroponics harvesting, removes the plant teleportation that it previously caused

### DIFF
--- a/code/game/objects/items/oddities_faction.dm
+++ b/code/game/objects/items/oddities_faction.dm
@@ -726,7 +726,7 @@ No more of that.
 					"wheat",
 					"potato",
 					"rice")]
-				S.harvest(get_turf(src),0,0,1)
+				S.harvest(get_turf(src),get_turf(src),0,0,1)
 
 
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -887,7 +887,7 @@ ADMIN_VERB_ADD(/datum/admins/proc/spawn_fruit, R_DEBUG, FALSE)
 	if(!seedtype || !plant_controller.seeds[seedtype])
 		return
 	var/datum/seed/S = plant_controller.seeds[seedtype]
-	S.harvest(usr,0,0,1)
+	S.harvest(usr,get_turf(usr),0,0,0,1)
 	log_admin("[key_name(usr)] spawned [seedtype] fruit at ([usr.x],[usr.y],[usr.z])")
 
 ADMIN_VERB_ADD(/datum/admins/proc/spawn_custom_item, R_DEBUG, FALSE)

--- a/code/modules/hydroponics/grown_predefined.dm
+++ b/code/modules/hydroponics/grown_predefined.dm
@@ -16,7 +16,7 @@
 /*
 /obj/plant_spawner/Initialize(mapload)
 	var/datum/seed/S = plant_controller.seeds[seedtype]
-	S.harvest(loc,0,0,1)
+	S.harvest(loc,get_turf(src),0,0,1)
 	spawn(1) if(src) qdel(src)
 */
 /obj/plant_spawner/New()
@@ -25,7 +25,7 @@
 
 /obj/plant_spawner/proc/spawn_growth()
 	var/datum/seed/S = plant_controller.seeds[seedtype]
-	S.harvest(loc,force_amount = 1, harvest_sample = FALSE)
+	S.harvest(loc,get_turf(src),force_amount = 1, harvest_sample = FALSE)
 	spawn(5) if(src) qdel(src)
 
 /obj/plant_spawner/libertycap

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -722,10 +722,13 @@
 		P.values[trait] = get_trait(trait)
 	return P
 
-//Place the plant products at the feet of the user.
-/datum/seed/proc/harvest(mob/living/user,yield_mod,potency_mod,harvest_sample,force_amount)
+//Place the plant products at the floor of the tray.
+/datum/seed/proc/harvest(mob/living/user,turf/location,yield_mod,potency_mod,harvest_sample,force_amount)
 
 	if(!user)
+		return
+
+	if(!location)
 		return
 
 	if(!force_amount && get_trait(TRAIT_YIELD) == 0 && !harvest_sample)
@@ -740,7 +743,7 @@
 			plant_controller.seeds[name] = src
 
 		if(harvest_sample)
-			var/obj/item/seeds/seeds = new(get_turf(user))
+			var/obj/item/seeds/seeds = new(get_turf(location))
 			seeds.seed_type = name
 			seeds.update_seed()
 			return
@@ -780,9 +783,9 @@
 		for(var/i = 0;i<total_yield;i++)
 			var/obj/item/product
 			if(has_mob_product)
-				product = new has_mob_product(get_turf(user),name)
+				product = new has_mob_product(get_turf(location),name)
 			else
-				product = new /obj/item/reagent_containers/snacks/grown(get_turf(user),name,potency_mod)
+				product = new /obj/item/reagent_containers/snacks/grown(get_turf(location),name,potency_mod)
 			if(get_trait(TRAIT_PRODUCT_COLOUR))
 				if(!ismob(product))
 					product.color = get_trait(TRAIT_PRODUCT_COLOUR)

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -57,7 +57,7 @@
 			return
 		if(prob(70))
 			sampled = 1
-		seed.harvest(user,0,1)
+		seed.harvest(user,get_turf(src),0,1)
 		health -= (rand(3,5)*5)
 		sampled = 1
 		return

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -8,7 +8,6 @@
 	volume = 100
 	price_tag = 150 //Mostly just to have a price for the beacon, but I guess you could sell them if you were REALLY desperate?
 
-	blue_ink_tk_blocker = TRUE //Removes bugs with teleportion
 
 	var/mechanical = 1         // Set to 0 to stop it from drawing the alert lights.
 	var/base_name = "tray"
@@ -272,7 +271,7 @@
 /*
 	if(user.stats.getPerk(PERK_MASTER_HERBALIST))
 		yield_mod += 2
-		seed.harvest(user,yield_mod)
+		seed.harvest(user,get_turf(src),yield_mod)
 	else
 */
 	var/post_moder_yield_mod = yield_mod
@@ -293,7 +292,7 @@
 //	to_chat(user, "yield_mod [seed.display_name]. post_moder_yield_mod [post_moder_yield_mod].")
 
 	if(user)
-		seed.harvest(user,yield_mod,potency_mod)
+		seed.harvest(user,get_turf(src),yield_mod,potency_mod)
 	else
 		seed.selfharvest(get_turf(src),yield_mod,potency_mod)
 	// Reset values.
@@ -512,7 +511,7 @@
 				to_chat(user, SPAN_NOTICE("You have already sampled from this plant."))
 				if(user.a_intent == I_HURT)
 					to_chat(user, SPAN_NOTICE("You start killing it for one last sample."))
-					seed.harvest(user,yield_mod,potency_mod,1)
+					seed.harvest(user,get_turf(src),yield_mod,potency_mod,1)
 					dead = 1
 					update_icon()
 				return
@@ -523,7 +522,7 @@
 
 			if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_VERY_EASY, required_stat = STAT_BIO))
 				// Create a sample.
-				seed.harvest(user,yield_mod, potency_mod,1)
+				seed.harvest(user,get_turf(src),yield_mod, potency_mod,1)
 				health -= (rand(3,5)*10)
 				sampled += 1 //no RnG not anymore
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	Another minor gripe PR (The best reason for PRs)
	
	I was mildly annoyed at being unable to harvest from trays and soil plots at a distance, but understood the reasoning why it was disabled.
	Therefore, I made harvesting from trays, even with telekinesis, put it on the same turf as the tray. Also works with farmbots, making automated farms infinitely neater.
	
	I tested every scenario where harvesting occurs I could find, but if something pops up, throw a brick at me, I'll try to fix it
<hr>
</details>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
