### PR TITLE
Data star fixes as well as buffs

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -996,7 +996,7 @@
 
 					var/obj/item/projectile/bullet/shotgun/relay/relayed = new type(enemy_turf)
 
-					if(health >= 1)
+					if(M.health >= 1)
 						//message_admins("dont relay")
 
 						relayed.allow_relay = FALSE
@@ -1006,13 +1006,13 @@
 					//message_admins("health 4     [target_mob.health]")
 					break
 
-			if(faction_shooter)
+			if(faction_shooter && !original_firer) //Way simpler verson for edge cases
 
 				if(M.faction != faction_shooter)
 
 					var/obj/item/projectile/bullet/shotgun/relay/relayed = new type(enemy_turf)
 
-					if(health >= 1)
+					if(M.health >= 1)
 						//message_admins("dont relay")
 
 						relayed.allow_relay = FALSE


### PR DESCRIPTION
## About The Pull Request
Data star no longer gets stuck using only teller if above 6000 data and not using k-amps
Data star now properly scales its armor based on what is attacking it rather then mile stones
Fixes a issue with data star if stunned early or weakened will be in a perma stunned mode
Fixes data star being bullied by tesla turrets
Fixes a small infi loop bug with relay shot if two targets are immortal 