### PR TITLE
Organic and Robotic internal injuries nerf

### DIFF
--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -9,7 +9,7 @@
 	treatments_tool = list(QUALITY_CAUTERIZING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_BLOODCLOT = 0.55)	// Tricordrazine/polystem + bicaridine + meralyne OR quickclot OD + any brute heal
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	hal_damage = IWOUND_MEDIUM_DAMAGE
 
 /datum/component/internal_wound/organic/blunt/rupture
@@ -34,7 +34,7 @@
 	treatments_tool = list(QUALITY_CAUTERIZING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_BLOODCLOT = 0.85)	// Brute heal chem mix + quickclot OD
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	next_wound = /datum/component/internal_wound/organic/swelling
 	hal_damage = IWOUND_MEDIUM_DAMAGE
 
@@ -60,7 +60,7 @@
 	treatments_tool = list(QUALITY_CAUTERIZING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_BLOODCLOT = 0.85)	// Brute heal chem mix + quickclot OD
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	next_wound = /datum/component/internal_wound/organic/swelling
 	hal_damage = IWOUND_MEDIUM_DAMAGE
 
@@ -87,7 +87,7 @@
 	treatments_chem = list(CE_STABLE = 1, CE_DEBRIDEMENT = 1)	// Inaprov will only keep it from killing you
 	scar = /datum/component/internal_wound/organic/necrosis_start
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	next_wound = /datum/component/internal_wound/organic/infection
 	hal_damage = IWOUND_MEDIUM_DAMAGE
 

--- a/code/modules/organs/internal/internal_wounds/robotic.dm
+++ b/code/modules/organs/internal/internal_wounds/robotic.dm
@@ -9,7 +9,7 @@
 	treatments_tool = list(QUALITY_HAMMERING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_MECH_REPAIR = 0.55)		// repair nanites + 3 metals OR repair nanite OD + a metal
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
 
 /datum/component/internal_wound/robotic/blunt/malfunction
@@ -34,7 +34,7 @@
 	treatments_tool = list(QUALITY_SEALING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_MECH_REPAIR = 0.85)		// repair nanites + 6 metals OR repair nanite OD + 7 metals
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
 
 /datum/component/internal_wound/robotic/sharp/perforation
@@ -59,7 +59,7 @@
 	treatments_tool = list(QUALITY_CLAMPING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_MECH_REPAIR = 0.85)
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
 
 /datum/component/internal_wound/robotic/edge/cut
@@ -84,7 +84,7 @@
 	treatments_tool = list(QUALITY_PULSING = FAILCHANCE_NORMAL)
 	treatments_chem = list(CE_MECH_REPAIR = 0.95)	// repair nanite OD + all metals
 	severity = 0
-	severity_max = 5
+	severity_max = 2
 	next_wound = /datum/component/internal_wound/robotic/overheat
 	hal_damage = IWOUND_INSIGNIFICANT_DAMAGE
 


### PR DESCRIPTION
Bumps down the max severity of individual internal wounds caused by external damage (brute/burn) to 2, instead of 5.

Doesn't touch poisoning, infections, radiation/tumors, etc.

Mostly meant to tune it from being a borderline death sentence for the smaller organs (Nerves, vessels, etc.) by an unlucky dice roll to something that feels like the player is accumulating deep wounds from overextending into combat.

Will have the secondary effect of making surgeries in the OR being less about constantly replacing dead tiny organs in people, and make chemical treatments more viable. 

Field surgeries will be less frequently in a  "Shit out of luck" situation due to this hopefully resulting in less dead organs.

Bone injuries aren't nerfed either, as demonstrated by the screenshots.

![image](https://github.com/user-attachments/assets/3ec4027f-6242-46f2-9a5e-36d7e0820526)
![image](https://github.com/user-attachments/assets/79cd78ee-719f-4425-907c-eb3af4d4cc7e)


![image](https://github.com/user-attachments/assets/c67aa3e2-9bf8-4805-abbc-ea3795353e25)


