### PR TITLE
Buffs Quick-Cement, Makes floorlights buildable

### DIFF
--- a/code/datums/craft/recipes/machinery.dm
+++ b/code/datums/craft/recipes/machinery.dm
@@ -16,7 +16,7 @@
 	related_stats = list(STAT_MEC, STAT_COG)
 
 /datum/craft_recipe/machinery/wall
-	flags = CRAFT_ON_FLOOR
+	flags = null
 
 /datum/craft_recipe/machinery/wall/air_alarm
 	name = "air alarm frame"

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -111,6 +111,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "tube-construct-item"
 	build_machine_type = /obj/machinery/light_construct
+	build_floormachine_type = /obj/machinery/light_construct/floor
 	reverse = 1
 
 /obj/item/frame/light/small

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -254,20 +254,12 @@ var/list/flooring_types
 				T.contents += CT
 	if (istype(I, /obj/item/stack/cement_bag))
 		var/obj/item/stack/cement_bag/CB = I
-		if(CB.inuse)
-			to_chat(user, SPAN_NOTICE("You cant pour the [src] that fast!"))
-			return
-		if(!T.wet)
-			to_chat(user, SPAN_NOTICE("The floor needs to be wet before pouring the [src]!"))
-			return
-		CB.inuse = TRUE
 		to_chat(user, SPAN_NOTICE("You start pouring and smoothing the [src]..."))
-		if(do_after(user,60))
+		if(do_after(user,20))
 			new /obj/effect/flooring_type_spawner/concrete(T)
 			CB.use(1)
 		else
 			to_chat(user, SPAN_NOTICE("You must stand still to finish the job!"))
-			CB.inuse = FALSE
 
 
 /decl/flooring/reinforced/plating/under/get_plating_type(var/turf/location)
@@ -1090,20 +1082,12 @@ var/list/flooring_types
 	if(can_repair)
 		if(istype(I, /obj/item/stack/cement_bag))
 			var/obj/item/stack/cement_bag/CB = I
-			if(CB.inuse)
-				to_chat(user, SPAN_NOTICE("You cant pour the [src] that fast!"))
-				return
-			if(!T.wet)
-				to_chat(user, SPAN_NOTICE("The floor needs to be wet before pouring the [src]!"))
-				return
-			CB.inuse = TRUE
 			to_chat(user, SPAN_NOTICE("You start pouring and smoothing the [src]..."))
-			if(do_after(user,60))
+			if(do_after(user,20))
 				new repair_into(T)
 				CB.use(1)
 			else
 				to_chat(user, SPAN_NOTICE("You must stand still to finish the job!"))
-				CB.inuse = FALSE
 
 //concrete
 

--- a/modular_sojourn/cement_bag.dm
+++ b/modular_sojourn/cement_bag.dm
@@ -4,7 +4,6 @@
 	icon = 'modular_sojourn/misc_stuff.dmi'
 	icon_state = "cementbag"
 	max_amount = 100
-	var/inuse = FALSE
 
 /obj/item/stack/cement_bag/full
 	amount = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
The need for the floor being wet, the inuse being very broken, and the very slow speed made repairing maintenance floors with the cement instead of just pulling them up and replacing them wildly impractical. I just sped it up, made it not need wet floors, and made it possible to repair more than one tile at a time.

Also, I actually fixed being able to build more than one light fixture frame on the floor, and made the large ones be able to be turned into floorlights like the ones in soteria lobby.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
