### PR TITLE
Fixes custom art names and allows them to be longer

### DIFF
--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -322,9 +322,10 @@
 	var/datum/design/art
 	if (isobj(artwork))
 		art = new()
-		var/setname = sanitizeSafe(input(user,"Name your creation. Keep empty for a random name.","Set Name",""), MAX_NAME_LEN)
+		var/setname = sanitizeSafe(input(user,"Name your creation. Keep empty for a random name.","Set Name",""), MAX_LNAME_LEN)
 		if (setname)
 			artwork.name = setname
+			artwork.fake_name = setname
 		var/setdesc = sanitizeSafe(input(user,"Describe your creation. Keep empty for a random description.","Set Description",""), MAX_DESC_LEN)
 		if (setdesc)
 			artwork.desc = setdesc


### PR DESCRIPTION
closes #5967 
Fixes artistic guns names being reset on fire, as well as increases name letter count from 24 to 64