### PR TITLE
Yet Another Cargo Tweaking (I'm tweaking)

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
@@ -19,7 +19,6 @@
 			/obj/item/reagent_containers/drinks/milk = good_data("milk carton", list(1, 2), 100),
 			/obj/item/storage/fancy/egg_box = good_data("egg box", list(1, 2), 300),
 			/obj/item/reagent_containers/snacks/tofu = good_data("tofu", list(1, 2), 20),
-			/obj/item/reagent_containers/snacks/meat = good_data("meat", list(1, 2), 25),
 			/obj/item/reagent_containers/condiment/enzyme,
 			/obj/item/reagent_containers/condiment/cookingoil = good_data("cooking oil bottle", list(1, 2), 200)
 		),

--- a/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
@@ -118,10 +118,14 @@
 	offer_types = list(
 		/obj/item/organ/internal/scaffold = offer_data_mods("aberrant organ (input, process, output)", 1200, 4, OFFER_ABERRANT_ORGAN, 3),
 		/datum/reagent/medicine/ossisine = offer_data("ossissine bottle (60u)", 2000, 1),
-		/datum/reagent/medicine/bicaridine = offer_data("bicard bottle (60u)", 300, 3),
-		/datum/reagent/medicine/kelotane = offer_data("kelotane bottle (60u)", 300, 3),
-		/datum/reagent/medicine/dylovene = offer_data("dylovene bottle (60u)", 300, 3),
-		/obj/item/reagent_containers/snacks/meat/spider = offer_data("spider meat", 250, 5),
+		/datum/reagent/medicine/bicaridine = offer_data("bicard bottle (60u)", 150, 3),
+		/datum/reagent/medicine/meralyne = offer_data("meralyne bottle (60u)", 400, 2),
+		/datum/reagent/medicine/varceptol = offer_data("varceptol bottle (60u)", 1000, 2),
+		/datum/reagent/medicine/kelotane = offer_data("kelotane bottle (60u)", 150, 3),
+		/datum/reagent/medicine/dermaline = offer_data("dermaline bottle (60u)", 500, 4),
+		/datum/reagent/medicine/dylovene = offer_data("dylovene bottle (60u)", 150, 3),
+		/datum/reagent/medicine/carthatoline = offer_data("carthatoline bottle (60u)", 500, 3),
+		/datum/reagent/toxin/pararein = offer_data("pararein bottle (60u)", 1500, 1),
 		/datum/reagent/nanites/uncapped/control_booster_utility = offer_data("Control Booster Utility bottle (60u)", 30000, 1),
 		/datum/reagent/nanites/uncapped/control_booster_combat = offer_data("Control Booster Combat bottle (60u)", 30000, 1)
 		)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
@@ -110,11 +110,11 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/gun/energy/laser/railgun/pistol = offer_data("\"Myrmidon\" rail pistol or rifle", 2500, 2),
-		/obj/item/tool/shovel/combat = offer_data("combat crovel", 400, 13),
-		/obj/item/tool_upgrade/armor/melee = offer_data("melee armor plate", 500, 5),
+		/obj/item/gun/energy/laser/railgun/pistol = offer_data("\"Myrmidon\" rail pistol or rifle", 4000, 2),
+		/obj/item/tool/shovel/combat = offer_data("combat crovel", 400, 10),
+		/obj/item/tool_upgrade/armor/melee = offer_data("melee armor plate", 1000, 3),
 		/obj/item/tool_upgrade/armor/bullet = offer_data("ballistic armor plate", 1200, 3),
-		/obj/item/tool_upgrade/armor/bomb = offer_data("bomb proofing armor plate", 800, 3),
+		/obj/item/tool_upgrade/armor/bomb = offer_data("bomb proofing armor plate", 1500, 3),
 		/obj/item/tool_upgrade/armor/energy = offer_data("energy armor plate", 2000, 2),
-		/obj/item/tool/baton/arcwelder = offer_data("arc welder", 2000, 2)
+		/obj/item/tool/baton/arcwelder = offer_data("arc welder", 2750, 2)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
@@ -18,7 +18,7 @@
 	stations_recommended = list("trapper")
 	inventory = list(
 		"Biomatter products" = list(
-			/obj/item/reagent_containers/snacks/meat,
+			// /obj/item/reagent_containers/snacks/meat, no more directly buying and selling back meat. Now you've got to butcher an animal at the very least.
 			/obj/item/reagent_containers/drinks/milk,
 			/obj/item/soap/church,
 			/obj/item/storage/pouch/small_generic,
@@ -36,12 +36,12 @@
 			/obj/item/clothing/accessory/holster/hip
 		),
 		"Livestock" = list(
-			/obj/structure/largecrate/animal/corgi,
-			/obj/structure/largecrate/animal/cow,
-			/obj/structure/largecrate/animal/goat,
-			/obj/structure/largecrate/animal/cat,
-			/obj/structure/largecrate/animal/chick,
-			/obj/structure/largecrate/animal/pig
+			/obj/structure/largecrate/animal/corgi = good_data("corgi crate", list(-1, 2), 800),
+			/obj/structure/largecrate/animal/cow = good_data("cow crate", list(-1, 2), 600),
+			/obj/structure/largecrate/animal/goat = good_data("goat crate", list(-1, 2), 500),
+			/obj/structure/largecrate/animal/cat = good_data("cat crate", list(-1, 2), 600),
+			/obj/structure/largecrate/animal/chick = good_data("chicken crate", list(-1, 2), 500),
+			/obj/structure/largecrate/animal/pig = good_data("pig crate", list(-1, 2), 500)
 		),
 		"Bee & Plant Supply" = list(
 			/obj/item/bee_pack,
@@ -156,7 +156,8 @@
 		/obj/item/clothing/suit/space/void/NTvoid = offer_data("angel voidsuit", 1250, 15),
 		/obj/item/clothing/shoes/hermes_shoes = offer_data("hermes shoes", 420, 10),
 		/obj/item/reagent_containers/snacks/grown = offer_data("spare grown food", 10, 120),
-		/obj/item/reagent_containers/snacks/meat = offer_data("meat", 80, 20) //Buys it for less than Dionis/McRonalds, but is willing to buy more of it.
+		///obj/item/reagent_containers/snacks/meat = offer_data("meat", 80, 20) //Buys it for less than Dionis/McRonalds, but is willing to buy more of it. SIKE! We're doing cutlets now.
+		/obj/item/reagent_containers/snacks/rawcutlet = offer_data("raw cutlet", 30, 30) //Up to 10 slabs of meat at a time!! (Assuming the given meat has slices_num = 3)
 	)
 
 /obj/item/reagent_containers/drinks/cans/cahors/cargo

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
@@ -54,13 +54,14 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/reagent_containers/snacks/meat = offer_data("meat", 100, 10),
+		/obj/item/reagent_containers/snacks/meat = offer_data("meat", 90, 10),
 		/obj/item/reagent_containers/snacks/meat/corgi = offer_data("corgi meat", 1000, 2),
-		/obj/item/reagent_containers/snacks/meat/roachmeat = offer_data("roach meat", 200, 15),
-		/obj/item/reagent_containers/snacks/meat/roachmeat/seuche = offer_data("seuche roach meat", 250, 10),
-		/obj/item/reagent_containers/snacks/meat/roachmeat/kraftwerk = offer_data("kraftwerk roach meat", 450, 10),
-		/obj/item/reagent_containers/snacks/meat/roachmeat/jager = offer_data("jager roach meat", 250, 10),
-		/obj/item/reagent_containers/snacks/meat/roachmeat/fuhrer = offer_data("fuhrer roach meat", 350, 5), //Caps it
-		/obj/item/reagent_containers/snacks/meat/roachmeat/kaiser = offer_data("kaiser roach meat", 2000, 2)
+		/datum/reagent/toxin/blattedin = offer_data("blattedin bottle (60u)", 1000, 1),
+		/datum/reagent/toxin/diplopterum = offer_data("diplopterum bottle (60u)", 1200, 1),
+		/datum/reagent/toxin/seligitillin = offer_data("seligitillin bottle (60u)", 1250, 1),
+		/datum/reagent/toxin/starkellin = offer_data("starkellinbottle bottle (60u)", 1000, 1),
+		/datum/reagent/toxin/gewaltine = offer_data("gewaltine bottle (60u)", 1400, 1),
+		/datum/reagent/toxin/fuhrerole = offer_data("fuhrerole bottle (60u)", 2400, 1),
+		/obj/item/reagent_containers/snacks/meat/roachmeat/kaiser = offer_data("kaiser roach meat", 1500, 2)
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/3-rare/monstertrapper.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/monstertrapper.dm
@@ -27,24 +27,24 @@
 			/obj/item/reagent_containers/snacks/cube/roach/grestrahlte = custom_good_amount_range(list(1, 2))
 		),
 		"Roach Toxins" = list(
-			/obj/item/reagent_containers/glass/bottle/trade/blattedin = good_data("blattedin bottle", list(-1, 2), 600),
-			/obj/item/reagent_containers/glass/bottle/trade/diplopterum = good_data("diplopterum bottle", list(-1, 2), 650),
-			/obj/item/reagent_containers/glass/bottle/trade/seligitillin = good_data("seligitillin bottle", list(-1, 2), 650),
-			/obj/item/reagent_containers/glass/bottle/trade/starkellin = good_data("starkellin bottle", list(-1, 2), 650),
-			/obj/item/reagent_containers/glass/bottle/trade/gewaltine = good_data("gewaltine bottle", list(-1, 2), 650)
+			/obj/item/reagent_containers/glass/bottle/trade/blattedin = good_data("blattedin bottle", list(-1, 2), 900),
+			/obj/item/reagent_containers/glass/bottle/trade/diplopterum = good_data("diplopterum bottle", list(-1, 2), 900),
+			/obj/item/reagent_containers/glass/bottle/trade/seligitillin = good_data("seligitillin bottle", list(-1, 2), 900),
+			/obj/item/reagent_containers/glass/bottle/trade/starkellin = good_data("starkellin bottle", list(-1, 2), 900),
+			/obj/item/reagent_containers/glass/bottle/trade/gewaltine = good_data("gewaltine bottle", list(-1, 2), 900)
 		),
 		"Spider Toxins" = list(
-			/obj/item/reagent_containers/glass/bottle/trade/pararein = good_data("pararein bottle", list(-1, 2), 400),
-			/obj/item/reagent_containers/glass/bottle/trade/aranecolmin = good_data("aranacolmin bottle", list(-1, 2), 500)
+			/obj/item/reagent_containers/glass/bottle/trade/pararein = good_data("pararein bottle", list(-1, 2), 1000),
+			/obj/item/reagent_containers/glass/bottle/trade/aranecolmin = good_data("aranacolmin bottle", list(-1, 2), 1000)
 		),
 		"Carp Toxins" = list(
-			/obj/item/reagent_containers/glass/bottle/trade/carpotoxin = good_data("carpotoxin bottle", list(-1, 2), 675)
+			/obj/item/reagent_containers/glass/bottle/trade/carpotoxin = good_data("carpotoxin bottle", list(-1, 2), 600)
 		)
 	)
 	hidden_inventory = list(
 		"High-End Roach Product" = list(
 			/obj/item/reagent_containers/snacks/cube/roach/kraftwerk = custom_good_amount_range(list(1, 2)),
-			/obj/item/reagent_containers/glass/bottle/trade/fuhrerole = good_data("fuhrerole bottle", list(1, 1), 900)
+			/obj/item/reagent_containers/glass/bottle/trade/fuhrerole = good_data("fuhrerole bottle", list(1, 1), 2000)
 //			/obj/item/reagent_containers/glass/bottle/trade/kaiseraurum = good_data("kaiseraurum bottle", list(1, 1), 1000) Kaiseraurum doesn't exist here, you just get an empty bottle
 		),
 		"Just Spiders" = list(


### PR DESCRIPTION
Removes plain meat from being sold from most stations.
Spider and Many variants of roach meat are no longer offers on stations, their chems in bottles are now what are sought after.
Lowers the value of the Bicaridine and Kelotane offers, adds plenty of more advanced medicine offers to be sought out by competent chemists.
Buffs the offers of many Guild crafted components and weapons in Hellcat.
Assigns prices to the animal crates listings in Faith.
Faith no longer wants slabs of meat, they want cutlets instead.
Slightly nerfed Dionis meat offer, gave them roach chem offers (Flavoring for Cht'Mant clientele, or something.)
Armitage chems bumped up in price. They're still lower than the offers, so they could stand to be bumped up even more in the future if this proves problematic.

![image](https://github.com/user-attachments/assets/ffee21c6-8881-4540-a8e9-76da46779c56)
![image](https://github.com/user-attachments/assets/882b9aae-b7fb-4a4d-ba2e-d48ba74bbe9b)
