### PR TITLE
Slightly better code for golems

### DIFF
--- a/code/modules/ameridian/ameridian_crystal.dm
+++ b/code/modules/ameridian/ameridian_crystal.dm
@@ -141,7 +141,7 @@
 	var/obj/item/stack/material/ameridian/T = new(get_turf(src))
 	T.amount = growth // Drop more crystal the further along we are
 	activate_mobs_in_range(src, 7, TRUE) // Wake up the nearby golems
-	qdel(src)
+	Destroy(src)
 
 
 /obj/structure/ameridian_crystal/proc/spread()

--- a/code/modules/mob/living/carbon/superior_animal/ameridian/ameridian_golem.dm
+++ b/code/modules/mob/living/carbon/superior_animal/ameridian/ameridian_golem.dm
@@ -83,13 +83,14 @@
 			SB.multiply_projectile_damage(SB.golem_damage_bonus)
 			drop_amount = 0 // No loot
 
-	. = ..()
+			. = ..()
 
-	addtimer(CALLBACK(src, PROC_REF(maintain_drop_amount)), 100 MILLISECONDS) //consider converting this to ticks?
+			if(!QDELETED(src) && !is_dead(src))
+				drop_amount = initial(drop_amount) // So we still have loot
 
-/mob/living/carbon/superior/ameridian_golem/proc/maintain_drop_amount()
-	if (!is_dead(src)) // We're still alive!
-		drop_amount = initial(drop_amount) // So we still have loot
+	else
+
+		. = ..()
 
 // Stole this code from 'code/__HELPERS/matrices.dm' because otherwise the golems shrink during the shake animation. -R4d6
 /mob/living/carbon/superior/ameridian_golem/shake_animation(var/intensity = 8)


### PR DESCRIPTION
By R4D6
Fixes a wrong proc call when harvesting ameridian crystal
By Trilby
Removes a un-needed timer and less proc calls for when a golem is shot.