### PR TITLE
movement recoil

### DIFF
--- a/code/__DEFINES/items.dm
+++ b/code/__DEFINES/items.dm
@@ -55,6 +55,8 @@
 #define GUN_UPGRADE_FIRE_DELAY_MULT "fire_delay_mult"
 #define GUN_UPGRADE_MOVE_DELAY_MULT "move_delay_mult"
 #define GUN_UPGRADE_RECOIL "recoil_mult"
+#define GUN_UPGRADE_PICKUP_RECOIL "recoil_pickup_mult"
+
 #define GUN_UPGRADE_ONEHANDPENALTY "onehandpenalty_mult"
 #define GUN_UPGRADE_MUZZLEFLASH "muzzleflash_mult"
 #define GUN_UPGRADE_STEPDELAY_MULT "stepdelay_mult"

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -301,7 +301,7 @@
 	var/extra_delay = HandleGrabs(direction, old_turf)
 	mob.add_move_cooldown(extra_delay)
 
-	if(!MOVING_DELIBERATELY(mob) && ishuman(mob)) //Do humans not have their own?
+	if(ishuman(mob)) //Do humans not have their own? //!MOVING_DELIBERATELY(mob)
 		mob.handle_movement_recoil()
 
 	/* TODO: Bay grab system

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -425,6 +425,8 @@
 		G.move_delay *= weapon_upgrades[GUN_UPGRADE_MOVE_DELAY_MULT]
 	if(weapon_upgrades[GUN_UPGRADE_RECOIL])
 		G.recoil = G.recoil.modifyAllRatings(weapon_upgrades[GUN_UPGRADE_RECOIL])
+	if(weapon_upgrades[GUN_UPGRADE_PICKUP_RECOIL])
+		G.pickup_recoil *= weapon_upgrades[GUN_UPGRADE_PICKUP_RECOIL]
 	if(weapon_upgrades[GUN_UPGRADE_MUZZLEFLASH])
 		G.muzzle_flash *= weapon_upgrades[GUN_UPGRADE_MUZZLEFLASH]
 	if(tool_upgrades[UPGRADE_BULK])
@@ -722,6 +724,13 @@
 				to_chat(user, SPAN_WARNING("Increases kickback by [amount*100]%"))
 			else
 				to_chat(user, SPAN_NOTICE("Decreases kickback by [abs(amount*100)]%"))
+
+		if(weapon_upgrades[GUN_UPGRADE_PICKUP_RECOIL])
+			var/amount = weapon_upgrades[GUN_UPGRADE_PICKUP_RECOIL]-1
+			if(amount > 0)
+				to_chat(user, SPAN_WARNING("Increases equipping recoil by [amount*100]%"))
+			else
+				to_chat(user, SPAN_NOTICE("Decreases equipping recoil by [abs(amount*100)]%"))
 
 		if(weapon_upgrades[GUN_UPGRADE_MUZZLEFLASH])
 			var/amount = weapon_upgrades[GUN_UPGRADE_MUZZLEFLASH]-1

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -131,10 +131,13 @@ uniquic_armor_act
 					var/math_var = clamp(0, (I.force * 0.05) + (I.w_class * 0.5), 10)
 					total += math_var
 					item_punishment = clamp(0, math_var, 8)
+
+/*			this dosnt work! recoil never goes back down for some reason
 			if(istype(I, /obj/item/gun))
 				var/obj/item/gun/G = I
 				if(G.recoil)
-					external_recoil(G.recoil.getRating(RECOIL_BASE) + 12) //Dont block with a gun that simple
+					external_recoil(G.recoil.getRating(RECOIL_BASE) + 12) //small delay of it to line up with when you get hit
+			*/
 
 		if(stats.getStat(STAT_TGH) > 0)
 			total += clamp(0, round(stats.getStat(STAT_TGH)/(12 + item_punishment)), 10)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -131,6 +131,10 @@ uniquic_armor_act
 					var/math_var = clamp(0, (I.force * 0.05) + (I.w_class * 0.5), 10)
 					total += math_var
 					item_punishment = clamp(0, math_var, 8)
+			if(istype(I, /obj/item/gun))
+				var/obj/item/gun/G = I
+				if(G.recoil)
+					external_recoil(G.recoil.getRating(RECOIL_BASE) + 12) //Dont block with a gun that simple
 
 		if(stats.getStat(STAT_TGH) > 0)
 			total += clamp(0, round(stats.getStat(STAT_TGH)/(12 + item_punishment)), 10)

--- a/code/modules/mob/living/carbon/human/human_recoil.dm
+++ b/code/modules/mob/living/carbon/human/human_recoil.dm
@@ -1,7 +1,10 @@
 /mob/living/carbon/human/handle_movement_recoil()
 	deltimer(recoil_reduction_timer)
 
-	var/base_recoil = 1
+	var/base_recoil = 8
+
+	if(MOVING_DELIBERATELY(src) || src.stats.getPerk(PERK_SURE_STEP))
+		base_recoil -= 1
 
 	var/mob/living/carbon/human/H = src
 	var/suit_stiffness = 0

--- a/code/modules/mob/living/carbon/human/human_recoil.dm
+++ b/code/modules/mob/living/carbon/human/human_recoil.dm
@@ -4,7 +4,7 @@
 	var/base_recoil = 8
 
 	if(MOVING_DELIBERATELY(src) || src.stats.getPerk(PERK_SURE_STEP))
-		base_recoil -= 1
+		base_recoil -= 3
 
 	var/mob/living/carbon/human/H = src
 	var/suit_stiffness = 0

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -686,14 +686,18 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 		if(muzzle_flash)
 			set_light(muzzle_flash)
 
-	kickback(user, P)
+	kickback(user, P, 0)
 	user.handle_recoil(src)
 	update_icon()
 
-/obj/item/gun/proc/kickback(mob/living/user, obj/item/projectile/P)
+/obj/item/gun/proc/kickback(mob/living/user, obj/item/projectile/P, hard_recoil = 0)
 	var/base_recoil = recoil.getRating(RECOIL_BASE)
 	var/brace_recoil = 0
 	var/unwielded_recoil = 0
+	var/proj_recoil = 0
+
+	if(P)
+		proj_recoil = P.recoil
 
 	if(!braced)
 		brace_recoil = recoil.getRating(RECOIL_TWOHAND)
@@ -729,7 +733,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 			if(1.2 to INFINITY)
 				to_chat(user, SPAN_WARNING("You struggle to keep \the [src] on target while carrying it!"))
 */
-	user.handle_recoil(src, (base_recoil + brace_recoil + unwielded_recoil) * P.recoil)
+	user.handle_recoil(src, (base_recoil + brace_recoil + unwielded_recoil + hard_recoil) * proj_recoil)
 
 /obj/item/gun/proc/process_point_blank(var/obj/item/projectile/P, mob/user, atom/target)
 	if(!istype(P))
@@ -1128,6 +1132,15 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 /obj/item/gun/pickup(mob/user)
 	. = ..()
 	update_firemode()
+	if(isliving(user))
+		var/mob/living/L = user
+		L.external_recoil(20) //Picking up guns gives you a lot of recoil
+
+/obj/item/gun/equipped(mob/user)
+	..()
+	if(isliving(user))
+		var/mob/living/L = user
+		L.external_recoil(20) //Picking up guns gives you a lot of recoil
 
 /obj/item/gun/dropped(mob/user)
 	// I really fucking hate this but this is how this is going to work.

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -145,6 +145,8 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	var/serial_type = "INDEX" // Index will be used for detective scanners, if there is a serial type , the gun will add a number onto its final , if none , it won;'t show on examine
 	var/serial_shown = TRUE
 
+	var/pickup_recoil = 20
+
 	var/overcharge_timer //Holds ref to the timer used for overcharging
 	var/overcharge_timer_step = 1 SECOND
 	var/overcharge_rate = 1 //Base overcharge additive rate for the gun
@@ -1134,13 +1136,13 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	update_firemode()
 	if(isliving(user))
 		var/mob/living/L = user
-		L.external_recoil(20) //Picking up guns gives you a lot of recoil
+		L.external_recoil(pickup_recoil) //Picking up guns gives you a lot of recoil
 
 /obj/item/gun/equipped(mob/user)
 	..()
 	if(isliving(user))
 		var/mob/living/L = user
-		L.external_recoil(20) //Picking up guns gives you a lot of recoil
+		L.external_recoil(pickup_recoil) //Picking up guns gives you a lot of recoil
 
 /obj/item/gun/dropped(mob/user)
 	// I really fucking hate this but this is how this is going to work.
@@ -1376,6 +1378,8 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	extra_bulk = initial(extra_bulk)
 
 	recoil = getRecoil(init_recoil[1], init_recoil[2], init_recoil[3])
+
+	pickup_recoil = initial(pickup_recoil)
 
 	braced = initial(braced)
 


### PR DESCRIPTION

## About The Pull Request
Requested by wilson

Increases recoil when moving
Picking up guns gives a massive amount of recoil, as does equipping them from bags/holster/pocket
Walking now gives recoil, but less then running
