### PR TITLE
Adds fancy movement

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -29,6 +29,7 @@
 #define NUM_E 2.71828183
 
 #define M_PI						3.1416
+#define SQRT_2 1.414214 //CLOSE ENOUGH!
 #define INFINITY				1.#INF // tg uses 1e31, not ready to change this
 #define SYSTEM_TYPE_INFINITY	1.#INF //only for isinf check
 

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -2,6 +2,9 @@
 #define MOVE_DELAY_BASE 1.1
 #define MOVE_DELAY_VENTCRAWL MOVE_DELAY_BASE //Ventcrawling has a static speed for all mobs
 
+#define MOVE_DELAY_DIAGONAL_ADDER 1.4
+
+
 //Glidesize
 #define FRACTIONAL_GLIDESIZES 1
 #ifdef FRACTIONAL_GLIDESIZES

--- a/code/controllers/subsystems/movement/movement_types.dm
+++ b/code/controllers/subsystems/movement/movement_types.dm
@@ -19,6 +19,8 @@
 	var/lifetime = INFINITY
 	///Delay between each move in deci-seconds
 	var/delay = 1
+	///Used to help keep track of mob delay
+	var/starting_delay = 1
 	///The next time we should process
 	///Used primarially as a hint to be reasoned about by our [controller], and as the id of our bucket
 	///Should not be modified directly outside of [start_loop]
@@ -41,6 +43,7 @@
 		return FALSE
 
 	src.delay = max(delay, world.tick_lag) //Please...
+	src.starting_delay = delay
 	src.lifetime = timeout
 	return TRUE
 
@@ -189,6 +192,8 @@
  *
 **/
 /datum/controller/subsystem/move_manager/proc/move_to_dir(moving, direction, delay, timeout, subsystem, priority, flags, datum/extra_info)
+	if(direction == NORTHEAST || direction == NORTHWEST || direction == SOUTHEAST || direction == SOUTHWEST)
+		delay += MOVE_DELAY_DIAGONAL_ADDER //help stops faster movement if going in diagonals
 	return add_to_loop(moving, subsystem, /datum/move_loop/move/move_to, priority, flags, extra_info, delay, timeout, direction)
 
 /datum/move_loop/move/move_to
@@ -459,6 +464,9 @@
  *
 **/
 /datum/controller/subsystem/move_manager/proc/move_to(moving, chasing, min_dist, delay, timeout, subsystem, priority, flags, datum/extra_info)
+
+	//log_and_message_admins("delay 0 [delay]")
+
 	return add_to_loop(moving, subsystem, /datum/move_loop/has_target/dist_bound/move_to, priority, flags, extra_info, delay, timeout, chasing, min_dist)
 
 ///Wrapper around walk_to()
@@ -468,11 +476,18 @@
 	return (get_dist(moving, target) > distance) //If you get too close, stop moving closer
 
 /datum/move_loop/has_target/dist_bound/move_to/move()
+	//log_and_message_admins("delay 1 [delay] vs [starting_delay]")
+	delay = starting_delay
 	. = ..()
 	if(!.)
 		return
 	var/atom/old_loc = moving.loc
+	var/true_direction = get_dir(moving, target)
+	if(true_direction == NORTHEAST || true_direction == NORTHWEST || true_direction == SOUTHEAST || true_direction == SOUTHWEST)
+		delay += MOVE_DELAY_DIAGONAL_ADDER //help stops faster movement if going in diagonalsy
 	step_to(moving, target)
+	//log_and_message_admins("delay 2 [delay] vs [starting_delay]")
+
 	return old_loc != moving?.loc
 
 /**

--- a/code/modules/client/edge_sliding/move_loop.dm
+++ b/code/modules/client/edge_sliding/move_loop.dm
@@ -4,7 +4,7 @@
 		move_dir = 0 //keep track of the direction the player is currently trying to move in.
 		true_dir = 0
 		keypresses = 0
-		CAN_MOVE_DIAGONALLY = 0
+		CAN_MOVE_DIAGONALLY = 1 //Soj edit
 
 	//rebind your interface so that your north/south/east/west keypresses are bound to:
 	//keydown: MoveKey [Direction] 1

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -88,7 +88,7 @@
 			client.UI.show()
 		else
 			client.create_UI(src.type)
-		client.CAN_MOVE_DIAGONALLY = FALSE
+		client.CAN_MOVE_DIAGONALLY = TRUE //Soj change to allow diagonal movement
 		add_click_catcher()
 		client.fullscreen_check()
 		client.init_verbs()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -190,6 +190,10 @@
 
 	. += move_intent.move_delay
 
+	if(client)
+		if(client.true_dir == NORTHEAST || client.true_dir == NORTHWEST || client.true_dir == SOUTHEAST || client.true_dir == SOUTHWEST)
+			. += MOVE_DELAY_DIAGONAL_ADDER //If we are moving in a cornerdirs then we slow down a bit to not cheat movement
+
 
 /mob/proc/Life()
 	LEGACY_SEND_SIGNAL(src, COMSIG_MOB_LIFE)


### PR DESCRIPTION
Adds in diagonal movement sanity and slowdown to prevent issues of wave dashing or movement speed buffs by always running in diagonal movements

Mobs now properly (in chases and some other intractions) keep same speed just about

Enables all players diagonal movements