### PR TITLE
Attack cooldown chem and fixes withdraws

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -76,6 +76,7 @@
 #define CE_BRAINHEAL        "neural tissue restoration"
 #define CE_EYEHEAL          "sensory organ regeneration stimulant"
 #define CE_DEBRIDEMENT      "debriding agent" //for fixing burn/necrosis type wounds.
+#define CE_ATTACK_COOLDOWN  "attacking cooldown adder" //Used to *add* attack cooldown, negitives will increase attack speed
 
 // Chem effects for robotic/assisted organs
 #define CE_MECH_STABLE 		"cooling"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -188,12 +188,13 @@
 /mob/proc/gather_click_delay(mob/living/M as mob)
 	var/gathered = 0
 	if(ishuman(M))
-		var/mob/living/carbon/human/back_pack_checker = M
-		var/obj/item/W = M.get_active_hand()
-		if(!back_pack_checker.back)
+		var/mob/living/carbon/human/H = M
+		var/obj/item/W = H.get_active_hand()
+		if(!H.back)
 			gathered -= 1
 		if(W)
 			gathered += W.clickdelay_offset
+		gathered += H.chem_effects[CE_ATTACK_COOLDOWN]
 	if(issilicon(M))
 		var/mob/living/silicon/S = M
 		var/obj/item/W = S.get_active_hand()

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -265,12 +265,12 @@
 /datum/reagent/proc/addiction_act_stage3(mob/living/carbon/human/M)
 	if(prob(30))
 		to_chat(M, SPAN_DANGER("You have an intense craving for [name]."))
-		M.sanity.changeLevel(-5)
+		M.sanity.changeLevel(-1)
 
 /datum/reagent/proc/addiction_act_stage4(mob/living/carbon/human/M)
 	if(prob(30))
 		to_chat(M, SPAN_DANGER("You're not feeling good at all! You really need some [name]."))
-		M.sanity.changeLevel(-10)
+		M.sanity.changeLevel(-2)
 
 /datum/reagent/proc/addiction_end(mob/living/carbon/human/M)
 	to_chat(M, SPAN_NOTICE("You feel like you've gotten over your need for [name]."))

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -5,6 +5,7 @@
 	scannable = TRUE
 
 	sanity_gain = 0.5
+	withdrawal_threshold = 20
 
 /datum/reagent/drug/on_mob_add(mob/living/L)
 	..()
@@ -191,6 +192,7 @@
 	addiction_chance = 30
 	overdose = REAGENTS_OVERDOSE
 	illegal = TRUE
+	withdrawal_threshold = 3
 
 /datum/reagent/drug/mindbreaker/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.hallucination(50 * effect_multiplier, 50 * effect_multiplier)
@@ -220,6 +222,7 @@
 	overdose = REAGENTS_OVERDOSE
 	nerve_system_accumulations = 90
 	addiction_chance = 30
+	withdrawal_threshold = 1
 
 /datum/reagent/drug/mindwipe/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.hallucination(50 * effect_multiplier, 50 * effect_multiplier)
@@ -255,6 +258,7 @@
 	addiction_chance = 90
 	nerve_system_accumulations = 40
 	reagent_type = "Drug/Stimulator"
+	withdrawal_threshold = 3 //Not to sure how to do this one
 
 /datum/reagent/drug/psi_juice/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	var/mob/living/carbon/human/H = M
@@ -373,6 +377,7 @@
 	addiction_chance = 1 // Note: NEVER make nicotine actually addictive. EVER. //Why? It's based.
 	sanity_gain = 0.8
 	nerve_system_accumulations = 15
+	withdrawal_threshold = 8
 
 /datum/reagent/drug/nicotineplus/affect_blood(mob/living/carbon/M, alien, effect_multiplier) // If you inject fine nicotine
 	..()
@@ -414,6 +419,7 @@
 	withdrawal_threshold = 10
 	nerve_system_accumulations = 55
 	reagent_type = "Drug/Stimulator"
+	withdrawal_threshold = 3
 
 /datum/reagent/drug/hyperzine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(prob(5))
@@ -486,6 +492,7 @@
 	metabolism = REM
 	overdose = REAGENTS_OVERDOSE/10
 	color = "#8a0303"
+	withdrawal_threshold = 0
 
 /datum/reagent/drug/nanoblood/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_BLOODRESTORE, 4.5 * effect_multiplier)
@@ -523,6 +530,7 @@
 	overdose = REAGENTS_OVERDOSE/2
 	nerve_system_accumulations = 40 // Was incredibly unforgiving for its effects, this makes it able to be mixed with painkillers without forcing vomit. - Seb
 	addiction_chance = 30
+	withdrawal_threshold = 0.01 //The vampire thirsts for the blood bags
 
 /datum/reagent/drug/sanguinum/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_BLOODRESTORE, 1.6 * effect_multiplier)
@@ -553,7 +561,7 @@
 /datum/reagent/drug/nosfernium
 	name = "Nosfernium"
 	id = "nosfernium"
-	description = "A chemical for when the body is bleed dry, and if its not will ensure you are left a skeleton."
+	description = "A chemical that disables the users issues with different blood types, affectively allowing them to be a universal receiver for any type or race."
 	taste_description = "teeth"
 	reagent_state = LIQUID
 	color = "#e06270"
@@ -561,13 +569,14 @@
 	overdose = REAGENTS_OVERDOSE/6
 	nerve_system_accumulations = 80
 	addiction_chance = 30
+	withdrawal_threshold = 0.01 //The thirsts, overwheling
 
 /datum/reagent/drug/nosfernium/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_NOPULSE, 1)
 
 /datum/reagent/drug/nosfernium/withdrawal_act(mob/living/carbon/M)
 	M.add_chemical_effect(CE_SLOWDOWN, 1)
-	M.adjustNutrition(-25)
+	M.adjustNutrition(-2)
 
 datum/reagent/drug/nosfernium/overdose(var/mob/living/carbon/human/M, var/alien)
 	M.adjustBrainLoss(5) // This is meant to be lethal. If you survive this give your doctor a pat on the back.

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -304,9 +304,6 @@
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "adrenaline")
 	M.add_chemical_effect(CE_TOXIN, 3)
 
-/datum/reagent/adrenaline/withdrawal_act(mob/living/carbon/M)
-	M.adjustOxyLoss(15)
-
 /datum/reagent/other/viroputine
 	name = "Viroputine"
 	id = "viroputine"
@@ -315,6 +312,7 @@
 	reagent_state = LIQUID
 	color = "#A5F0EE"
 	addiction_chance = 5
+	withdrawal_threshold = 8 //gives you chances to purge it
 
 /datum/reagent/other/viroputine/withdrawal_act(mob/living/carbon/M)
 	M.drowsyness = max(M.drowsyness, 20)

--- a/code/modules/reagents/reagents/race.dm
+++ b/code/modules/reagents/reagents/race.dm
@@ -91,10 +91,6 @@
 	M.stats.addTempStat(STAT_VIG, -100, STIM_TIME, "robustitol")
 	M.stats.addTempStat(STAT_MEC, -100, STIM_TIME, "robustitol")
 
-/datum/reagent/drug/robustitol/withdrawal_act(mob/living/carbon/M)
-	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "robustitol_w")
-	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "robustitol_w")
-
 /datum/reagent/medicine/sergatonin
 	name = "Naratonin"
 	id = "naratonin"

--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -14,6 +14,7 @@
 	overdose = REAGENTS_OVERDOSE
 	addiction_chance = 20
 	nerve_system_accumulations = 15
+	withdrawal_threshold = 16
 
 /datum/reagent/stim/greaser/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_BASIC, STIM_TIME, "greaser")
@@ -59,6 +60,7 @@
 	overdose = REAGENTS_OVERDOSE + 5
 	nerve_system_accumulations = 20
 	addiction_chance = 30
+	withdrawal_threshold = 6
 
 /datum/reagent/stim/cherrydrops/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_COG, STAT_LEVEL_BASIC, STIM_TIME, "cherrydrops")
@@ -86,6 +88,7 @@
 	overdose = REAGENTS_OVERDOSE
 	nerve_system_accumulations = 20
 	addiction_chance = 20
+	withdrawal_threshold = 6
 
 /datum/reagent/stim/pro_surgeon/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_BASIC, STIM_TIME, "pro_surgeon")
@@ -118,6 +121,7 @@
 	overdose = REAGENTS_OVERDOSE - 10
 	nerve_system_accumulations = 30
 	addiction_chance = 30
+	withdrawal_threshold = 11
 
 /datum/reagent/stim/violence/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_BASIC, STIM_TIME, "violence")
@@ -150,6 +154,7 @@
 	overdose = REAGENTS_OVERDOSE
 	nerve_system_accumulations = 10
 	addiction_chance = 20
+	withdrawal_threshold = 5
 
 /datum/reagent/stim/bouncer/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_BASIC, STIM_TIME, "bouncer")
@@ -179,6 +184,7 @@
 	overdose = REAGENTS_OVERDOSE - 10
 	nerve_system_accumulations = 20
 	addiction_chance = 20
+	withdrawal_threshold = 5
 
 /datum/reagent/stim/steady/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_BASIC, STIM_TIME, "steady")
@@ -207,6 +213,7 @@
 	overdose = REAGENTS_OVERDOSE - 12
 	nerve_system_accumulations = 30
 	addiction_chance = 30
+	withdrawal_threshold = 15
 
 /datum/reagent/stim/greasy_lard/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_ADEPT, STIM_TIME, "greasy_lard")
@@ -236,6 +243,7 @@
 	overdose = REAGENTS_OVERDOSE - 5
 	nerve_system_accumulations = 30
 	addiction_chance = 40
+	withdrawal_threshold = 15
 
 /datum/reagent/stim/grape_drops/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_COG, STAT_LEVEL_ADEPT, STIM_TIME, "grape_drops")
@@ -266,6 +274,7 @@
 	overdose = REAGENTS_OVERDOSE - 13
 	nerve_system_accumulations = 30
 	addiction_chance = 30
+	withdrawal_threshold = 1
 
 /datum/reagent/stim/ultra_surgeon/on_mob_add(mob/living/carbon/M, alien, effect_multiplier)
 	if(ishuman(M))
@@ -308,16 +317,19 @@
 	overdose = REAGENTS_OVERDOSE - 19
 	nerve_system_accumulations = 60
 	addiction_chance = 40
+	withdrawal_threshold = 1
 
 /datum/reagent/stim/violence_ultra/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_ADEPT, STIM_TIME, "violence_ultra")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "violence_ultra")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "violence_ultra")
+	M.add_chemical_effect(CE_ATTACK_COOLDOWN, -0.6)
 
 /datum/reagent/stim/violence_ultra/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "violenceUltra_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "violenceUltra_w")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "violenceUltra_w")
+	M.add_chemical_effect(CE_ATTACK_COOLDOWN, 0.6)
 	if(prob(25 - (10 * (1 - M.stats.getMult(STAT_TGH)))))
 		M.shake_animation(8)
 	M.adjustNutrition(-5)
@@ -343,15 +355,18 @@
 	overdose = REAGENTS_OVERDOSE/2
 	nerve_system_accumulations = 50
 	addiction_chance = 30
+	withdrawal_threshold = 6
 
 /datum/reagent/stim/boxer/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT, STIM_TIME, "boxer")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "boxer")
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "boxer")
+	M.add_chemical_effect(CE_ATTACK_COOLDOWN, -0.3)
 
 /datum/reagent/stim/boxer/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "boxer_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "boxer_w")
+	M.add_chemical_effect(CE_ATTACK_COOLDOWN, 0.3)
 
 /datum/reagent/stim/boxer/overdose(mob/living/carbon/M, alien)
 	var/inverse_tough_mult = 1 - M.stats.getMult(STAT_TGH)
@@ -373,6 +388,7 @@
 	overdose = REAGENTS_OVERDOSE-18
 	nerve_system_accumulations = 60
 	addiction_chance = 40
+	withdrawal_threshold = 1
 
 /datum/reagent/stim/turbo/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_ADEPT, STIM_TIME, "turbo")
@@ -407,6 +423,7 @@
 	overdose = REAGENTS_OVERDOSE - 20
 	nerve_system_accumulations = 70
 	addiction_chance = 50
+	withdrawal_threshold = 6
 
 /datum/reagent/stim/party_drops/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_ADEPT, ADV_STIM_TIME, "party_drops")
@@ -415,6 +432,7 @@
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, ADV_STIM_TIME, "party_drops")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, ADV_STIM_TIME, "party_drops")
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, ADV_STIM_TIME, "party_drops")
+	M.add_chemical_effect(CE_ATTACK_COOLDOWN, 0.5)
 
 /datum/reagent/stim/party_drops/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "partyDrops_w")
@@ -453,6 +471,7 @@
 	overdose = REAGENTS_OVERDOSE - 18
 	nerve_system_accumulations = 70
 	addiction_chance = 90
+	withdrawal_threshold = 1
 
 /datum/reagent/stim/menace/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_VIG, STAT_LEVEL_ADEPT, ADV_STIM_TIME, "menace")
@@ -463,11 +482,13 @@
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, ADV_STIM_TIME, "menace")
 	M.slurring = max(M.slurring, 30)
 	M.add_chemical_effect(CE_SPEECH_VOLUME, 4)
+	M.add_chemical_effect(CE_ATTACK_COOLDOWN, -0.9)
 
 /datum/reagent/stim/menace/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT, ADV_STIM_TIME, "menace_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_ADEPT, ADV_STIM_TIME, "menace_w")
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT, ADV_STIM_TIME, "menace_w")
+	M.add_chemical_effect(CE_ATTACK_COOLDOWN, 0.9)
 	if(prob(25 - (5 * (1 - M.stats.getMult(STAT_TGH)))))
 		M.shake_animation(8)
 	M.adjustNutrition(-7)
@@ -502,6 +523,7 @@
 	overdose = REAGENTS_OVERDOSE + 5
 	nerve_system_accumulations = 10
 	addiction_chance = 5
+	withdrawal_threshold = 12
 
 /datum/reagent/stim/gumdrops/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_COG, (STAT_LEVEL_BASIC - 10), STIM_TIME, "gum drops")
@@ -522,6 +544,7 @@
 	overdose = REAGENTS_OVERDOSE
 	nerve_system_accumulations = 80
 	addiction_chance = 100
+	withdrawal_threshold = 0.01
 
 /datum/reagent/stim/hacker/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_COG, STAT_LEVEL_PROF, STIM_TIME, "hacker")

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -108,6 +108,7 @@
 	heating_point = 523
 	heating_products = list("toxin")
 	reagent_type = "Toxin/Stimulator"
+	withdrawal_threshold = 8 //gives you chances to purge it
 
 /datum/reagent/toxin/carpotoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()


### PR DESCRIPTION

## About The Pull Request
Removes some race-chem withdraws that where non functional
Fixes withdraws for every chemical that has them

massively lowers sanity damage from chem addition stage 3 and 4 so that way you dont sanity spiral as hard for not constantly smoking 8 packs a day

Makes it so Boxer, Utra violence and mence slightly increase attack speed when used, on withdraw slightly reduce attack speed
Makes it so party drops slightly reduce attack speed