### PR TITLE
fixes a roach runtime on equipment checks

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/types/glowing.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/glowing.dm
@@ -35,18 +35,19 @@
 			playsound(src, 'sound/voice/insect_battle_screeching.ogg', 30, 1, -3)
 			L.visible_message(SPAN_DANGER("\the [src] pinches hard, chemically burning \the [L]!"))
 		if(prob(5))
-			var/mob/living/carbon/C = L
-			C.update_equipment_vision()
-			var/safety = C.eyecheck()
-			if(safety < FLASH_PROTECTION_MINOR)
-				var/flash_strength = 5
-				if(ishuman(L))
-					var/mob/living/carbon/human/H = L
-					flash_strength *= H.flash_mod
-				if(flash_strength > 0)
-					L.Weaken(flash_strength)
-					if (L.HUDtech.Find("flash"))
-						flick("e_flash", L.HUDtech["flash"])
-					L.visible_message(SPAN_DANGER("\the [src] flashes a bright green, blinding \ [L]!"))
+			if(iscarbon(L))
+				var/mob/living/carbon/C = L
+				C.update_equipment_vision()
+				var/safety = C.eyecheck()
+				if(safety < FLASH_PROTECTION_MINOR)
+					var/flash_strength = 5
+					if(ishuman(L))
+						var/mob/living/carbon/human/H = L
+						flash_strength *= H.flash_mod
+					if(flash_strength > 0)
+						L.Weaken(flash_strength)
+						if (L.HUDtech.Find("flash"))
+							flick("e_flash", L.HUDtech["flash"])
+						L.visible_message(SPAN_DANGER("\the [src] flashes a bright green, blinding \ [L]!"))
 			else
 				L.visible_message(SPAN_DANGER("\the [src] fails to blind \ [L]!"))


### PR DESCRIPTION

## About The Pull Request
Glowing roaches no longer runtime when using its fancy glow attack against targets that cant ware glasses