### PR TITLE
Organ damage delaying

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -77,6 +77,8 @@
 #define CE_EYEHEAL          "sensory organ regeneration stimulant"
 #define CE_DEBRIDEMENT      "debriding agent" //for fixing burn/necrosis type wounds.
 
+#define CE_WOUND_STABLIZE   "wound stablizer" //for preventing internal wounds form progressing
+
 // Chem effects for robotic/assisted organs
 #define CE_MECH_STABLE 		"cooling"
 #define CE_MECH_ACID 		"acid"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -89,7 +89,7 @@
 	var/list/markings = list() //EQUINOX EDIT - List of body markings for use in update_icon under organ_icon.dm (per-limb markings)
 
 	//Used for internal wounds, if limb damage is below this value dont progress it.
-	var/internal_wound_suppression = 10 //If you have *more* then this value, wounds progress
+	var/internal_wound_suppression = 4 //If you have *more* then this value, wounds progress
 	//When editing IWS ^ make sure to update the organ_description.dm
 
 /obj/item/organ/external/New(mob/living/carbon/human/holder, datum/organ_description/OD)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -88,6 +88,10 @@
 
 	var/list/markings = list() //EQUINOX EDIT - List of body markings for use in update_icon under organ_icon.dm (per-limb markings)
 
+	//Used for internal wounds, if limb damage is below this value dont progress it.
+	var/internal_wound_suppression = 10 //If you have *more* then this value, wounds progress
+	//When editing IWS ^ make sure to update the organ_description.dm
+
 /obj/item/organ/external/New(mob/living/carbon/human/holder, datum/organ_description/OD)
 	if(OD)
 		set_description(OD)
@@ -125,6 +129,7 @@
 	src.default_bone_type = desc.default_bone_type
 
 	src.max_damage = desc.max_damage
+	src.internal_wound_suppression = desc.internal_wound_suppression
 	src.min_broken_damage = desc.min_broken_damage
 	src.nerve_struck = desc.nerve_struck
 	src.vital = desc.vital

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -87,14 +87,29 @@
 	if((!parent || O.status & ORGAN_DEAD) && !(characteristic_flag & IWOUND_PROGRESS_DEATH))
 		return PROCESS_KILL
 
-	// Progress if not in a cryo tube or in stasis
-	if(characteristic_flag & IWOUND_PROGRESS && (H && !(H.bodytemperature < 170 || H.in_stasis)))
-		++current_progression_tick
-		if(current_progression_tick >= progression_threshold)
-			current_progression_tick = 0
-			progress()
-			if(H)
-				H.custom_pain("Something inside your [E.name] hurts a lot.", 0)
+	//Handles if and when we progress are wound severity
+	if(characteristic_flag & IWOUND_PROGRESS)
+		var/progression_suppression = FALSE
+
+		if(E) //Are we in a limb? If so check it's damage
+			if(E.brute_dam + E.burn_dam > E.internal_wound_suppression)
+				progression_suppression = TRUE //Are limb is stable dont progress wounds
+
+		if(H)
+			//Dont progress wounds if we are chemically stablized
+			if(H.chem_effects[CE_WOUND_STABLIZE])
+				progression_suppression = TRUE
+			//Dont progress wounds if we are in statis or cryo-tube like tempture
+			if(H.bodytemperature < 170 || H.in_stasis)
+				progression_suppression = TRUE
+
+		if(!progression_suppression)
+			++current_progression_tick
+			if(current_progression_tick >= progression_threshold)
+				current_progression_tick = 0
+				progress()
+				if(H)
+					H.custom_pain("Something inside your [E.name] hurts a lot.", 0)
 
 	if(!H)
 		return

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -49,6 +49,9 @@
 	// Parent organ adjustments
 	var/status_flag = ORGAN_WOUNDED		// Causes the parent limb to start processing
 
+	//Prevents wounds that would be stoped by healthy limbs from being stopped
+	var/progress_while_healthy = FALSE
+
 /datum/component/internal_wound/RegisterWithParent()
 	// Internal organ parent
 	RegisterSignal(parent, COMSIG_IWOUND_EFFECTS, PROC_REF(apply_effects))
@@ -91,8 +94,8 @@
 	if(characteristic_flag & IWOUND_PROGRESS)
 		var/progression_suppression = FALSE
 
-		if(E) //Are we in a limb? If so check it's damage
-			if(E.brute_dam + E.burn_dam > E.internal_wound_suppression)
+		if(E) //Are we in a limb? If so check it's damage. Also check if we progress even in a healthy limb
+			if((E.brute_dam + E.burn_dam > E.internal_wound_suppression) && !progress_while_healthy)
 				progression_suppression = TRUE //Are limb is stable dont progress wounds
 
 		if(H)

--- a/code/modules/organs/internal/internal_wounds/eyes.dm
+++ b/code/modules/organs/internal/internal_wounds/eyes.dm
@@ -102,6 +102,7 @@
 	severity_max = 3
 	hal_damage = IWOUND_LIGHT_DAMAGE
 	diagnosis_difficulty = STAT_LEVEL_EXPERT
+	progress_while_healthy = TRUE
 
 /// Cheap hack, but prevents unbalanced toxins from killing someone immediately
 /datum/component/internal_wound/organic/eyes_poisoning/InheritComponent()

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -137,6 +137,7 @@
 	severity = 0
 	severity_max = 3
 	hal_damage = IWOUND_LIGHT_DAMAGE
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/organic/poisoning/pustule
 	name = "pustule"
@@ -167,6 +168,7 @@
 	blood_req_multiplier = 0.50
 	nutriment_req_multiplier = 0.50
 	oxygen_req_multiplier = 0.50
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/organic/heavy_poisoning/toxin
 	name = "toxin accumulation"
@@ -186,6 +188,7 @@
 	severity_max = 1
 	hal_damage = IWOUND_LIGHT_DAMAGE
 	status_flag = ORGAN_WOUNDED|ORGAN_MUTATED
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/organic/radiation/benign
 	name = "benign tumor"
@@ -207,6 +210,7 @@
 	next_wound = /datum/component/internal_wound/organic/infection
 	hal_damage = IWOUND_LIGHT_DAMAGE
 	specific_organ_size_multiplier = 0.2
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/organic/swelling/normal
 	name = "swelling"
@@ -220,6 +224,7 @@
 	severity = 0
 	severity_max = IORGAN_MAX_HEALTH
 	progression_threshold = IWOUND_1_MINUTE	// Kills small organs in 7 minutes, normal in 14
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/organic/oxy/blood_loss
 	name = "blood loss"
@@ -234,6 +239,7 @@
 	hal_damage = IWOUND_LIGHT_DAMAGE
 	spread_threshold = IORGAN_SMALL_HEALTH
 	status_flag = ORGAN_WOUNDED|ORGAN_INFECTED
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/organic/infection/standard
 	name = "infection"

--- a/code/modules/organs/internal/internal_wounds/sanity.dm
+++ b/code/modules/organs/internal/internal_wounds/sanity.dm
@@ -7,6 +7,7 @@
 	severity = 1
 	severity_max = 1
 	psy_damage = IWOUND_MEDIUM_DAMAGE
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/organic/sanity/twitch
 	name = "twitching tissue"

--- a/code/modules/organs/internal/internal_wounds/slime.dm
+++ b/code/modules/organs/internal/internal_wounds/slime.dm
@@ -92,6 +92,7 @@
 	severity_max = 1
 	hal_damage = IWOUND_LIGHT_DAMAGE
 	status_flag = ORGAN_WOUNDED|ORGAN_MUTATED
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/slime/radiation/benign
 	name = "benign growth"
@@ -129,6 +130,7 @@
 	hal_damage = IWOUND_LIGHT_DAMAGE
 	spread_threshold = IORGAN_SMALL_HEALTH
 	status_flag = ORGAN_WOUNDED|ORGAN_INFECTED
+	progress_while_healthy = TRUE
 
 /datum/component/internal_wound/slime/infection/standard
 	name = "infection"

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -25,6 +25,7 @@
 	var/icon_position = null
 	var/functions = NONE
 	var/list/drop_on_remove = null
+	var/internal_wound_suppression = 10
 
 /datum/organ_description/proc/create_organ(var/mob/living/carbon/human/H)
 	return new default_type(H,src)

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -25,7 +25,7 @@
 	var/icon_position = null
 	var/functions = NONE
 	var/list/drop_on_remove = null
-	var/internal_wound_suppression = 10
+	var/internal_wound_suppression = 4
 
 /datum/organ_description/proc/create_organ(var/mob/living/carbon/human/H)
 	return new default_type(H,src)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -1507,6 +1507,23 @@ We don't use this but we might find use for it. Porting it since it was updated 
 		M.drowsyness = max(M.drowsyness, 60)
 	M.add_chemical_effect(CE_PULSE, -1)
 
+//Welsh -> oh weepless
+/datum/reagent/medicine/o_wylo
+	name = "Owylo"
+	id = "owylo"
+	description = "A SI branded mix of chemicals that are designed to prevent wounds from getting worse."
+	taste_description = "rosted lam"
+	reagent_state = LIQUID
+	color = "#043A5C"
+	scannable = TRUE
+	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = -5
+
+//Just stables, no need to add drawbacks, its a pain to make
+/datum/reagent/medicine/o_wylo/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.add_chemical_effect(CE_WOUND_STABLIZE, 1)
+	M.add_chemical_effect(CE_STABLE, 1)
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Meds made from animals. Unga.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -963,6 +963,13 @@
 	result_amount = 1
 	catalysts = list("honey" = 5)
 
+//Quite a useful chem so its a bit annoying to make, but you get a lot
+/datum/chemical_reaction/owylo
+	result = "owylo"
+	required_reagents = list("spaceacillin" = 2, "sanguinum" = 3,"inaprovaline" = 5, "carthatoline" = 2, "meralyne" = 0.5, "somnadine" = 0.5)
+	result_amount = 10
+	catalysts = list("suppressital" = 5)
+
 /datum/chemical_reaction/suppressital
 	result = "suppressital"
 	required_reagents = list("blood" = 1, "citalopram" = 1)


### PR DESCRIPTION
## About The Pull Request
Tweaks readability of wound damage progression
Wounds no longer progress if the limb they are in, if said limb is almost fully healed
Adds a new chemical for science to make that stops wound progression and stabilizes people (inaproval stabilize affect)

Having poor circulation lowers bleeding out
Having slower pulse lowers bleeding out
Resting, or being buckled to a bed lowers bleeding out
Having fast pulse increases bleeding out
Having more blood then normal increases bleed out

Many types of wounds such as infections, radiation, toxins ect progress even in a healthy limb, but still can be delayed by new stabilizer chemical