### PR TITLE
Cleans up gun code a little and removes feature

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -268,8 +268,6 @@
 
 /obj/proc/multiply_projectile_agony(newmult)
 
-/obj/proc/multiply_pve_damage(newmult)
-
 /obj/proc/add_fire_stacks(newmult)
 
 //Proj for thrown items

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -703,6 +703,9 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	if(!istype(P))
 		return //default behaviour only applies to true projectiles
 
+	//P.B gives you a bit more damage after all your in melee range
+	var/damage_mult = 1.1
+
 	//determine multiplier due to the target being grabbed
 	if(ismob(target))
 		var/mob/M = target

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -361,15 +361,16 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 /obj/item/gun/afterattack(atom/A, mob/living/user, adjacent, params)
 	if(adjacent) return //A is adjacent, is the user, or is on the user's person
 
+	//DUAL WIELDING
 	if(ishuman(user) && user.a_intent == I_HURT)
 		var/mob/living/carbon/human/H = user
-		var/obj/item/gun/off_hand   //DUAL WIELDING
+		var/obj/off_hand = H.get_inactive_hand()
 
-		if(istype(H.get_inactive_hand(), /obj/item/gun))
-			off_hand = H.get_inactive_hand()
+		if(istype(off_hand, /obj/item/gun))
+			var/obj/item/gun/G = off_hand
 
-		if(off_hand && off_hand.can_hit(user) && off_hand.can_dual)
-			off_hand.Fire(A,user,params)
+			if(G.can_dual)
+				G.Fire(A,user,params)
 
 	Fire(A,user,params) //Otherwise, fire normally.
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -555,11 +555,13 @@
 
 		if(pointblank)
 			process_point_blank(projectile, user, target)
+
 		if(projectile_color)
 			projectile.icon = get_proj_icon_by_color(projectile, projectile_color)
 			if(istype(projectile, /obj/item/projectile))
 				var/obj/item/projectile/P = projectile
 				P.proj_color = projectile_color
+
 		if(process_projectile(projectile, user, target, user.targeted_organ, clickparams))
 			handle_post_fire(user, target, pointblank, reflex, projectile)
 			update_icon()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -516,7 +516,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 
 		if(muzzle_flash)
 			//Use a temp affect so we avoid using sleep and walking around with the light moving with us
-			var/obj/effect/temporary/S = new(get_turf(user), muzzle_flash / 7) //Dosnt stick around long but needs to be long enuff to allow for it to trigger
+			var/obj/effect/temporary/S = new(get_turf(user), muzzle_flash / 3) //Dosnt stick around long but needs to be long enuff to allow for it to trigger
 			S.set_light(muzzle_flash)
 
 		if(extra_proj_damagemult)

--- a/code/modules/projectiles/guns/_projectile.dm
+++ b/code/modules/projectiles/guns/_projectile.dm
@@ -375,17 +375,18 @@
 
 /obj/item/gun/projectile/afterattack(atom/A, mob/living/user)
 	..()
-	if(auto_eject && ammo_magazine && ammo_magazine.stored_ammo && !ammo_magazine.stored_ammo.len)
-		ammo_magazine.forceMove(get_turf(src.loc))
-		user.visible_message(
-			"[ammo_magazine] falls out and clatters on the floor!",
-			SPAN_NOTICE("[ammo_magazine] falls out and clatters on the floor!")
-			)
-		if(auto_eject_sound)
-			playsound(user, auto_eject_sound, 40, 1)
-		ammo_magazine.update_icon()
-		ammo_magazine = null
-		update_icon() //make sure to do this after unsetting ammo_magazine
+	if(auto_eject) //Faster return and less processing to quickly boot out
+		if(ammo_magazine && ammo_magazine.stored_ammo && !ammo_magazine.stored_ammo.len)
+			ammo_magazine.forceMove(get_turf(src.loc))
+			user.visible_message(
+				"[ammo_magazine] falls out and clatters on the floor!",
+				SPAN_NOTICE("[ammo_magazine] falls out and clatters on the floor!")
+				)
+			if(auto_eject_sound)
+				playsound(user, auto_eject_sound, 40, 1)
+			ammo_magazine.update_icon()
+			ammo_magazine = null
+			update_icon() //make sure to do this after unsetting ammo_magazine
 
 /obj/item/gun/projectile/examine(mob/user)
 	..(user)

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -18,11 +18,6 @@
 /obj/item/gun/launcher/can_hit(var/mob/living/target as mob, var/mob/living/user as mob)
 	return 1
 
-//Override this to avoid a runtime with suicide handling.
-/obj/item/gun/launcher/handle_suicide(mob/living/user)
-	to_chat(user, SPAN_WARNING("Shooting yourself with \a [src] is pretty tricky. You can't seem to manage it."))
-	return
-
 /obj/item/gun/launcher/proc/update_release_force(obj/item/projectile)
 	return 0
 

--- a/code/modules/projectiles/guns/matter/launcher.dm
+++ b/code/modules/projectiles/guns/matter/launcher.dm
@@ -9,10 +9,6 @@
 /obj/item/gun/matter/launcher/can_hit(mob/living/target, mob/living/user)
 	return TRUE
 
-/obj/item/gun/matter/launcher/handle_suicide(mob/living/user)
-	to_chat(user, SPAN_WARNING("Shooting yourself with \a [src] is pretty tricky. You can't seem to manage it."))
-	return
-
 /obj/item/gun/matter/launcher/proc/update_release_force(obj/item/projectile)
 	return FALSE
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -130,6 +130,7 @@
 	var/ignition_source = TRUE //Used for deciding if a projectile should blow up a benzin.
 	var/predetermed = null //Used for NPCs to sudo rng, uses define zones directly
 
+	var/steel_rain = 0
 
 /obj/item/projectile/New()
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -174,7 +174,17 @@ Bullet also tend to have more armor against them do to this and can be douged un
 	if(!newdamages.len)
 		return
 	for(var/damage_type in newdamages)
-		var/bonus = pellets > 2 ? newdamages[damage_type] / pellets * 2 : newdamages[damage_type]
+		var/bonus = (pellets + steel_rain) > 2 ? newdamages[damage_type] / (pellets + steel_rain) * 2 : newdamages[damage_type]
+		if(damage_type == IRRADIATE)
+			irradiate += bonus
+			continue
+		damage_types[damage_type] += bonus
+
+/obj/item/projectile/bullet/adjust_damages(var/list/newdamages)
+	if(!newdamages.len)
+		return
+	for(var/damage_type in newdamages)
+		var/bonus = steel_rain > 2 ? newdamages[damage_type] / steel_rain * 2 : newdamages[damage_type]
 		if(damage_type == IRRADIATE)
 			irradiate += bonus
 			continue


### PR DESCRIPTION
## About The Pull Request
Removes unneeded vars that didnt really work as intented for nerfing gun damage
Removes being able to handle_suicide with guns, if you want to self end you got to use more then one round or bleed out slowly!
Cleans up muzzle flashes and prevents a few exploits with them do to how they worked before
Muzzle flashes now leave a small gas decal on the ground, this is done for lighting reasons and looks nicer then having it attached onto the gun itself 
Cleans up dual wielding mechanics to be less wierd to use: Basically if the gun and off hand can both dual wield both will fire basically at the same time rather then delayed
Removes a *second* clumy trigger in gun checks, this was clearly a bug and not intented to be able to have clumy trigger twice

Allows bullets, lasers and ecta to have cone base firing in a really bad unoptimized way, but it dosnt doup damage from additive mods.