### PR TITLE
Ways to disable traps

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -114,6 +114,14 @@
 /obj/item/spider_shadow_trap/Bumped(AM as mob|obj)
 	Crossed(AM)
 */
+
+/obj/item/spider_shadow_trap/attackby(obj/item/I, mob/user)
+	..()
+	//Get ambushed stupid
+	if(istype(I, /obj/item/reagent_containers/snacks/meat))
+		ambush(null)
+		return
+
 /obj/item/spider_shadow_trap/attack_hand(mob/user as mob)
 	Crossed(user)
 
@@ -129,7 +137,8 @@
 /obj/item/spider_shadow_trap/proc/ambush(var/mob/living/M)
 	triggered = 1
 	playsound(src.loc, 'sound/sanity/screech.ogg', 300, 1)
-	M.Weaken(3)
+	if(M)
+		M.Weaken(3)
 	new /mob/living/carbon/superior/spider/fortress/emperor(src.loc)
 	qdel(src)
 
@@ -154,7 +163,8 @@
 /obj/item/spider_shadow_trap/burrowing/ambush(var/mob/living/M)
 	triggered = 1
 	playsound(src.loc, 'sound/effects/impacts/rumble2.ogg', 300, 1)
-	M.Weaken(3)
+	if(M)
+		M.Weaken(3)
 	new /mob/living/carbon/superior/spider/fortress/burrowing(src.loc)
 	qdel(src)
 

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -133,6 +133,20 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 	if (C.has_quality(QUALITY_PRYING))
 		attempt_release(user, C)
 		return
+
+	//Disarming a trap with rods or gripper, qol for borgs
+	if(!buckled_mob && deployed)
+		if(istype(C, /obj/item/stack/rods) || istype(C, /obj/item/gripper))
+			if (do_after(user, 15)) //Faster to disarm via just stabbing it with rods/triggering with a gripper
+				user.visible_message(
+					SPAN_DANGER("[user] has disarmed \the [src]."),
+					SPAN_DANGER("You have disarmed \the [src]!")
+					)
+				deployed = FALSE
+				anchored = FALSE
+				playsound(src, 'sound/effects/impacts/beartrap_shut.ogg', 10, 1,-2,-2)//Fairly quiet snapping sound, it was controled
+				update_icon()
+
 	.=..()
 
 /obj/item/beartrap/attack_hand(mob/user as mob)

--- a/code/modules/tips_and_tricks/gameplay.dm
+++ b/code/modules/tips_and_tricks/gameplay.dm
@@ -90,4 +90,4 @@
     tipText = "Clicking a bear trap with rods or a gripper will disarm it slightly faster."
 
 /tipsAndTricks/gameplay/spider_traps_n_you
-    tipText = "Clicking a spider base traps (collection of webs, odd shadow) with meat will lure out the spider without stunning you!"
+    tipText = "Clicking a spider base traps (collection of webs, odd shadow) with meat (in hand) will lure out the spider without stunning you!"

--- a/code/modules/tips_and_tricks/gameplay.dm
+++ b/code/modules/tips_and_tricks/gameplay.dm
@@ -81,9 +81,13 @@
     tipText = "If you're hurt in the wilderness, some red-flowers can yield poppys if a knife is used on them. Poppys contain a small amount of brute healing meds."
 
 /tipsAndTricks/gameplay/sinks
-    tipText = "you can alt-click a sink with a container to pour the reagents down the drain."
+    tipText = "You can alt-click a sink with a container to pour the reagents down the drain."
 
-/tipsAndTricks/gameplay/sinks
+/tipsAndTricks/gameplay/ammou_mass_reload
     tipText = "if you spill all the bullets out of an ammobox, you can click the tile they're on with their box to scoop them back up"
 
+/tipsAndTricks/gameplay/traps_n_you
+    tipText = "Clicking a bear trap with rods or a gripper will disarm it slightly faster."
 
+/tipsAndTricks/gameplay/spider_traps_n_you
+    tipText = "Clicking a spider base traps (collection of webs, odd shadow) with meat will lure out the spider without stunning you!"


### PR DESCRIPTION

## About The Pull Request
You can now click a bear trap with rods or a gripper (for borgs) to disarm it, this is slightly faster
You can now disarm spider traps (colletion of webs, dark shadow) by clicking on it with meat, this prevents the stun
Fixes a tip being labled wrong and never properly being triggered
Adds two new tips and tricks explaining these mechanics