### PR TITLE
framework for sounds

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -138,6 +138,19 @@
 
 	var/swing_icon_mod = "" //Used for when you make a swing attack, some items may get fancy icons for it
 
+	//sound based vars
+	var/pickup_sound
+	var/pickup_volume = 60
+	var/pickup_volume_extra_range = 1 //Picking something up is quite silent
+	var/pickup_volume_dropoff = -1 //so that we dont let everyone 4 tiles away from us know
+
+	var/dropped_sound
+	var/dropped_sound_volume = 60
+	var/dropped_sound_volume_extra_range = 1
+	var/dropped_sound_volume_dropoff = -1
+
+	var/thrown_sound
+
 /obj/item/Initialize()
 
 	for (var/upgrade_typepath in initialized_upgrades)
@@ -293,6 +306,8 @@
 		if((target != old_loc) && (target != old_loc.get_holding_mob()))
 			do_pickup_animation(target,old_loc)
 	add_hud_actions(target)
+	if(pickup_sound)
+		playsound(src, pickup_sound, pickup_volume, pickup_volume_extra_range, pickup_volume_dropoff)
 
 /obj/item/attack_ai(mob/user as mob)
 	if(istype(loc, /obj/item/robot_module))
@@ -756,3 +771,14 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	attack_verb = LAZYCOPY(alt_mode_verbs)
 	sharp = alt_mode_sharp
 	flags |= NOBLOODY
+
+/obj/item/post_thrown_hit()
+	if(thrown_sound)
+		//Same volume as if you missed
+		playsound(src, thrown_sound, 50, 1, -6)
+
+/obj/item/dropped()
+	..()
+
+	if(dropped_sound)
+		playsound(src, dropped_sound, dropped_sound_volume, dropped_sound_volume_extra_range, dropped_sound_volume_dropoff)

--- a/code/game/objects/items/stacks/throwing.dm
+++ b/code/game/objects/items/stacks/throwing.dm
@@ -156,6 +156,7 @@
 	..()
 
 /obj/item/stack/thrown/throwing_knife/bone_needle/poison/post_thrown_hit(mob)
+	..()
 	if(isliving(mob))
 		var/mob/living/L
 		if(ishuman(L))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -338,7 +338,7 @@
 
 		if (prob(miss_chance))
 			visible_message("\blue \The [O] misses [src] narrowly!")
-			playsound(src, "miss_sound", 50, 1, -6)
+			playsound(src, get_sfx("miss_sound"), 50, 1, -6)
 			return
 
 		if (O.is_hot() >= HEAT_MOBIGNITE_THRESHOLD)


### PR DESCRIPTION
Fixes when an item misses it was silent when it was meant to be playing a sound
Adds framework to allow every item to have uniquic pickup, dropped and thrown sounds