### PR TITLE
small tweaks to nades and impact nades

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -183,7 +183,7 @@
 		C.throw_mode_off()
 
 	invisibility = INVISIBILITY_MAXIMUM //Why am i doing this?
-	spawn(50)		   //To make sure all reagents can work
+	spawn(3)		   //To make sure all reagents can work
 		qdel(src)	   //correctly before deleting the grenade.
 
 

--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -4,26 +4,27 @@
 	icon_state = "emp"
 	item_state = "empgrenade"
 	origin_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 3)
+	var/pluse_range_h = 4
+	var/pluse_range_l = 10
 
 /obj/item/grenade/empgrenade/prime()
 	..()
-	if(empulse(src, 4, 10))
+	if(empulse(src, pluse_range_h, pluse_range_l))
 		icon_state = "emp_off"
 		desc = "[initial(desc)] It has already been used."
 	return
 
 /obj/item/grenade/empgrenade/low_yield
 	name = "HS EMP grenade \"Power Zapper\" - C"
-	desc = "A weaker variant of the \"Power Zapper\" emp grenade, with lesser radius."
+	desc = "A weaker variant of the \"Frye\" emp grenade, with lesser radius."
 	icon_state = "lyemp"
 	item_state = "empgrenade"
-	origin_tech = list(TECH_MATERIAL = 2, TECH_MAGNET = 3)
+	pluse_range_h = 1
+	pluse_range_l = 4
 
-/obj/item/grenade/empgrenade/low_yield/prime() // Inheritance is a fuck . this made low yields as effective as normal.
-	var/turf/T = get_turf(src)
-	if(T)
-		T.hotspot_expose(700,125)
-	if(empulse(src, 4, 1))
-		icon_state = "emp_off"
-		desc = "[initial(desc)] It has already been used."
-	return
+/obj/item/grenade/empgrenade/impact
+	name = "HS EMP-I grenade \"Pluser\" - C"
+	desc = "A weaker variant of the \"Power Zapper\" emp grenade, with even lesser radius."
+	pluse_range_h = 0
+	pluse_range_l = 2
+	impact = TRUE

--- a/code/game/objects/items/weapons/grenades/explosive.dm
+++ b/code/game/objects/items/weapons/grenades/explosive.dm
@@ -1,41 +1,56 @@
 /obj/item/grenade/explosive
-    name = "NT OBG \"Cracker\""
-    desc = "A military-grade offensive blast grenade, designed to be thrown by assaulting troops."
-    icon_state = "explosive"
-    loadable = TRUE
+	name = "SA OBG \"Cracker\""
+	desc = "A military-grade offensive blast grenade, designed to be thrown by assaulting troops."
+	icon_state = "explosive"
+	loadable = TRUE
 
-    var/devastation_range = -1
-    var/heavy_range = 1
-    var/weak_range = 4
-    var/flash_range = 10
+	var/devastation_range = -1
+	var/heavy_range = 1
+	var/weak_range = 4
+	var/flash_range = 10
 
 
 /obj/item/grenade/explosive/prime()
-    set waitfor = 0
-    ..()
-    var/turf/O = get_turf(src)
-    if(!O) return
+	set waitfor = 0
+	..()
+	var/turf/O = get_turf(src)
+	if(!O) return
 
-    on_explosion(O)
+	on_explosion(O)
 
-    qdel(src)
+	qdel(src)
 
 /obj/item/grenade/explosive/proc/on_explosion(var/turf/O)
 	explosion(O, devastation_range, heavy_range, weak_range, flash_range)
 
 /obj/item/grenade/explosive/nt
 	name = "NT OBG \"Holy Grail\""
-	desc = "There's an inscription along the bands. \'And the Lord spake, saying: First shalt thou take out the Holy Pin. Then, shalt thou count to three, no more, no less. Three shall be the number thou shalt count, and the number of the counting shall be three. Four shalt thou not count, nor either count thou two, excepting that thou then proceed to three. Five is right out! Once the number three, being the third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch towards thou foe, who being naughty in my sight, shall snuff it.\'"
+	desc = "There's an inscription along the bands. \'And the Lord spake, saying: \
+	First shalt thou take out the Holy Pin. Then, \
+	shalt thou count to three, no more, no less. \
+	Three shall be the number thou shalt count, and the number of the counting shall be three. \
+	Four shalt thou not count, nor either count thou two, excepting that thou then proceed to three. \
+	Five is right out! Once the number three, being the third number, \
+	be reached, then lobbest thou thy Holy Hand Grenade of Antioch towards thou foe, \
+	who being naughty in my sight, shall snuff it.\'"
 	icon_state = "explosive_nt"
 	item_state = "explosive_nt"
 	heavy_range = 1.5
 	weak_range = 5
 	matter = list(MATERIAL_BIOMATTER = 50)
 
+/obj/item/grenade/explosive/impact
+	name = "SA OBG-I \"Hardtack\""
+	desc = "A mini military-grade offensive blast grenade, designed to be thrown by assaulting troops."
+	icon_state = "sting_ag"
+	heavy_range = 0
+	weak_range = 0.1
+	impact = TRUE
 
 /obj/item/grenade/explosive/artileria
 	name = "Excelsior \"Artileria Flare\""
-	desc = "ARTILERIA! This is a standard artillery signaling flare used by Excelsior forces. Better stay well away from it!"
+	desc = "ARTILERIA! This is a standard artillery signaling flare used by Excelsior forces. \
+	Better stay well away from it!"
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "aflare-on"
 	item_state = "aflare-on"

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -7,26 +7,27 @@
 	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 1)
 	var/banglet = 0
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_SILVER = 1)
+	var/hear_range = 7
 
 /obj/item/grenade/flashbang/prime()
 	..()
-	for(var/obj/structure/closet/L in hear(7, get_turf(src)))
+	for(var/obj/structure/closet/L in hear(hear_range, get_turf(src)))
 		if(locate(/mob/living/carbon/, L))
 			for(var/mob/living/carbon/M in L)
 				flashbang_bang(get_turf(src), M)
 
 
-	for(var/mob/living/carbon/M in hear(7, get_turf(src)))
+	for(var/mob/living/carbon/M in hear(hear_range, get_turf(src)))
 		flashbang_bang(get_turf(src), M)
 
-	for(var/mob/living/carbon/human/thermal_user in orange(9, loc))
+	for(var/mob/living/carbon/human/thermal_user in orange(hear_range+2, loc))
 		if(!thermal_user.glasses)
 			return
 		var/obj/item/clothing/glasses/potential_thermals = thermal_user.glasses
 		if(potential_thermals.overlays == global_hud.thermal)
 			flashbang_without_the_bang(get_turf(src), thermal_user)
 
-	for(var/obj/effect/blob/B in hear(8,get_turf(src)))	//Blob damage here
+	for(var/obj/effect/blob/B in hear(hear_range+1,get_turf(src)))	//Blob damage here
 		var/damage = round(30/(get_dist(B,get_turf(src))+1))
 		B.take_damage(damage)
 		B.update_icon()
@@ -154,3 +155,10 @@
 	if(M.get_core_implant(/obj/item/implant/core_implant/cruciform))
 		intensity += 1
 	..()
+
+/obj/item/grenade/flashbang/impact
+	name = "Seinemetall Defense GmbH FBG-I \"Bulb\""
+	desc = "A mini verson \"Serra\" flashbang grenade. Only useful if thrown directly at target."
+	icon_state = "sting_ih"
+	impact = TRUE
+	hear_range = 2

--- a/code/game/objects/items/weapons/grenades/frag.dm
+++ b/code/game/objects/items/weapons/grenades/frag.dm
@@ -94,3 +94,10 @@
 	qdel(smoke)
 	smoke = null
 	return ..()
+
+/obj/item/grenade/frag/impact
+	name = "SA DF-I grenade \"Seeds\""
+	desc = "A mini military-grade defensive fragmentation grenade, designed to be thrown from cover."
+	icon_state = "sting_ag"
+	impact = TRUE
+	num_fragments = 12

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -9,11 +9,15 @@
 	throw_range = 20
 	flags = CONDUCT
 	slot_flags = SLOT_BELT|SLOT_MASK
+	price_tag = 300
 	var/active = 0
 	var/det_time = 40
 	var/loadable = TRUE
-	var/variance = 0 //How much the fuse time varies up or down. Punishes cooking with makeshift nades, proper ones should have 0
-	price_tag = 300
+	//How much the fuse time varies up or down. Punishes cooking with makeshift nades, proper ones should have 0
+	var/variance = 0
+	var/impact = FALSE
+	var/impact_unsafe = FALSE
+	var/exploded = FALSE
 
 /obj/item/grenade/proc/clown_check(var/mob/living/user)
 	if((CLUMSY in user.mutations) && prob(10))
@@ -28,6 +32,8 @@
 
 /obj/item/grenade/examine(mob/user)
 	if(..(user, 0))
+		if(impact)
+			to_chat(user, "This grenade is set to explode when hitting anything[impact_unsafe ? "" : " when primed"].")
 		if(det_time > 1)
 			to_chat(user, "The timer is set to [det_time/10] seconds.")
 			return
@@ -71,24 +77,87 @@
 
 
 /obj/item/grenade/proc/prime(mob/user)
+	if(exploded)
+		return
+	exploded = TRUE
 	var/turf/T = get_turf(src)
 	T.hotspot_expose(700,125)
-	user.hud_used.updatePlaneMasters(user)
+	if(ismob(user))
+		user.hud_used.updatePlaneMasters(user)
 
 
 /obj/item/grenade/attackby(obj/item/I, mob/user as mob)
-	if(QUALITY_SCREW_DRIVING in I.tool_qualities)
-		if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_SCREW_DRIVING, FAILCHANCE_EASY, required_stat = STAT_COG))
-			switch(det_time)
-				if (1)
-					det_time = 30
-					to_chat(user, SPAN_NOTICE("You set the [name] for 3 second detonation time."))
-				if (30)
-					det_time = 40
-					to_chat(user, SPAN_NOTICE("You set the [name] for 4 second detonation time."))
-				if (40)
-					det_time = 1
-					to_chat(user, SPAN_NOTICE("You set the [name] for instant detonation."))
+
+	var/list/usable_qualities = list(QUALITY_SCREW_DRIVING)
+
+	if(impact)
+		usable_qualities += QUALITY_BOLT_TURNING
+
+	var/tool_type = I.get_tool_type(user, usable_qualities, src)
+	switch(tool_type)
+		if(QUALITY_BOLT_TURNING)
+			if(impact)
+				impact_unsafe = !impact_unsafe
+
+				to_chat(user, "You adjust the [src] to \
+				[impact_unsafe ? "explode even when unprimed on impact" : "explode only when when primed"].")
+				add_fingerprint(user)
+
+
+		if(QUALITY_SCREW_DRIVING)
+			if(I.use_tool(user, src, WORKTIME_NEAR_INSTANT, QUALITY_SCREW_DRIVING, FAILCHANCE_EASY, required_stat = STAT_COG))
+				switch(det_time)
+					if (1)
+						det_time = 30
+						to_chat(user, SPAN_NOTICE("You set the [name] for 3 second detonation time."))
+					if (30)
+						det_time = 40
+						to_chat(user, SPAN_NOTICE("You set the [name] for 4 second detonation time."))
+					if (40)
+						det_time = 1
+						to_chat(user, SPAN_NOTICE("You set the [name] for instant detonation."))
+
 			add_fingerprint(user)
+
+		if(ABORT_CHECK)
+			return
+
 	..()
 	return
+
+/obj/item/grenade/throw_at(atom/target, range, speed, thrower)
+	..()
+
+	//More logging
+	if(active && impact)
+		if(throwing && thrower)
+			log_and_message_admins("impact based nade \a [src] used by [thrower], to hit [target] at [jumplink(thrower)]")
+			if(ismob(thrower))
+				var/mob/M = thrower
+				M.attack_log += "\[[time_stamp()]\] <font color='red'>primed \a [src] via impact</font>"
+
+	if(impact_unsafe)
+		log_and_message_admins("impact -unsafe- based nade \a [src] used by [thrower], to hit [target] at [jumplink(thrower)]")
+		if(ismob(thrower))
+			var/mob/M = thrower
+			M.attack_log += "\[[time_stamp()]\] <font color='red'>primed \a [src] via impact</font>"
+
+
+//called when src is thrown into hit_atom
+/obj/item/grenade/throw_impact(atom/hit_atom, var/speed)
+	..()
+	if(active && impact)
+		if(throwing && thrower)
+			log_and_message_admins("primed \a [src] via impact at [hit_atom]")
+			if(ismob(thrower))
+				var/mob/M = thrower
+				M.attack_log += "\[[time_stamp()]\] <font color='red'>primed \a [src] via impact</font>"
+		prime(hit_atom)
+
+	if(impact_unsafe)
+		log_and_message_admins("primed \a [src] via impact at [hit_atom]")
+		if(ismob(thrower))
+			var/mob/M = thrower
+			M.attack_log += "\[[time_stamp()]\] <font color='red'>primed \a [src] via impact</font>"
+
+		prime(hit_atom)


### PR DESCRIPTION
## About The Pull Request
Nades that delete themselfs do so faster then before
EMP nades now are standerized
Fixes some bad naming and descs

Adds some for now admin only impact nades ~~will add them to spawn pools before merging~~

Impacts nades are nades that when pinned is pulled and thrown will instently go off when landing or hitting a mob
Impact nades can be made to be always going off when thrown, using a wrench
Impact nades that are not admin set are incredibly weaker for balance of not needing to cook the nade