### PR TITLE
Maints touch ups and SI improvements

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -43,6 +43,15 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"aax" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "aaA" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -632,6 +641,10 @@
 /obj/item/device/lighting/toggleable/lamp,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"agN" = (
+/obj/structure/sign/department/robo,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/rnd/rbreakroom)
 "agU" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -822,6 +835,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
+"aix" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/light/small,
+/obj/random/mob/termite_no_despawn,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "aiF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/bluecorner,
@@ -885,6 +907,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfacesec)
+"aiV" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/roboticist,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/robotics)
 "aiZ" = (
 /obj/structure/multiz/stairs/active{
 	dir = 8
@@ -1152,6 +1184,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "alT" = (
@@ -1395,6 +1430,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/nadezhda/engineering/atmos)
+"aou" = (
+/obj/structure/salvageable/server,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "aov" = (
 /obj/random/cluster/termite_no_despawn/lower_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -1434,6 +1477,15 @@
 /obj/random/medical,
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"aoS" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "aoT" = (
 /obj/machinery/camera/network/engineering{
 	dir = 8
@@ -1448,9 +1500,6 @@
 /turf/simulated/floor/industrial/navy_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "apk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1461,7 +1510,7 @@
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "apq" = (
 /obj/machinery/power/breakerbox{
@@ -1823,6 +1872,15 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"asU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/robotics)
 "asW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2105,6 +2163,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
+"avv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/mecha_wreckage/ripley{
+	oldified = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "avw" = (
 /obj/item/stock_parts/manipulator,
 /obj/item/circuitboard/vending,
@@ -2218,6 +2286,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"awk" = (
+/obj/structure/table/bench/standard,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "awx" = (
 /obj/structure/toilet{
 	dir = 8
@@ -2237,6 +2310,17 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/arcade)
+"awE" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/spider/hunter,
+/obj/effect/spider/stickyweb,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "awJ" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/table/rack,
@@ -3298,6 +3382,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
+"aGy" = (
+/obj/machinery/washing_machine,
+/obj/item/towel/random,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "aGD" = (
 /obj/structure/flora/small/lavarock1,
 /turf/simulated/floor/asteroid/grass,
@@ -3632,6 +3721,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"aKL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "aKM" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular/open{
@@ -3741,7 +3837,6 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "aLQ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -3753,6 +3848,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "aLR" = (
@@ -4350,6 +4446,14 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/hallway)
+"aSE" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/mob/termite_no_despawn,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "aSO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4615,6 +4719,12 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"aVJ" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aVK" = (
 /turf/simulated/floor/reinforced/plasma,
 /area/nadezhda/engineering/atmos)
@@ -4628,15 +4738,14 @@
 /turf/simulated/floor/tiled/steel/panels,
 /area/nadezhda/command/tcommsat/computer)
 "aVR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/rnd/rbreakroom)
+/obj/item/trash/material/circuit,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "aVX" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
@@ -5303,7 +5412,7 @@
 /obj/landmark/join/start/scientist,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "bcp" = (
 /obj/machinery/door/airlock/maintenance_common,
@@ -5363,16 +5472,10 @@
 /turf/simulated/floor/industrial/blue_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "bcQ" = (
-/obj/structure/table/rack/shelf,
-/obj/item/storage/toolbox/electrical,
-/obj/item/tool/weldingtool,
-/obj/item/tool/saw,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/glasses/welding,
 /obj/machinery/camera/network/research{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
 "bcT" = (
@@ -5715,11 +5818,13 @@
 /area/nadezhda/command/crematorium)
 "bgi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance{
@@ -6128,6 +6233,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"bjs" = (
+/obj/item/contraband/poster/placed/eris/agreeablework,
+/turf/simulated/wall,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "bjv" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -6166,6 +6277,11 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
+"bjJ" = (
+/obj/structure/table/rack/shelf,
+/obj/item/towel/random,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bjP" = (
 /obj/machinery/light/floor,
 /obj/effect/floor_decal/steeldecal/steel_decals_central6,
@@ -6510,6 +6626,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"bnQ" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/device,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
+"bnR" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/random/mob/termite_no_despawn,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "bnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/light/tube,
@@ -6524,6 +6659,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/hallway)
+"boa" = (
+/obj/structure/reagent_dispensers/fueltank/derelict,
+/obj/item/tool_upgrade/augment/fuel_tank,
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/structure/flora/small/trailrockb1,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "bog" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -6774,6 +6917,13 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"bqd" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "bqf" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -7346,6 +7496,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/ward)
+"bvl" = (
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/glowstick/random,
+/turf/simulated/floor/wood,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "bvo" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -7580,6 +7738,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"bxv" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/robot/gp/roomba,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "bxA" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushc1,
@@ -7725,6 +7890,12 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"byR" = (
+/obj/machinery/light,
+/obj/random/furniture/pottedplant,
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/crew_quarters/pool)
 "byV" = (
 /obj/structure/table/steel,
 /obj/random/credits/low_chance,
@@ -8549,8 +8720,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "bHt" = (
-/obj/landmark/join/late/cyborg,
-/turf/simulated/floor/tiled/white/techfloor,
+/obj/machinery/vending/engivend,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
 "bHA" = (
 /obj/structure/flora/small/lavarock2,
@@ -8708,6 +8882,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"bIG" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/spider,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bIH" = (
 /obj/item/material/shard/shrapnel/scrap,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -9740,6 +9922,17 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"bTW" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/item/brokenposi,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/robotics)
 "bTZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -9997,6 +10190,13 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/engineering/engine_room)
+"bVT" = (
+/obj/machinery/light/small,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "bVU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -10807,6 +11007,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"ceQ" = (
+/obj/machinery/door/airlock/maintenance_common,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/crew_quarters/pool)
 "ceW" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil{
 	layer = 1
@@ -11365,6 +11569,15 @@
 "ckO" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
+"ckP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/custom/onestar{
+	dir = 1
+	},
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ckQ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing{
@@ -12413,10 +12626,10 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "cvD" = (
-/obj/structure/bed/chair{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "cvH" = (
@@ -13028,6 +13241,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "cBE" = (
@@ -13106,6 +13322,15 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/side/f2section1)
+"cCm" = (
+/obj/structure/mopbucket,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre_paste,
+/obj/item/trash/mre_can,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "cCp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -13341,6 +13566,14 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
+"cEl" = (
+/obj/structure/table/rack/shelf,
+/obj/random/powercell,
+/obj/random/powercell/low_chance,
+/obj/random/powercell/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cEA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -13448,15 +13681,9 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate)
 "cFB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/mecha_wreckage/ripley{
-	oldified = 1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/industrial/bricks,
-/area/nadezhda/maintenance{
-	name = "Residential District Maintenance"
-	})
+/obj/item/stack/rods/random,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cFD" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,6";
@@ -13848,6 +14075,20 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"cIR" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/roach/roachling,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/tastybread,
+/obj/item/trash/waffles,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "cIX" = (
 /obj/structure/table/standard,
 /obj/item/tool/multitool,
@@ -13960,10 +14201,13 @@
 	name = "Residential District Maintenance"
 	})
 "cJX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/research{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "cKc" = (
@@ -14626,6 +14870,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"cQn" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "cQu" = (
 /obj/structure/flora/big/rocks2,
 /mob/living/simple/chicken,
@@ -14780,6 +15029,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"cRP" = (
+/obj/item/mop,
+/obj/structure/mopbucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "cRS" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -15025,6 +15282,12 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"cUz" = (
+/obj/structure/largecrate,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cUB" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -15131,6 +15394,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/hallway)
+"cVY" = (
+/obj/structure/bed/chair,
+/obj/item/grenade/chem_grenade/metalfoam,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "cVZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departmentold/restroom{
@@ -15429,6 +15699,8 @@
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/box/matches,
+/obj/item/reagent_containers/drinks/drinkingglass/wineglass,
+/obj/item/flame/lighter/zippo,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -15691,6 +15963,15 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"day" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "daI" = (
 /obj/random/closet_maintloot/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -16146,15 +16427,8 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "dfC" = (
-/obj/item/device/camera,
-/obj/item/folder/black{
-	pixel_x = 6
-	},
-/obj/item/folder/blue,
-/obj/item/folder/red{
-	pixel_x = -6
-	},
-/obj/structure/table/glass,
+/obj/structure/bed/chair/comfy/purp,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
 "dfE" = (
@@ -16569,6 +16843,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/rocinante_shuttle_area)
+"dkb" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/roach/roachling,
+/obj/item/trash/chips_green,
+/obj/item/trash/syndi_cakes,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "dkc" = (
 /obj/machinery/light,
 /obj/machinery/alarm{
@@ -17150,6 +17433,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "dpH" = (
@@ -18097,10 +18381,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "dys" = (
@@ -18340,16 +18631,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "dAP" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/random,
-/obj/item/tool/wrench,
-/obj/item/clothing/glasses/welding,
-/obj/item/tool/weldingtool,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/machinery/constructable_frame/machine_frame,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/research)
 "dAX" = (
 /turf/simulated/open,
@@ -18851,7 +19138,9 @@
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
 "dFx" = (
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "dFy" = (
 /obj/structure/extinguisher_cabinet{
@@ -19063,6 +19352,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
+"dHs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dHt" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/tool_upgrade,
@@ -19372,6 +19668,12 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"dKt" = (
+/obj/structure/closet,
+/obj/random/cloth/armor/low_chance,
+/obj/random/cloth/gloves/low_chance,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dKy" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/effect/decal/cleanable/dirt,
@@ -19992,14 +20294,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "dQD" = (
 /obj/machinery/conveyor/east{
@@ -20094,6 +20390,14 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/industrial/grey_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dRB" = (
+/obj/structure/largecrate,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dRE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20225,20 +20529,12 @@
 /turf/simulated/floor/rock,
 /area/colony)
 "dSM" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/item/brokenposi,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/rnd/robotics)
+/obj/random/scrap/sparse_weighted,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "dSP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -21075,6 +21371,13 @@
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"eaX" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ebs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -21173,7 +21476,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/rnd/robotics)
+/area/nadezhda/rnd/xenobiology/xenoflora)
 "ebP" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -21274,6 +21577,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/industrial/checker_large,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"ecM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/assembly/mousetrap/armed,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ecO" = (
 /obj/structure/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
@@ -21535,14 +21844,7 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/maingate)
 "efm" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/robotics,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "efr" = (
@@ -21986,9 +22288,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ejB" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/research)
 "ejE" = (
 /obj/structure/catwalk,
@@ -22021,6 +22325,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"ejJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ejS" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -22640,10 +22951,10 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
 "epJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/rnd/research)
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "epP" = (
 /obj/random/cluster/tengolo,
 /turf/simulated/floor/asteroid/dirt,
@@ -22659,6 +22970,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/ornate,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"eqa" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "eqe" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -23495,6 +23812,17 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm4)
+"exF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/raisins,
+/obj/item/trash/mre/os,
+/obj/item/trash/liquidfood,
+/obj/item/trash/plate,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "exO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -23507,7 +23835,13 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
 "exT" = (
-/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/obj/machinery/power/hydrogen_gen{
+	anchored = 1
+	},
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "exU" = (
@@ -23538,6 +23872,12 @@
 /obj/random/mob/nightmare/low_chance,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"eyk" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "eyo" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -24595,6 +24935,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"eJU" = (
+/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "eJW" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -24975,13 +25320,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "eMW" = (
-/obj/machinery/cryopod/robot{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/landmark/join/late/cyborg,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/rnd/robotics)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "eNc" = (
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/lakeside)
@@ -25532,6 +25873,8 @@
 /area/nadezhda/engineering/atmos)
 "eRg" = (
 /obj/structure/table/rack/shelf,
+/obj/item/towel/random,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "eRh" = (
@@ -25740,6 +26083,14 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"eTT" = (
+/obj/structure/bed/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "eTU" = (
 /obj/machinery/door/airlock/maintenance_engineering{
 	req_access = list(24,10)
@@ -25889,6 +26240,13 @@
 /obj/machinery/suit_storage_unit/rad_unit,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
+"eVM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "eVN" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
@@ -26394,6 +26752,16 @@
 	},
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfaceeast)
+"eZi" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cane,
+/turf/simulated/floor/carpet,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "eZk" = (
 /obj/structure/railing{
 	dir = 8
@@ -26670,6 +27038,16 @@
 /obj/item/book/manual/nonfiction/thetranscendentalist,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"fcV" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/scrap/sparse_weighted,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "fdk" = (
 /turf/simulated/shuttle/floor/science{
 	icon_state = "11,4"
@@ -26919,6 +27297,20 @@
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"ffF" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/mob/roaches,
+/obj/item/trash/semki,
+/obj/item/trash/liquidfood,
+/obj/item/trash/tray,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ffH" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -27029,6 +27421,14 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
+"fgR" = (
+/obj/effect/decal/mecha_wreckage/hoverpod,
+/obj/item/trash/material/metal,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "fgT" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
@@ -27374,6 +27774,13 @@
 	opacity = 0
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"fjy" = (
+/obj/item/storage/hcases/parts/has_items_spawn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "fjz" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "9,3"
@@ -28421,9 +28828,9 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fsS" = (
-/obj/landmark/join/start/scientist,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/machinery/smartfridge/disk,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/research)
 "fsX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28906,6 +29313,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"fyp" = (
+/obj/random/mob/termite_no_despawn,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "fyw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29121,6 +29535,12 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
+"fAu" = (
+/obj/structure/flora/pottedplant/dead,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fAw" = (
 /obj/structure/catwalk,
 /obj/structure/barricade,
@@ -29369,6 +29789,12 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"fDj" = (
+/obj/structure/boulder,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "fDn" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -29639,6 +30065,17 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
+"fFv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "fFD" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -30114,11 +30551,14 @@
 	name = "Residential District Maintenance"
 	})
 "fLc" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/folder/red{
+	pixel_x = -6
 	},
-/obj/landmark/join/start/scientist,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/folder/blue,
+/obj/item/folder/black{
+	pixel_x = 6
+	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
 "fLq" = (
@@ -30213,6 +30653,11 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
+"fMi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "fMr" = (
 /obj/structure/closet/crate,
 /obj/item/circuitboard/smes,
@@ -30673,6 +31118,11 @@
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
+"fRz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/salvageable/personal,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fRM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -30904,13 +31354,11 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
 "fUe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/plushie/drone{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "fUg" = (
 /obj/random/cluster/termite_no_despawn/lower_chance,
@@ -31228,6 +31676,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"fXr" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "fXt" = (
 /obj/machinery/door/window/westright,
 /obj/structure/table/rack,
@@ -31646,6 +32103,13 @@
 /obj/item/tool/scalpel,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/medical/morgue)
+"gbj" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/glass/bottle/potassium,
+/obj/item/reagent_containers/glass/bottle/sodium,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gbm" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/techmaint,
@@ -31814,6 +32278,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "gcR" = (
@@ -32025,6 +32493,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"geF" = (
+/obj/item/storage/bag/trash,
+/obj/structure/table/standard,
+/obj/item/trash/mre,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "geI" = (
 /obj/structure/table/steel,
 /obj/random/credits/low_chance,
@@ -32037,6 +32513,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "geL" = (
 /obj/structure/table/woodentable,
+/obj/item/flame/candle,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -32115,8 +32592,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/hallway)
 "gfo" = (
-/obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "gfw" = (
@@ -32237,19 +32714,7 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "ggq" = (
-/obj/structure/table/rack,
-/obj/item/stack/material/steel{
-	amount = 120
-	},
-/obj/item/stack/material/glass{
-	amount = 120
-	},
-/obj/item/stack/material/plasteel{
-	amount = 20
-	},
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
 "ggs" = (
@@ -32576,9 +33041,11 @@
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "gjz" = (
-/obj/item/storage/deferred/crate/uniform_black,
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "gjE" = (
@@ -32829,6 +33296,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "glJ" = (
 /obj/structure/table/woodentable,
+/obj/item/flame/candle,
 /turf/simulated/floor/industrial/sierra,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -33809,11 +34277,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "gus" = (
-/obj/structure/sign/department/robo{
-	pixel_x = 32
-	},
-/obj/machinery/repair_station,
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/cyborg,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "guA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33998,9 +34465,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/engineering/engine_room)
 "gvS" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
 	},
@@ -34194,7 +34658,10 @@
 "gxP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
 "gyd" = (
 /obj/random/scrap/dense_weighted/low_chance,
@@ -34216,6 +34683,12 @@
 /obj/random/gun_normal/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"gyz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gyC" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -34226,6 +34699,13 @@
 	},
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"gyP" = (
+/obj/structure/table/rack/shelf,
+/obj/item/trash/chips_green,
+/obj/structure/scrap/food,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gyW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34335,6 +34815,12 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"gzv" = (
+/obj/item/stack/rods/random,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "gzw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34674,6 +35160,13 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/range)
+"gDk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "gDv" = (
 /obj/random/structures/low_chance,
 /obj/structure/catwalk,
@@ -34975,11 +35468,17 @@
 /obj/item/mine/old/armed,
 /turf/simulated/floor/rock,
 /area/colony)
+"gGD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/papershredder,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gGG" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/industrial/blue_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gGN" = (
+/obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -35401,6 +35900,16 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gLN" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/robot/gp/roomba,
+/obj/structure/bed/chair/custom/onestar{
+	dir = 1
+	},
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "gLR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -36119,6 +36628,12 @@
 	icon_state = "11,8"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"gSr" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/rnd/xenobiology/xenoflora)
 "gSt" = (
 /obj/item/reagent_containers/glass/fertilizer,
 /obj/item/reagent_containers/glass/fertilizer/ez,
@@ -36200,6 +36715,12 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/east)
+"gST" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/colony)
 "gSV" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/rock,
@@ -36803,6 +37324,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
+"gZq" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "gZv" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -36929,17 +37457,10 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "haL" = (
-/obj/structure/boulder,
+/obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance{
-	name = "Residential District Maintenance"
-	})
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "haN" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/structure/railing/grey{
@@ -37024,6 +37545,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"hbR" = (
+/obj/effect/decal/mecha_wreckage/ripley,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hcb" = (
 /obj/item/material/shard,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -37036,9 +37562,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "hcn" = (
-/obj/machinery/computer/rdconsole/core{
-	dir = 8
-	},
+/obj/machinery/autolathe/rnd/imprinter/loaded,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/research)
 "hco" = (
@@ -37440,7 +37965,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -37452,6 +37976,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "hfY" = (
@@ -37698,6 +38223,18 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/absolutism/bioreactor)
+"hiJ" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre_can,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hiM" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -38514,6 +39051,7 @@
 "hrk" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/scientist,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "hro" = (
@@ -38603,6 +39141,16 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"hsb" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/roach_egg_remains,
+/obj/random/card_carp/flying,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hsc" = (
 /obj/random/structures,
 /turf/simulated/floor/industrial/ceramic,
@@ -38662,11 +39210,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
 "hsz" = (
-/obj/machinery/repair_station,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/machinery/vending/assist,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "hsA" = (
@@ -38679,6 +39227,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hsE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/colony)
 "hsW" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -39201,15 +39753,12 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/workshop)
 "hxR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/rnd/rbreakroom)
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/salvageable/computer,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hxU" = (
 /obj/machinery/mineral/stacking_unit_console{
 	pixel_x = -28
@@ -39486,6 +40035,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"hAd" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/largecrate,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hAj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -39563,6 +40117,11 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"hAG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "hAT" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -39825,6 +40384,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hDf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/custom/onestar,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hDj" = (
 /obj/machinery/bioprinter,
 /turf/simulated/floor/tiled/white,
@@ -39860,6 +40426,15 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"hDq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/oddity/common/old_newspaper,
+/obj/structure/table/onestar,
+/obj/item/clothing/mask/smokable/cigarette/os/nova,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hDr" = (
 /obj/structure/low_wall,
 /obj/item/material/shard,
@@ -39944,20 +40519,14 @@
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/crew_quarters/arcade)
 "hDX" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/random/material_resources/low_chance,
-/obj/random/material_rare/low_chance,
-/obj/random/material_rare,
-/obj/random/material,
-/obj/random/material,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass{
-	amount = 120
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/structure/table/rack/shelf,
+/obj/item/storage/belt,
+/obj/item/storage/belt,
+/obj/item/storage/belt,
+/obj/item/storage/belt,
+/obj/item/stack/cable_coil/random,
+/obj/item/tool/wrench,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/research)
 "hEc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40075,6 +40644,15 @@
 	icon_state = "7,10"
 	},
 /area/nadezhda/hallway/main/stairwell)
+"hFk" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hFn" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "9,6"
@@ -40155,8 +40733,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
 "hGu" = (
-/obj/item/storage/deferred/crate,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/cardboardbulk,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "hGB" = (
@@ -40801,11 +41379,8 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "hKX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/research)
 "hKZ" = (
 /obj/random/dungeon_gun_ballistic/low_chance,
@@ -41117,11 +41692,16 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/bar)
 "hNV" = (
-/obj/machinery/chemical_dispenser/industrial{
-	fancy_hack = 1
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/item/pen{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "hOa" = (
 /obj/structure/table/woodentable,
@@ -41136,12 +41716,10 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/swo/quarters)
 "hOh" = (
-/obj/landmark/join/start/cyborg,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/rnd/robotics)
+/obj/structure/flora/pottedplant/dead,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hOi" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
@@ -41480,6 +42058,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/surfaceeast)
+"hTf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hTh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -41577,7 +42160,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
 "hTN" = (
@@ -41650,6 +42232,14 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/armoryshop)
+"hUE" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/trash/material/device,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hUI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -41688,6 +42278,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
+"hUN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candle,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hUO" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
@@ -41794,12 +42391,7 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "hVu" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/landmark/join/start/scientist,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
 "hVz" = (
@@ -42165,6 +42757,12 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hYz" = (
+/obj/machinery/repair_station,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/landmark/join/start/cyborg,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/robotics)
 "hYF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
@@ -42318,6 +42916,14 @@
 "hZv" = (
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai_upload)
+"hZy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/hcases/parts/scrap/has_items_spawn,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "hZz" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
@@ -42549,6 +43155,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"ibu" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/roach/roachling,
+/obj/item/trash/candy,
+/obj/item/trash/os_wrapper,
+/obj/item/trash/spacetwinkie,
+/obj/item/trash/plate,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ibw" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -42973,11 +43594,21 @@
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfacenorth)
 "ifA" = (
-/obj/item/storage/deferred/crate/uniform_brown,
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"ifK" = (
+/obj/structure/boulder,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ifN" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -43204,6 +43835,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"ihR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ihV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -43295,6 +43931,11 @@
 /obj/item/reagent_containers/cwj/container/pot,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"ijq" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/colony)
 "ijr" = (
 /obj/random/scrap/moderate_weighted,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -44036,6 +44677,11 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
+"ipO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "ipU" = (
 /obj/structure/flora/small/lavarock2,
 /obj/effect/decal/cleanable/dirt,
@@ -44052,6 +44698,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"ipY" = (
+/obj/machinery/mech_recharger,
+/obj/item/toy/figure/mecha/ripley,
+/obj/item/toy/figure/mecha/ripley,
+/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "iqg" = (
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
@@ -45650,6 +46306,11 @@
 /obj/random/gun_cheap/low_chance,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"iGI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/obj/structure/reagent_dispensers/fueltank/huge,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/research)
 "iGJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cabinet,
@@ -46229,6 +46890,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4)
+"iMp" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/snacks/openable/chips_alt,
+/obj/item/reagent_containers/snacks/openable/chips_alt,
+/obj/item/reagent_containers/snacks/openable/chips_alt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iMu" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted,
@@ -46375,8 +47044,10 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "iNU" = (
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/machinery/chemical_dispenser/industrial{
+	fancy_hack = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/research)
 "iNY" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -46471,6 +47142,15 @@
 	},
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"iOR" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iOV" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46755,12 +47435,11 @@
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "iRT" = (
-/obj/structure/spider_nest,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/maintenance{
-	name = "Residential District Maintenance"
-	})
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/obj/item/stack/material/wood/random,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iRW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -47357,7 +48036,9 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "iZi" = (
@@ -47589,7 +48270,10 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/camera/network/research{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/rbreakroom)
 "jbr" = (
 /obj/machinery/door/firedoor/multi_tile,
@@ -47954,6 +48638,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4)
+"jeF" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jeJ" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 8
@@ -48148,6 +48839,14 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"jgQ" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/salvageable/personal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jgS" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /turf/simulated/floor/plating/under,
@@ -48482,6 +49181,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "jjy" = (
@@ -48543,6 +49243,17 @@
 /obj/structure/closet/secure_closet/rare_loot,
 /turf/simulated/floor/industrial/cafe_large,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jkm" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jkn" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -48581,6 +49292,16 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
+"jku" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jkx" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/dirt,
@@ -48618,6 +49339,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"jkK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "jkN" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/industrial/green_large_slates,
@@ -48825,8 +49551,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jmR" = (
-/obj/machinery/autolathe/loaded,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/machinery/reagentgrinder/industrial,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#0892d0"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/research)
 "jmU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -48943,6 +49673,12 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
+"jnK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/folder/yellow,
+/obj/item/paper,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jnO" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -49193,6 +49929,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/hallways)
+"jqf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/salvageable/server,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jqw" = (
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/rock,
@@ -49463,6 +50204,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"jsI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jsO" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/random/traps/low_chance{
@@ -49734,11 +50480,6 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "juR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/belt,
-/obj/item/storage/belt,
-/obj/item/storage/belt,
-/obj/item/storage/belt,
 /obj/machinery/holoposter{
 	pixel_x = -32
 	},
@@ -49746,7 +50487,8 @@
 	dir = 4;
 	pixel_x = -8
 	},
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/structure/closet/crate/plastic,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/research)
 "juZ" = (
 /obj/structure/cable/green{
@@ -49990,6 +50732,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"jxk" = (
+/obj/structure/scrap/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jxq" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -50373,6 +51121,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"jCs" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/robotics)
 "jCw" = (
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
@@ -50696,6 +51451,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"jFB" = (
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jFC" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Surface";
@@ -50885,18 +51646,23 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/security/barracks)
 "jHF" = (
-/obj/machinery/holoposter{
-	pixel_y = 30
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/bed/chair/comfy/purp,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "jHH" = (
 /obj/structure/multiz/stairs/active/bottom{
@@ -50939,6 +51705,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/prep)
+"jIa" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jIe" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/item/genetics/purger,
@@ -50979,6 +51754,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
+"jIo" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/mob/termite_no_despawn,
+/obj/item/stack/rods/random,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jIq" = (
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
@@ -51993,6 +52777,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/flame/candle,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -52285,12 +53070,13 @@
 	},
 /area/nadezhda/absolutism/vectorrooms)
 "jVT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/research)
+/obj/machinery/door/firedoor,
+/obj/random/traps,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "jVU" = (
 /obj/structure/filingcabinet/employment,
 /turf/simulated/floor/wood/wild1,
@@ -52387,6 +53173,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jWX" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/spider,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jWZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
@@ -53010,6 +53801,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/command/tcommsat/computer)
+"kdz" = (
+/obj/structure/table/woodentable,
+/obj/random/lathe_disk/tools/low_chance,
+/obj/item/storage/box/lights/mixed,
+/obj/machinery/light/small,
+/obj/random/tool_upgrade/low_chance,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "kdC" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -53369,6 +54170,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"kgR" = (
+/obj/item/trash/chips_green,
+/obj/item/trash/chips_green,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kgS" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -54185,6 +54992,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"koS" = (
+/obj/structure/table/woodentable,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/item/trash/material/device,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "koW" = (
 /obj/structure/closet/wall_mounted{
 	pixel_x = -32
@@ -54200,6 +55016,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"kpc" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/glass/bottle/iron,
+/obj/item/reagent_containers/glass/bottle/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kpg" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -54627,6 +55450,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"kte" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider_nest,
+/turf/simulated/floor/carpet,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ktk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -55659,11 +56489,20 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/range)
 "kCD" = (
-/obj/machinery/vending/assist,
-/obj/machinery/firealarm{
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	dir = 4;
+	pixel_x = -8
+	},
+/obj/machinery/holoposter{
 	pixel_x = -32
 	},
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/tool/weldingtool,
+/obj/item/storage/toolbox/electrical,
+/obj/item/tool/saw,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
 "kCK" = (
@@ -55921,6 +56760,14 @@
 /obj/machinery/ntnet_relay,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/atmos/surface)
+"kEt" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/power/port_gen/pacman/diesel,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "kEu" = (
 /obj/structure/scrap/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -56483,6 +57330,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"kMC" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/spider/hunter,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kMD" = (
 /obj/machinery/camera/network/research{
 	dir = 4
@@ -57697,6 +58549,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"kYG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/termite_colony/plasma,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kYI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -58211,6 +59068,7 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "leS" = (
+/obj/machinery/recharge_station/robotics,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "leW" = (
@@ -58284,6 +59142,13 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"lfz" = (
+/obj/structure/table/rack/shelf,
+/obj/structure/scrap/food,
+/obj/item/reagent_containers/glass/bottle/sugar,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lfE" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
@@ -58449,6 +59314,15 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"lgQ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lgV" = (
 /obj/machinery/camera/network/colony_underground,
 /obj/structure/closet/wall_mounted/emcloset{
@@ -58797,6 +59671,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"llA" = (
+/obj/structure/boulder,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "llB" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -58899,8 +59782,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/rnd/rbreakroom)
 "lnk" = (
 /obj/structure/toilet{
@@ -59432,6 +60314,16 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
+"lsO" = (
+/obj/machinery/mech_recharger,
+/obj/item/toy/figure/mecha/fireripley,
+/obj/item/mecha_parts/mecha_equipment/tool/extinguisher,
+/obj/structure/foamedmetal,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "lsR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -59576,6 +60468,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"luo" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/glass/plastic_jug,
+/obj/item/reagent_containers/glass/plastic_jug,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "luq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -59777,6 +60677,12 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"lwc" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/termite_colony/plasma,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lwk" = (
 /obj/structure/railing{
 	dir = 8
@@ -59807,6 +60713,9 @@
 /area/nadezhda/rnd/lab)
 "lww" = (
 /obj/structure/closet,
+/obj/item/towel/random,
+/obj/random/cloth/armor/low_chance,
+/obj/random/cloth/gloves/low_chance,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "lwy" = (
@@ -60103,6 +61012,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"lzP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/random,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "lzW" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -60242,6 +61158,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"lBL" = (
+/obj/structure/reagent_dispensers/beerkeg{
+	name = "salt barrel";
+	starting_reagent = "sodiumchloride"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "lBP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -60723,7 +61647,6 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "lGe" = (
 /obj/effect/floor_decal/industrial/loading/red,
-/obj/landmark/join/start/roboticist,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -60925,24 +61848,11 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "lIc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southright{
-	name = "Research desk";
+/obj/machinery/door/airlock/glass_research{
+	name = "Research and Development";
 	req_access = list(5)
 	},
-/obj/machinery/door/window/northleft{
-	name = "shower door"
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "research_shutters";
-	name = "R&D Privacy Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/gray_platform,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/research)
 "lIg" = (
 /obj/structure/catwalk,
@@ -61109,6 +62019,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/roboticist,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
 "lJs" = (
@@ -61252,6 +62163,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"lKU" = (
+/obj/item/stack/material/wood/random,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lKW" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -61311,6 +62226,14 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"lMb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/hcases/engi/has_items_spawn,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "lMd" = (
 /obj/random/closet/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -61451,6 +62374,14 @@
 /obj/effect/floor_decal/industrial/inputgate,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
+"lNE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/random/cigarettes/singles,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lNN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack/shelf,
@@ -62793,6 +63724,13 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/command/smc/quarters)
+"mar" = (
+/obj/item/trash/material/metal,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "mat" = (
 /obj/structure/barricade,
 /obj/structure/grille,
@@ -62873,6 +63811,11 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
+"mbk" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/scrap/food,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mbm" = (
 /obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
@@ -62955,8 +63898,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacesec)
 "mch" = (
-/obj/structure/sign/department/drones,
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
 "mcj" = (
 /obj/structure/grille,
@@ -63094,6 +64037,13 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"mdt" = (
+/obj/structure/salvageable/machine,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "mdx" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -63442,6 +64392,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"mfI" = (
+/obj/structure/reagent_dispensers/beerkeg{
+	starting_reagent = "sugar";
+	name = "sugar barrel"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "mfK" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -64340,6 +65299,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "mof" = (
@@ -64421,6 +65383,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"mpx" = (
+/obj/structure/table/reinforced,
+/obj/random/material,
+/obj/random/material,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "mpy" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 8
@@ -64433,12 +65401,9 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/command/tcommsat/computer)
 "mpA" = (
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/rbreakroom)
 "mpH" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -64608,9 +65573,6 @@
 	},
 /area/nadezhda/rnd/server)
 "mqX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -64940,6 +65902,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"mut" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/snacks/openable/gamerchips,
+/obj/item/reagent_containers/snacks/openable/gamerchips,
+/obj/item/reagent_containers/snacks/openable/gamerchips,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "muu" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -66022,6 +66993,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/sechall)
+"mES" = (
+/obj/structure/table/bench/standard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/oddity/common/towel,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mET" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66422,9 +67399,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
 "mIe" = (
-/obj/machinery/camera/network/research,
+/obj/machinery/door/airlock/glass{
+	name = "R&D"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/research)
 "mIf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -68501,7 +69486,6 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
 "nct" = (
-/obj/landmark/join/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -68720,7 +69704,10 @@
 	})
 "neL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
 "nfc" = (
 /obj/machinery/firealarm{
@@ -70020,6 +71007,12 @@
 /obj/structure/invislight,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"nrI" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "nrO" = (
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -70328,15 +71321,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
 "ntV" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/cryopod/robot{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/landmark/join/late/cyborg,
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "ntX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -70352,7 +71341,7 @@
 /area/nadezhda/pros/shuttle)
 "nug" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/rnd/rbreakroom)
 "nuh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -70380,6 +71369,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nus" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/random/cigarettes,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nut" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -70743,6 +71743,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"nxt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nxx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -70811,6 +71816,12 @@
 /obj/random/cloth/under,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2north)
+"nyb" = (
+/obj/structure/table/rack/shelf,
+/obj/item/tool_upgrade/augment/cell_mount,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "nye" = (
 /obj/effect/floor_decal/industrial/danger/corner{
@@ -71231,6 +72242,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"nCa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/material/plastic/random,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nCe" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/tiled/cafe,
@@ -71735,6 +72751,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
+"nGg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nGh" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -71918,7 +72939,8 @@
 "nIi" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/industrial/bricks,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/blue_slates_long,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
@@ -72118,10 +73140,6 @@
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "nKg" = (
-/obj/machinery/newscaster{
-	dir = 4;
-	pixel_x = 30
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -72157,6 +73175,15 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfacenorth)
+"nKs" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/box/lights/tubes,
+/obj/item/device/lightreplacer,
+/obj/item/trash/material/e_sword_cutlass,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "nKz" = (
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "cobweb1";
@@ -72196,6 +73223,16 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/rock,
 /area/colony)
+"nKN" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cloth/suit/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "nKS" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/belt/webbing,
@@ -72659,17 +73696,17 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "nPH" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/computer/cryopod/robot{
+	pixel_x = -24
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/white/gray_platform,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "nPL" = (
 /obj/structure/flora/small/rock3,
@@ -72727,6 +73764,11 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
+"nQn" = (
+/obj/random/scrap/sparse_weighted,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/colony)
 "nQz" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -72770,11 +73812,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nQR" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/industrial/ornate,
-/area/nadezhda/maintenance{
-	name = "Residential District Maintenance"
-	})
+/obj/structure/table/rack/shelf,
+/obj/item/bottle_kit,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "nQU" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -73190,6 +74231,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"nVl" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lathe_disk/tools,
+/obj/item/storage/toolbox/emergency,
+/obj/item/wrapping_paper,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "nVo" = (
 /obj/structure/table/steel,
 /obj/structure/flora/pottedplant/dead{
@@ -73215,6 +74265,13 @@
 /obj/landmark/join/late/cryo/elevator,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"nVV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/hcases/engi/has_items_spawn,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "nVX" = (
 /obj/machinery/computer/shuttle_control/multi/rocinante{
 	dir = 4
@@ -73332,13 +74389,11 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "nWB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "nWD" = (
@@ -73822,11 +74877,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/hunter_cabin)
 "oaG" = (
-/obj/machinery/drone_fabricator/ai{
-	desc = "A large automated factory for producing maintenance cyborgs that AIs can use it and control it.";
-	name = "cyborg fabricator"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "oaI" = (
 /obj/structure/window/reinforced{
@@ -74315,6 +75368,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
+"ofg" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "ofj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74606,8 +75664,8 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "oio" = (
-/obj/machinery/autolathe/rnd/protolathe/loaded,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/research)
 "oiq" = (
 /obj/machinery/door/airlock/maintenance_rnd{
@@ -74828,8 +75886,6 @@
 /turf/simulated/floor/industrial/sierra,
 /area/nadezhda/command/hallway)
 "ojJ" = (
-/obj/random/furniture/pottedplant,
-/obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/pool)
 "ojM" = (
@@ -76214,6 +77270,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
+"owY" = (
+/obj/structure/closet,
+/obj/item/towel/random,
+/obj/random/cloth/shoes/low_chance,
+/obj/random/cloth/gloves/low_chance,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "owZ" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/beach/water/jungle,
@@ -76414,6 +77477,12 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"oyX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oyY" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/simulated/floor/bluegrid{
@@ -76423,6 +77492,14 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
+"ozd" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ozk" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -76597,8 +77674,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "oAG" = (
 /obj/structure/flora/small/busha3,
@@ -77256,6 +78332,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/workshop)
+"oGU" = (
+/obj/structure/scrap/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oGY" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/closet_maintloot,
@@ -77917,6 +78998,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cro)
+"oNq" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/snacks/openable/chips,
+/obj/item/reagent_containers/snacks/openable/chips,
+/obj/item/reagent_containers/snacks/openable/chips,
+/obj/item/reagent_containers/snacks/openable/chips,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oNs" = (
 /obj/structure/bed/chair/sofa/teal/right{
 	dir = 8
@@ -78275,6 +79366,13 @@
 "oQL" = (
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/server)
+"oQN" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "oQQ" = (
 /obj/machinery/computer/prisoner{
 	dir = 4
@@ -78704,15 +79802,13 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "oVi" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_platform,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "oVk" = (
 /obj/machinery/cryopod,
@@ -78878,7 +79974,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "oWU" = (
-/obj/landmark/join/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -79148,8 +80243,7 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
 "oZD" = (
-/obj/item/storage/deferred/crate/uniform_light,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "oZF" = (
@@ -79735,6 +80829,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/security/maingate)
+"pfN" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pfU" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -80303,6 +81402,13 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
+"plc" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "plh" = (
 /obj/machinery/light{
 	dir = 8
@@ -80414,6 +81520,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"pmS" = (
+/obj/structure/table/standard,
+/obj/item/soap,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "pmT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -80790,9 +81903,13 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "pqe" = (
-/obj/item/storage/deferred/crate/tools,
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/glass/bottle/copper,
+/obj/item/reagent_containers/glass/bottle/copper,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/concrete_bricks,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "pqm" = (
 /obj/structure/railing{
@@ -81104,6 +82221,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"ptw" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/stack/rods/random,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ptD" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -81409,12 +82531,6 @@
 	pixel_x = -1;
 	pixel_y = 3
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/computer/cryopod/robot{
-	pixel_x = -24
-	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "pvU" = (
@@ -81490,6 +82606,19 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pwH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "pwQ" = (
 /obj/structure/railing{
 	dir = 4
@@ -81578,7 +82707,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/command/panic_room)
 "pxF" = (
-/obj/machinery/recharge_station/robotics,
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	dir = 1;
@@ -82397,6 +83525,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"pGj" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/scientist,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "pGp" = (
 /obj/structure/closet/secure_closet/reinforced/CMO,
 /obj/item/pc_part/drive/disk/design/medical/cmo,
@@ -82633,6 +83769,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"pIZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/robotics)
 "pJd" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -83002,6 +84146,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pMu" = (
+/obj/machinery/autolathe/loaded,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/rnd/research)
 "pMv" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -83175,11 +84323,8 @@
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/command/panic_room)
 "pNU" = (
-/obj/structure/catwalk,
-/obj/machinery/power/hydrogen_gen{
-	anchored = 1
-	},
-/turf/simulated/floor/plating/under,
+/obj/structure/sign/department/drones,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "pNZ" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
@@ -83546,10 +84691,9 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm4)
 "pQG" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
+/obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/scientist,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
 "pQH" = (
@@ -83617,6 +84761,10 @@
 /obj/structure/bonfire/permanent,
 /turf/simulated/floor/rock,
 /area/nadezhda/crew_quarters/dorm4)
+"pRh" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/research)
 "pRj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates_long,
@@ -83639,6 +84787,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/item/device/lighting/glowstick/random,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -83745,6 +84894,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
+"pRW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "pRX" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/unsimulated/wall/jungle,
@@ -83968,6 +85124,10 @@
 /obj/random/rig_module/rare/low_chance,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"pUH" = (
+/obj/structure/sign/warning/fire/small,
+/turf/simulated/wall,
+/area/colony)
 "pUJ" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/machinery/alarm{
@@ -84239,6 +85399,9 @@
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
 	},
+/obj/machinery/camera/network/research{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/research)
 "pWj" = (
@@ -84388,6 +85551,11 @@
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/engineering/engine_room)
+"pYf" = (
+/obj/structure/table/bench/steel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "pYi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -84577,9 +85745,13 @@
 	name = "Residential District Maintenance"
 	})
 "pZU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/rnd/rbreakroom)
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "qaf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -84668,6 +85840,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/skyyard)
+"qaU" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qaV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -84748,6 +85928,17 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"qbC" = (
+/obj/machinery/autolathe/rnd/protolathe/loaded,
+/obj/item/stack/material/glass{
+	amount = 120
+	},
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/rnd/research)
 "qbG" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -85004,6 +86195,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
+"qee" = (
+/obj/structure/table/rack/shelf,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/candy/proteinbar,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/material/plastic/random,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qen" = (
 /obj/effect/floor_decal/industrial/road/warning4,
 /obj/effect/decal/cleanable/dirt,
@@ -85305,6 +86505,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"qhl" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "qho" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/machinery/vending/blackshield_kit,
@@ -85556,11 +86763,10 @@
 	pixel_x = 4;
 	pixel_y = 10
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/rnd/rbreakroom)
 "qjV" = (
 /obj/structure/closet/crate/radiation,
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -85712,6 +86918,13 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"qlk" = (
+/obj/item/storage/bag/trash,
+/obj/structure/table/standard,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "qln" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -85785,6 +86998,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"qlN" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "qlT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -87062,7 +88280,7 @@
 	})
 "qxX" = (
 /obj/machinery/vending/fitness,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/rbreakroom)
 "qyc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -87193,6 +88411,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qzn" = (
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "qzp" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/spray/sterilizine,
@@ -87697,9 +88921,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "qEw" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/boulder,
-/turf/simulated/floor/industrial/bricks,
+/obj/random/scrap/sparse_weighted,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/blue_slates_long,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
@@ -87766,6 +88990,13 @@
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qFj" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/trash/chips_green,
+/obj/item/trash/chips_green,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qFl" = (
 /obj/machinery/disposal,
 /obj/machinery/light/small{
@@ -88126,6 +89357,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qHW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/obj/structure/salvageable/data,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qHX" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -88428,6 +89665,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/checker_large,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qLu" = (
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "qLz" = (
 /obj/machinery/photocopier,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -88448,6 +89691,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qLI" = (
+/obj/machinery/camera/network/research{
+	dir = 8
+	},
+/obj/structure/plushie/drone{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/robotics)
 "qLJ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -89187,6 +90439,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"qTG" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qTN" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/donkpockets,
@@ -89950,6 +91211,12 @@
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/hallway)
+"rco" = (
+/obj/item/contraband/poster/placed/eris/electricwarning,
+/turf/simulated/wall,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "rcy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/machinery/camera/network/colony_surface,
@@ -90510,6 +91777,14 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"rhn" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "rhv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -90678,6 +91953,13 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/crew_quarters/toilet/public)
+"riM" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/rubble,
+/obj/item/stack/material/wood/random,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rjf" = (
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
@@ -90981,6 +92263,13 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"rlV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/material/wood/random,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "rmg" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -91240,6 +92529,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfaceeast)
+"rop" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/material/plastic/random,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "roq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91381,8 +92676,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
 "rpN" = (
-/turf/simulated/wall,
-/area/nadezhda/rnd/research)
+/obj/structure/table/rack/shelf,
+/obj/random/junkfood,
+/obj/random/junkfood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rpP" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush2,
@@ -91932,6 +93231,11 @@
 "rwk" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"rwn" = (
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "rwy" = (
 /obj/machinery/camera/network/church{
 	dir = 1
@@ -93236,6 +94540,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"rJW" = (
+/obj/random/scrap/sparse_weighted,
+/obj/item/storage/hcases/ammo/excel/has_items_spawn,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "rKb" = (
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "BrigFoyer";
@@ -93863,6 +95174,19 @@
 /obj/effect/floor_decal/industrial/road/straight4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"rPr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/computerframe{
+	anchored = 1;
+	dir = 1;
+	tag = "icon-0 (NORTH)"
+	},
+/obj/item/stack/material/glass/five,
+/obj/item/circuitboard/broken,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "rPB" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/newscaster/directional/north,
@@ -93901,6 +95225,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"rPR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 15
+	},
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "rQb" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/machinery/door/window/westright,
@@ -94157,6 +95492,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"rSr" = (
+/obj/item/storage/deferred/crate/uniform_light,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rSw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_common,
@@ -94540,6 +95881,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/engineering/shield_generator)
+"rWt" = (
+/obj/structure/fermentation_keg,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "rWI" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -94604,12 +95950,9 @@
 /area/nadezhda/security/nuke_storage)
 "rXi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/boulder,
+/obj/item/remains/mouse,
 /turf/simulated/floor/industrial/bricks,
-/area/nadezhda/maintenance{
-	name = "Residential District Maintenance"
-	})
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rXm" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -94732,6 +96075,11 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"rYa" = (
+/obj/structure/largecrate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rYd" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -94910,8 +96258,11 @@
 	},
 /area/shuttle/surface_transport_lz)
 "rZs" = (
-/obj/machinery/reagentgrinder/industrial,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/item/modular_computer/console/preset/pointminer{
+	dir = 8
+	},
+/obj/item/pc_part/drive/disk/basic,
+/turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "rZw" = (
 /obj/structure/disposalpipe/segment{
@@ -95323,6 +96674,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"scv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "scH" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/plastic/random,
@@ -96180,6 +97538,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"slN" = (
+/obj/structure/salvageable/autolathe,
+/obj/random/lathe_disk/tools/low_chance,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "slP" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -96622,8 +97992,8 @@
 /turf/simulated/mineral,
 /area/nadezhda/outside/inside_colony)
 "spO" = (
-/obj/structure/reagent_dispensers/fueltank/huge,
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/machinery/constructable_frame/machine_frame,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/research)
 "spR" = (
 /obj/structure/bed/chair,
@@ -97025,6 +98395,26 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"std" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southright{
+	name = "Research desk";
+	req_access = list(5)
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "research_shutters";
+	name = "R&D Privacy Shutters";
+	opacity = 0;
+	layer = 3.2;
+	open_layer = 3.2
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/northleft,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/research)
 "stI" = (
 /obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
@@ -97467,6 +98857,10 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
+"sxk" = (
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sxn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -97497,6 +98891,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/toilet/public)
+"sxz" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/belt/medical,
+/obj/item/stack/medical/splint,
+/obj/item/stack/medical/bruise_pack,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sxB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -98487,6 +99889,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"sHE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sHF" = (
 /obj/structure/flora/ausbushes/reedbush{
 	layer = 4.2;
@@ -98668,6 +100076,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"sJB" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/rubble,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sJD" = (
 /obj/machinery/disposal,
 /obj/effect/spider/stickyweb,
@@ -98723,6 +100138,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
+"sKf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/random/card_carp/flying,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "sKl" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
@@ -99201,6 +100622,22 @@
 	dir = 4
 	},
 /area/nadezhda/maintenance/surfacesec)
+"sPk" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/random/cloth/belt/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "sPy" = (
 /obj/machinery/light{
 	dir = 8
@@ -99496,6 +100933,14 @@
 	},
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"sSt" = (
+/obj/structure/table/woodentable,
+/obj/random/tool,
+/obj/random/tool_upgrade/low_chance,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "sSu" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -100187,6 +101632,18 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"sZH" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "sZK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -100260,6 +101717,7 @@
 	dir = 8
 	},
 /obj/structure/table/woodentable,
+/obj/item/flame/candle,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -100430,6 +101888,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "tbR" = (
@@ -100463,7 +101922,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "tcm" = (
 /obj/item/spider_shadow_trap,
@@ -100700,6 +102159,10 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"teT" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "teU" = (
 /obj/structure/closet/l3closet/janitor,
 /turf/simulated/floor/tiled/techmaint,
@@ -100834,11 +102297,8 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
 "tgU" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+/obj/structure/table/glass,
+/turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
 "tgW" = (
 /obj/structure/table/steel_reinforced,
@@ -101652,6 +103112,22 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"tph" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/random/cloth/masks/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "tpl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -102262,6 +103738,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tvC" = (
+/obj/structure/reagent_dispensers/beerkeg{
+	starting_reagent = "carbon";
+	name = "carbon barrel"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "tvD" = (
 /obj/structure/table/woodentable,
 /obj/structure/sign/painting/paintingtemple{
@@ -102424,6 +103908,16 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"twZ" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cloth/head/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "txa" = (
 /obj/item/mecha_parts/part/ivan_left_arm,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -103041,6 +104535,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"tCB" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/termite_colony/diamond,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tCF" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/industrial/warningred{
@@ -103138,6 +104637,15 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"tDC" = (
+/obj/structure/table/rack/shelf,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/item/reagent_containers/glass/bottle/carbon,
+/obj/item/reagent_containers/glass/bottle/lithium,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tDE" = (
 /obj/structure/catwalk,
 /obj/random/junk/low_chance,
@@ -103312,6 +104820,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
+"tFb" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/salvageable/computer,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "tFf" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -103657,6 +105173,17 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"tIw" = (
+/obj/structure/reagent_dispensers/beerkeg{
+	starting_reagent = "ethanol";
+	name = "ethanol barrel"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "tIz" = (
 /obj/machinery/camera/network/engineering{
 	dir = 4
@@ -103792,6 +105319,22 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/hallway/side/f2section1)
+"tJe" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "tJh" = (
 /obj/structure/table/marble,
 /obj/effect/decal/cleanable/dirt,
@@ -105116,6 +106659,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tVG" = (
+/obj/random/mob/termite_no_despawn,
+/obj/item/stack/rods/random,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "tVO" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/flora/big/bush3{
@@ -105209,6 +106760,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/ceramic,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"tWH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tWK" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush3{
@@ -105253,7 +106809,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "tWW" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -106148,10 +107705,7 @@
 /area/nadezhda/outside/forest)
 "ufq" = (
 /obj/machinery/photocopier,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/rbreakroom)
 "ufr" = (
 /obj/machinery/camera/network/colony_surface{
@@ -106602,6 +108156,13 @@
 "ujg" = (
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/turret_protected/ai)
+"ujn" = (
+/obj/random/closet_maintloot,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ujo" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "14,10"
@@ -106838,8 +108399,11 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/engineering/foyer)
 "ulb" = (
-/obj/machinery/autolathe/rnd/imprinter/loaded,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/computer/rdconsole/core{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/research)
 "ulj" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -106974,6 +108538,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "umn" = (
@@ -107257,11 +108824,12 @@
 /obj/machinery/cryopod/robot{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -32
+	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/landmark/join/late/cyborg,
-/obj/item/device/radio/intercom{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
 "uoU" = (
@@ -107291,6 +108859,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"ups" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "upz" = (
 /obj/structure/flora/small/bushb3,
 /obj/structure/flora/small/bushb3,
@@ -107573,6 +109154,34 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/dorm4)
+"usS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/contraband/poster/placed/advertisement/smoke{
+	pixel_x = 32
+	},
+/obj/structure/sign/warning/smoking/small{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
+"usT" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/hcases/cardcarp,
+/obj/random/card_carp,
+/obj/random/card_carp,
+/obj/random/card_carp,
+/obj/item/cardholder,
+/obj/item/cardholder/squirl,
+/obj/structure/table/onestar,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "usV" = (
 /obj/structure/catwalk,
 /obj/machinery/light{
@@ -107610,6 +109219,15 @@
 "utf" = (
 /turf/simulated/open,
 /area/nadezhda/maintenance/surfacesec)
+"uth" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior/roach/roachling,
+/obj/item/trash/cheesie,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "utn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 5
@@ -108041,12 +109659,13 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "uyL" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/rnd/xenobiology/xenoflora)
+/obj/structure/salvageable/personal,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "uyM" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -109106,6 +110725,17 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"uJj" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/drone_fabricator/ai{
+	desc = "A large automated factory for producing maintenance cyborgs that AIs can use it and control it.";
+	name = "cyborg fabricator"
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/robotics)
 "uJn" = (
 /obj/machinery/door/unpowered/simple/wood{
 	color = "#9a977b"
@@ -109533,7 +111163,7 @@
 "uMy" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "uMF" = (
 /turf/simulated/wall/iron,
@@ -110472,6 +112102,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"uUn" = (
+/obj/structure/sink{
+	pixel_y = 25
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/robotics)
 "uUq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -110860,11 +112497,9 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
 "uXZ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/rnd/rbreakroom)
 "uYb" = (
 /obj/machinery/hologram/holopad,
@@ -111300,10 +112935,22 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/vending/robotics,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -32
+	},
+/obj/structure/table/rack,
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/obj/item/stack/material/plasteel{
+	amount = 20
+	},
+/obj/item/stack/material/glass{
+	amount = 120
+	},
+/obj/item/stack/material/steel{
+	amount = 120
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
@@ -111477,6 +113124,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"vey" = (
+/obj/structure/table/reinforced,
+/obj/random/material_resources/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "veB" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/secrecroom)
@@ -112130,7 +113782,6 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/shuttle/rocinante_shuttle_area)
 "vkf" = (
-/obj/landmark/join/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -113279,6 +114930,14 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
+"vuV" = (
+/obj/machinery/repair_station,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/landmark/join/start/cyborg,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/robotics)
 "vuY" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -113402,6 +115061,12 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"vvU" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/deferred/crate/tools,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vvV" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -113449,7 +115114,8 @@
 "vwn" = (
 /obj/item/toy/plushie/corgi/robo,
 /obj/structure/table/glass,
-/turf/simulated/floor/carpet/purcarpet,
+/obj/item/device/camera,
+/turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
 "vwo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -113872,6 +115538,13 @@
 "vBh" = (
 /turf/simulated/floor/industrial/ceramic,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"vBj" = (
+/obj/machinery/door/airlock/glass_research{
+	name = "Robotics Lab";
+	req_access = list(29)
+	},
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/rnd/robotics)
 "vBk" = (
 /obj/random/junk/nondense,
 /obj/effect/decal/cleanable/dirt,
@@ -114014,12 +115687,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/smartfridge/disk,
-/turf/simulated/floor/tiled/dark/danger,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/research)
 "vCx" = (
 /obj/structure/table/woodentable,
@@ -114392,13 +116060,11 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "vGd" = (
-/obj/machinery/repair_station,
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/rnd/robotics)
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vGf" = (
 /obj/machinery/door/airlock/maintenance_rnd{
 	req_access = list(5)
@@ -115902,6 +117568,12 @@
 /obj/random/tool_upgrade,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"vUj" = (
+/obj/item/contraband/poster/placed/advertisement/cc64k_ad,
+/turf/simulated/wall,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "vUm" = (
 /obj/item/pen,
 /obj/item/paper_bin,
@@ -116065,6 +117737,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/fo)
+"vVd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/assembly/mousetrap,
+/obj/item/toy/plushie/mouse,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vVe" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -116216,9 +117894,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/item/book/manual/robotics_catalogue{
-	pixel_y = 12
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
@@ -116896,6 +118571,12 @@
 /obj/item/aiModule/reset,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"wcy" = (
+/obj/structure/salvageable/server,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "wcA" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "14,2"
@@ -117274,12 +118955,12 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
 "wfZ" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/rnd/xenobiology/xenoflora)
+/obj/item/storage/deferred/crate/uniform_brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wgu" = (
 /obj/structure/table/woodentable,
 /obj/item/stamp/hos2,
@@ -117356,8 +119037,10 @@
 /turf/simulated/mineral,
 /area/nadezhda/pros/foreman)
 "whB" = (
-/obj/structure/closet/crate/secure/large,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair{
+	dir = 4
+	},
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "whC" = (
@@ -118280,9 +119963,6 @@
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm3)
 "wpJ" = (
-/obj/item/modular_computer/console/preset/pointminer{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -118290,7 +119970,10 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/research)
 "wpL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -118300,6 +119983,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	pixel_y = -7
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "wpM" = (
@@ -118328,6 +120017,10 @@
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"wqh" = (
+/obj/structure/boulder,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wqj" = (
 /obj/structure/multiz/stairs/active/bottom,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -118902,6 +120595,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/detectives_office)
+"wuX" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "wuZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -118912,6 +120612,10 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
+"wva" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wve" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -120551,6 +122255,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/ceramic,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"wMh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "wMi" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -121069,6 +122779,11 @@
 /obj/structure/sign/department/prison,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/sechall)
+"wQH" = (
+/obj/machinery/washing_machine,
+/obj/item/oddity/common/coin,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wQJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -121313,6 +123028,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "wTh" = (
@@ -121986,6 +123702,9 @@
 	req_access = list(29)
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xax" = (
@@ -122026,7 +123745,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
 "xaS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -122122,6 +123841,12 @@
 /obj/item/reagent_containers/glass/beaker/vial/nanites,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/scave)
+"xbI" = (
+/obj/structure/curtain/open/shower,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xbJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -123004,17 +124729,14 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "xkR" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/reagent_dispensers/beerkeg{
+	name = "floor barrel";
+	starting_reagent = "flour"
 	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/rnd/research)
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "xkT" = (
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
@@ -123236,6 +124958,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"xnC" = (
+/obj/structure/table/rack/shelf,
+/obj/item/tool/weldingtool,
+/obj/item/clothing/glasses/welding,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/rnd/research)
 "xnE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -123323,6 +125051,11 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"xoD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/hcases/engi/has_items_spawn,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xoI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/light{
@@ -123379,6 +125112,15 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
+"xpd" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/obj/random/structures/low_chance,
+/obj/item/grenade/chem_grenade/metalfoam,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xpf" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -123437,6 +125179,15 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "xpJ" = (
@@ -123700,12 +125451,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xsv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/rnd/rbreakroom)
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xsx" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -123815,16 +125565,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "xtF" = (
-/obj/machinery/vending/engivend,
-/obj/machinery/holoposter{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	dir = 4;
-	pixel_x = -8
-	},
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/rnd/robotics)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xtK" = (
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -124186,8 +125931,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
 "xwW" = (
 /obj/structure/cable/cyan{
@@ -124461,6 +126205,15 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"xzN" = (
+/obj/structure/table/woodentable,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/item/circuitboard/broken,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xzQ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -124959,6 +126712,11 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"xEB" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates,
+/area/colony)
 "xED" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
@@ -125016,6 +126774,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/substation/servist)
+"xFb" = (
+/obj/random/lowkeyrandom,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xFg" = (
 /obj/structure/catwalk,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -125074,6 +126839,13 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/dorm1)
+"xFE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xFF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -125433,6 +127205,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/east)
+"xIH" = (
+/obj/item/storage/deferred/crate/uniform_black,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xII" = (
 /obj/machinery/atm_exchange{
 	dir = 8
@@ -125614,6 +127392,16 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"xKm" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/random/mob/termite_no_despawn,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xKn" = (
 /obj/structure/catwalk,
 /obj/random/structures,
@@ -125702,6 +127490,15 @@
 /obj/structure/invislight,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"xKU" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/roach_egg_remains,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xKY" = (
 /obj/structure/catwalk,
 /obj/structure/barricade,
@@ -125775,20 +127572,13 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/hallways)
 "xLD" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/rnd/robotics)
+/obj/random/mob/roaches,
+/obj/item/trash/popcorn,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xLH" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -126387,6 +128177,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"xRx" = (
+/obj/random/closet_maintloot,
+/obj/item/contraband/poster/placed/generic/work_for_a_future{
+	pixel_y = 32
+	},
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -126574,6 +128374,13 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
+"xTn" = (
+/obj/random/furniture/pottedplant,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/blue_slates_long,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "xTs" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -126706,6 +128513,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"xUY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/pistachios,
+/obj/item/trash/mre_can,
+/obj/item/trash/syndi_cakes,
+/obj/item/trash/energybar,
+/obj/item/trash/chips,
+/obj/item/trash/candy/proteinbar,
+/obj/item/trash/candy,
+/obj/item/trash/cheesie,
+/turf/simulated/floor/industrial/concrete_bricks,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xVd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/airlock{
@@ -127076,18 +128897,8 @@
 	},
 /area/nadezhda/security/vacantoffice2)
 "xYS" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "xYV" = (
 /obj/machinery/door/airlock/glass{
@@ -127137,6 +128948,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"xZn" = (
+/obj/structure/table/reinforced,
+/obj/random/material_rare/low_chance,
+/obj/random/material_rare,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "xZv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -127715,6 +129532,7 @@
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "yfx" = (
@@ -127758,6 +129576,14 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/command/hallway)
+"yfZ" = (
+/obj/structure/salvageable/machine,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ygn" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/leafybush,
@@ -128163,6 +129989,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"ykH" = (
+/obj/effect/landmark/stationroom/maint/threexthree,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "ylc" = (
 /obj/machinery/light/floor{
 	dir = 8
@@ -174001,13 +175833,13 @@ tad
 cZb
 cZb
 tvc
-lYu
-lYu
+qaU
+lgQ
 eMN
 mqt
 mUG
 mqt
-lww
+owY
 tvc
 rRq
 xUC
@@ -174203,13 +176035,13 @@ cZb
 cZb
 cZb
 tvc
-rbt
-rXr
+iOR
+bIG
 eMN
 mqt
 kkU
 mqt
-lZm
+wQH
 tvc
 uci
 fPf
@@ -174611,9 +176443,9 @@ lYu
 lYu
 eMN
 mqt
-kkU
+mES
 mqt
-lww
+owY
 tvc
 vGc
 fPf
@@ -175014,7 +176846,7 @@ tvc
 tvc
 tvc
 tvc
-mqt
+nGg
 kkU
 mqt
 lww
@@ -175213,13 +177045,13 @@ cZb
 cZb
 cZb
 tvc
-lYu
-lYu
-eMN
-mqt
+hsb
+lgQ
+xbI
+gyz
 kkU
 mqt
-lZm
+aGy
 tvc
 qMx
 tCv
@@ -175415,10 +177247,10 @@ cZb
 cZb
 cZb
 tvc
-rbt
-rXr
-eMN
-mqt
+awE
+xKU
+xbI
+sKf
 kkU
 mqt
 lZm
@@ -175623,7 +177455,7 @@ tvc
 mqt
 mqt
 mqt
-lww
+dKt
 tvc
 eJW
 tXG
@@ -176023,14 +177855,14 @@ cZb
 cZb
 cZb
 tvc
-eRg
+bjJ
 mqt
 mqt
 oMa
 oMa
-oMa
-oMa
-oMa
+jWX
+ihR
+ihR
 tvc
 cgk
 xSl
@@ -176232,7 +178064,7 @@ oMa
 ueA
 nhi
 nhi
-oMa
+xtF
 tvc
 cgk
 mqt
@@ -176629,8 +178461,8 @@ cZb
 cZb
 cZb
 tvc
-vOz
-mqt
+awk
+kMC
 mqt
 oMa
 wLS
@@ -176832,7 +178664,7 @@ cZb
 cZb
 tvc
 eRg
-mqt
+gyz
 mqt
 oMa
 oMa
@@ -176993,9 +178825,9 @@ jdE
 jdE
 jdE
 jdE
-cZb
-cZb
-cZb
+kUx
+kUx
+kUx
 cZb
 cZb
 cZb
@@ -177194,21 +179026,21 @@ kaV
 ksW
 whM
 sFL
-jdE
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+oZD
+qHW
+qTG
+epJ
+lKU
+fTV
+wqh
+lKU
+fTV
+lKU
+fTV
+fTV
+lKU
+fTV
+lKU
 tvc
 lrR
 rAz
@@ -177395,22 +179227,22 @@ jdE
 vJx
 vZK
 bli
-dRK
-jdE
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+vvU
+oZD
+jqf
+bli
+wva
+iRT
+fTV
+fTV
+fTV
+fTV
+fTV
+fTV
+fTV
+fTV
+fTV
+epJ
 tvc
 qGe
 lTZ
@@ -177594,25 +179426,25 @@ bli
 kBB
 bli
 jdE
-vJx
+hOh
 bli
 rlx
 qjV
-jdE
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+oZD
+fRz
+bli
+lfz
+eyk
+cFB
+cFB
+cFB
+cFB
+ptw
+iRT
+sJB
+pfN
+iRT
+riM
 tvc
 gaK
 rAz
@@ -177798,23 +179630,23 @@ bli
 dMP
 bli
 rlx
+wOL
+aVJ
+sxk
+vJx
 bli
-hLg
-jdE
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+vZK
+vGd
+pfN
+pfN
+iRT
+iRT
+rlx
+lwc
+qFj
+vGd
+mbk
+hAd
 tvc
 qpp
 rAz
@@ -178002,21 +179834,21 @@ bli
 bli
 hLg
 gfo
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+sxk
+jsI
+bli
+cEl
+rXi
+qee
+mut
+oNq
+rpN
+rpN
+bli
+gyP
+eJU
+rYa
+vqs
 tvc
 lrR
 rAz
@@ -178200,25 +180032,25 @@ bli
 ilZ
 bli
 jdE
-whB
+ejJ
 glY
 bli
-hLg
-qqy
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+dRK
+oZD
+xUY
+hTf
+tWH
+jnK
+rXi
+bli
+bli
+bli
+bli
+vZK
+kgR
+hbR
+cUz
+wfZ
 tvc
 lrR
 rAz
@@ -178405,22 +180237,22 @@ jdE
 whB
 bli
 rlx
+gjz
 oZD
-jdE
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+gGD
+tWH
+nyb
+tWH
+sxz
+pqe
+kpc
+gbj
+tDC
+bli
+iMp
+xoD
+rYa
+vqs
 tvc
 iWC
 rAz
@@ -178604,25 +180436,25 @@ bli
 ghL
 bli
 xff
-vJx
+dHs
 bli
 bli
 ifA
-jdE
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+oZD
+nxt
+rXi
+tWH
+vZK
+oyX
+bli
+ecM
+bli
+bli
+kYG
+bli
+bli
+tCB
+vqs
 tvc
 daI
 rAz
@@ -178806,25 +180638,25 @@ bli
 bbI
 bli
 xff
-vJx
+whB
 bli
 bli
 gjz
-jdE
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+teT
+fAu
+usS
+nus
+lNE
+sHE
+rop
+jxk
+xIH
+oGU
+nCa
+dRB
+vqs
+rSr
+vVd
 tvc
 tvc
 tvc
@@ -179008,10 +180840,10 @@ bli
 qbJ
 bli
 xff
-vJx
+dHs
 bli
 bli
-pqe
+gjz
 jdE
 qBg
 qBg
@@ -179213,7 +181045,7 @@ xff
 vJx
 bli
 bli
-vJx
+hOh
 jdE
 qBg
 hEq
@@ -180921,11 +182753,11 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+kUx
+kUx
+kUx
+kUx
 cZb
 cZb
 tad
@@ -181118,17 +182950,17 @@ rWi
 wUj
 lDf
 tbj
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+rWi
+rWi
+ghg
+ghg
+ghg
+rWi
+kEt
+yfZ
+mdt
+rWi
+ghg
 tad
 tad
 tad
@@ -181319,18 +183151,18 @@ cZb
 tbj
 rHi
 lDf
-sps
-liX
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+rhn
+llA
+plc
+mZX
+mZX
+mZX
+pZU
+pZU
+jIo
+aix
+vUj
+ghg
 tad
 tad
 tad
@@ -181522,17 +183354,17 @@ emu
 rHi
 kJK
 qCQ
-liX
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+fDj
+plc
+plc
+plc
+eaX
+tbj
+pZU
+aou
+uyL
+rWi
+ghg
 tad
 tad
 tad
@@ -181644,7 +183476,7 @@ xFF
 iOV
 mVT
 fdZ
-dPU
+qBg
 ebO
 dPU
 dPU
@@ -181716,25 +183548,25 @@ eZE
 aBE
 cZb
 cZb
-cZb
-cZb
+kUx
+boa
 cZb
 ptU
 alm
 wUj
 hua
 cFt
-liX
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+lHA
+rWi
+plc
+rWi
+qzn
+rWi
+rWi
+rWi
+rWi
+rWi
+ghg
 tad
 tad
 tad
@@ -181856,7 +183688,7 @@ bHt
 pvR
 eGz
 dPU
-nhN
+uWd
 tvL
 viS
 npr
@@ -181918,25 +183750,25 @@ eZE
 pfY
 cZb
 cZb
-cZb
-cZb
+kUx
+ofg
 cZb
 ptU
 sww
 rHi
 hua
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+rWi
+jIa
+rWi
+rwn
+rwn
+rJW
+cVY
+wcy
+ghg
+ghg
 tad
 tad
 tad
@@ -182046,15 +183878,15 @@ qBg
 fxl
 qSf
 gcQ
-wfZ
 rRo
-dPU
+qBg
+uJj
 fUe
 nPH
 iKK
 nWB
-hOh
 iKK
+asU
 nct
 iKK
 fAZ
@@ -182120,25 +183952,25 @@ wLg
 wpG
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
+pUH
+xkR
+qlN
+ptU
 rWi
 rHi
 veL
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+ghg
+aSE
+rWi
+wcy
+gzv
+rwn
+xsv
+wcy
+ghg
+ghg
 tad
 tad
 tad
@@ -182253,13 +184085,13 @@ pNU
 mch
 oaG
 oVi
-eMW
-gvS
-vGd
-bHt
 gus
-dSM
-dPU
+gvS
+gus
+jCs
+gus
+oxA
+xxm
 nhN
 vIr
 kTu
@@ -182323,24 +184155,24 @@ wpG
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
+fMi
+xEB
+luo
 rWi
-rHi
+bgi
 veL
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+rWi
+eaX
+rWi
+jgQ
+qhl
+fiB
+fiB
+bVT
+bjs
+ghg
 tad
 tad
 tad
@@ -182450,19 +184282,19 @@ qBg
 sox
 wtQ
 dpG
-exT
 lSn
-dPU
+qBg
+pIZ
 dFx
+blv
+oxA
+dWZ
+oxA
+oxA
 xYS
-dPU
-dPU
-dPU
-dPU
-dPU
-dPU
-dPU
-uWd
+oxA
+xxm
+nhN
 vIr
 cCf
 iIq
@@ -182524,25 +184356,25 @@ wXv
 wpG
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
+ipO
+fMi
+eMW
+ijq
 rWi
 rHi
 veL
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+rWi
+fiB
+ghg
+ghg
+qhl
+qhl
+aoS
+qhl
+rWi
+ghg
 tad
 tad
 tad
@@ -182650,19 +184482,19 @@ cZb
 cZb
 qBg
 qBg
-qBg
+gSr
 gGN
-uyL
 hop
-dPU
+qBg
+uUn
 ntV
-xLD
-dPU
-cZb
-cZb
-cZb
-cZb
-cZb
+blv
+oxA
+hYz
+qLI
+vuV
+leS
+bTW
 dPU
 meF
 vIr
@@ -182725,26 +184557,26 @@ wXv
 wXv
 wpG
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+haL
+fMi
+hsE
+hsE
 qEw
 wEn
 bbQ
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+rWi
+jIa
+ghg
+ghg
+ghg
+tFb
+hxR
+tFb
+qhl
+ghg
 tad
 tad
 tad
@@ -182856,14 +184688,14 @@ dPU
 pNC
 dPU
 dPU
-dPU
+vBj
 txJ
 eOT
+mrK
+mrK
 txJ
-txJ
-txJ
-txJ
-txJ
+mrK
+mrK
 txJ
 txJ
 nhN
@@ -182927,26 +184759,26 @@ klv
 trQ
 wpG
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+tIw
+eMW
+gST
+nQn
 nIi
 rHi
 awL
 eBR
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+rWi
+eaX
+ghg
+ghg
+ghg
+rWi
+rWi
+rWi
+rWi
+rWi
 cZb
 tad
 tad
@@ -183058,9 +184890,9 @@ ltn
 oqf
 vcs
 kCD
-xtF
-txJ
-hxR
+ggq
+mrK
+dQp
 ufq
 nug
 jbo
@@ -183129,26 +184961,26 @@ wpG
 wpG
 wpG
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+lBL
+eMW
+eMW
+hsE
 rWi
 rHi
+kJK
 fBc
-fBc
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+ghg
+fiB
+aSE
+fiB
+wuX
+fyp
+ifK
+ghg
+xFb
+rWi
 cZb
 tad
 tad
@@ -183261,15 +185093,15 @@ ePd
 hTJ
 kbF
 ggq
-txJ
+mrK
 dQp
-pZU
-pZU
-pZU
-pZU
+rNy
+rNy
+rNy
+rNy
 bcl
 mpA
-txJ
+mrK
 nhN
 vIr
 fws
@@ -183331,28 +185163,28 @@ jeE
 iMl
 lUB
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+tvC
+eMW
+eMW
+eqa
 rWi
 bgi
-fBc
+kJK
+rWi
+ghg
+rWi
+fcV
+ghg
+rWi
+rWi
+xKm
+ghg
+ghg
+rWi
 rWi
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
 tad
 tad
 tad
@@ -183465,13 +185297,13 @@ nTx
 bcQ
 txJ
 apk
-tgU
+pQG
 fLc
 tgU
 neL
 uMy
 lmZ
-txJ
+mrK
 nhN
 otu
 fws
@@ -183533,26 +185365,26 @@ hFQ
 hFQ
 lUB
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+mfI
+eMW
+eMW
+nQR
 rWi
-bgi
-cFB
+rHi
+lDf
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+rWi
+jeF
+qLu
+rWi
+ipY
+fyp
+mar
+tVG
+lsO
+rWi
 cZb
 tad
 tad
@@ -183736,25 +185568,25 @@ ldC
 cPz
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-rQi
-bgi
-rXi
+rWt
+rWt
+eMW
+pYf
+nrI
+rHi
+lDf
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ghg
+rWi
+xpd
+qLu
+rWi
+xRx
+jkm
+fgR
+bnR
+ujn
+rWi
 cZb
 tad
 tad
@@ -183868,10 +185700,10 @@ blv
 oxA
 pxF
 txJ
-aVR
+dQp
 pQG
 hVu
-pQG
+tgU
 gxP
 xwM
 tck
@@ -183938,25 +185770,25 @@ ldC
 pRf
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
+wMh
+fMi
+cQn
+kUx
 rWi
 rHi
-wJD
+avv
 eBR
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+kUx
+kUx
+rWi
+rWi
+rco
+rWi
+rWi
+rWi
+rWi
 cZb
 cZb
 cZb
@@ -184140,10 +185972,10 @@ nNX
 lUB
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
+rWt
+rWt
+rWt
+kUx
 eBR
 rHi
 wJD
@@ -184271,9 +186103,9 @@ jaE
 blv
 leS
 ekq
-txJ
+agN
 oMe
-xsv
+rNy
 rNy
 rNy
 aLQ
@@ -184341,11 +186173,11 @@ rYi
 lUB
 lUB
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+kUx
+kUx
+kUx
+kUx
+kUx
 eBR
 rHi
 juF
@@ -184671,7 +186503,7 @@ cZb
 cZb
 dPU
 quS
-jaE
+aiV
 vkf
 gLz
 yfw
@@ -184679,9 +186511,9 @@ spO
 juR
 wpJ
 dAP
-aYT
+pRh
 umk
-lTl
+brG
 naG
 gLz
 rHM
@@ -184878,10 +186710,10 @@ upq
 jdF
 alM
 dyp
-sQP
+tJe
 cBD
-sQP
-sQP
+tJe
+tJe
 moe
 sQP
 sQP
@@ -185084,7 +186916,7 @@ brG
 cJX
 brG
 brG
-jVT
+aOJ
 brG
 brG
 dhO
@@ -185151,7 +186983,7 @@ lUB
 cZb
 rWi
 wJe
-wJe
+rPR
 awL
 awL
 awL
@@ -185280,13 +187112,13 @@ dPU
 fJt
 lqb
 gLz
-gLz
+hKX
 mIe
-glv
-cJX
-brG
+hKX
+gLz
+eVM
+mpx
 eJN
-jVT
 brG
 ghd
 gLz
@@ -185480,15 +187312,15 @@ cZb
 cZb
 mpm
 xaw
-wpL
+pwH
 xXf
-gLz
-npe
+iGI
+ups
 ejB
 hKX
 brG
+xZn
 glv
-aOJ
 brG
 wSZ
 gLz
@@ -185556,13 +187388,13 @@ jYM
 eBR
 rHi
 hua
-ghg
-ghg
-ghg
-ghg
-ghg
-ghg
-cZb
+rWi
+rWi
+rWi
+bqd
+rWi
+rWi
+rWi
 rWi
 dRl
 dRl
@@ -185683,16 +187515,16 @@ cZb
 mpm
 lYa
 wpL
-htN
-brG
+gLz
+xnC
 brG
 hDX
+hKX
 brG
+vey
+hAG
 brG
-glv
-brG
-brG
-glv
+day
 gLz
 uUs
 gWf
@@ -185759,12 +187591,12 @@ eBR
 rHi
 hua
 rWi
-ghg
-ghg
-ghg
-ghg
-ghg
-cZb
+nVl
+ozd
+aKL
+aax
+rlV
+jFB
 rWi
 dRl
 dRl
@@ -185884,16 +187716,16 @@ jdE
 jdE
 mpm
 yky
-wpL
+fFv
 lIc
 cvD
 brG
-brG
-brG
-brG
+jkK
+dhO
+cvD
 brG
 ocT
-ocT
+brG
 brG
 htN
 gWW
@@ -185961,12 +187793,12 @@ eBR
 rHi
 hua
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+cRP
+hua
+hUN
+lMb
+hUN
+nKs
 rWi
 dRl
 dRl
@@ -186087,14 +187919,14 @@ kid
 bwm
 jRm
 jjx
-htN
-xkR
+std
 brG
 brG
+lTl
+hKX
+pMu
 brG
-brG
-brG
-brG
+qbC
 brG
 hrk
 eoD
@@ -186161,14 +187993,14 @@ syS
 jYM
 eBR
 wEn
-hua
+xFE
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+hUN
+nVV
+fXr
+hua
+eTT
+kdz
 rWi
 oOE
 eCs
@@ -186289,11 +188121,11 @@ erG
 erG
 dfH
 goP
-htN
-epJ
-brG
-brG
-brG
+gLz
+npe
+pGj
+aYT
+hKX
 fsS
 tpp
 brG
@@ -186365,12 +188197,12 @@ eBR
 rHi
 awL
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+rlV
+xzN
+sSt
+koS
+hUN
+hUE
 rWi
 wSf
 cIM
@@ -186567,7 +188399,7 @@ rQi
 rHi
 hqL
 rWi
-cZb
+slN
 rWi
 rWi
 rWi
@@ -186697,7 +188529,7 @@ xXf
 gLz
 htN
 htN
-rpN
+gLz
 htN
 htN
 htN
@@ -186975,7 +188807,7 @@ tbj
 rBL
 oRY
 rwz
-nqS
+bvl
 bER
 oRY
 oRY
@@ -187568,7 +189400,7 @@ icV
 icV
 sBz
 rwG
-vGb
+byR
 rWi
 rWi
 rWi
@@ -187775,7 +189607,7 @@ rWi
 hua
 hua
 fiB
-lDf
+jku
 xnB
 noP
 awL
@@ -187973,7 +189805,7 @@ ieR
 wTC
 rwG
 ojJ
-rWi
+ceQ
 mwe
 dKK
 dKK
@@ -188178,8 +190010,8 @@ jYM
 rWi
 jtQ
 eBR
-eBR
-eBR
+rWi
+rWi
 eBR
 eBR
 rWi
@@ -188373,16 +190205,16 @@ gwG
 gwG
 gwG
 jYM
-cZb
-cZb
-cZb
-cZb
+dSM
+dSM
+ffF
+qlk
 rWi
 tYr
-eBR
-eBR
-eBR
-eBR
+bpe
+ghg
+ghg
+ghg
 cZb
 cZb
 cZb
@@ -188575,15 +190407,15 @@ adV
 adV
 adV
 jYM
-cZb
-cZb
-cZb
-cZb
+bnQ
+aVR
+uth
+geF
 rWi
 vUJ
 eBR
-eBR
-eBR
+ghg
+ghg
 ghg
 cZb
 cZb
@@ -188777,15 +190609,15 @@ sbL
 gwG
 eti
 jYM
-cZb
-cZb
-cZb
-cZb
-rWi
-tYr
+cIR
+xLD
+exF
+dkb
+gZq
+sZH
 eBR
-eBR
-eBR
+ghg
+ghg
 eBR
 eBR
 rWi
@@ -188979,21 +190811,21 @@ jYM
 jYM
 jYM
 jYM
-cZb
-cZb
-cZb
-cZb
+hiJ
+cCm
+ibu
+pmS
 rWi
 hdo
-bpe
-eBR
-eBR
+fiB
+rWi
+ghg
 eBR
 iGf
 geL
 tam
 buk
-nQR
+bWi
 jNj
 sOM
 ssy
@@ -189173,11 +191005,11 @@ dVw
 pbk
 bKt
 rWi
-cZb
-cZb
-pen
-cZb
-cZb
+xTn
+hDf
+usT
+ckP
+tqA
 rWi
 rWi
 rWi
@@ -189187,18 +191019,18 @@ rWi
 rWi
 rWi
 hdo
-eBR
-eBR
+fiB
+ghg
 cZb
 eBR
 oRY
 ndY
 lwG
 lwG
+nKN
 sXs
 sXs
-sXs
-jnl
+sPk
 wHv
 rWi
 cZb
@@ -189375,11 +191207,11 @@ ujX
 kzJ
 cbm
 rWi
-cZb
-pen
-pen
-cZb
-cZb
+gDk
+hDf
+hDq
+gLN
+tqA
 rWi
 eCI
 xpr
@@ -189398,7 +191230,7 @@ geL
 wHv
 wHv
 sXs
-sXs
+eZi
 sXs
 jnl
 kER
@@ -189577,11 +191409,11 @@ bnh
 cUl
 rek
 rWi
-pen
-pen
-cZb
-cZb
-cZb
+scv
+bxv
+tqA
+lzP
+fjy
 rWi
 kwH
 nXm
@@ -189597,11 +191429,11 @@ cZb
 rWi
 kER
 siy
-iRT
+wHv
 wHv
 kER
 wHv
-wHv
+kte
 vRy
 wHv
 rWi
@@ -189777,13 +191609,13 @@ rWi
 rWi
 rWi
 oHg
-haL
-rWi
-pen
-cZb
-cZb
-cZb
-cZb
+rHi
+jVT
+tqA
+tqA
+hFk
+hZy
+rPr
 rWi
 awx
 khd
@@ -189981,11 +191813,11 @@ rSw
 osE
 caN
 rWi
-pen
-cZb
-cZb
-cZb
-cZb
+oQN
+pRW
+rWi
+rWi
+rWi
 rWi
 rWi
 rWi
@@ -190003,10 +191835,10 @@ muD
 bWi
 bLx
 lwG
+twZ
 sXs
 sXs
-sXs
-jnl
+tph
 wHv
 rWi
 cZb
@@ -190183,11 +192015,11 @@ rWi
 kWy
 oqU
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
+wZE
+wZE
+ykH
+rWi
+ghg
 rWi
 eCI
 xpr
@@ -190385,11 +192217,11 @@ rWi
 kWy
 oqU
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
+wZE
+wZE
+wZE
+rWi
+ghg
 rWi
 jZt
 wHv
@@ -190587,11 +192419,11 @@ rWi
 fhb
 oqU
 rWi
-cZb
-cZb
-cZb
-cZb
-cZb
+wZE
+wZE
+wZE
+rWi
+ghg
 rWi
 awx
 khd

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -352,6 +352,13 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
+"adQ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "adR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -1018,6 +1025,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"aki" = (
+/obj/structure/flora/small/trailrockb5,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "akr" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2
@@ -1407,6 +1418,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"anW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/scrap/poor,
+/turf/simulated/floor/industrial/checker_large,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "aoa" = (
 /obj/structure/cyberplant,
 /turf/simulated/floor/carpet/bcarpet,
@@ -1997,6 +2015,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
+"auc" = (
+/obj/structure/table/marble,
+/obj/random/junkfood/low_chance,
+/obj/random/junkfood/rotten/low_chance,
+/obj/random/junk,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "aud" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -2024,6 +2049,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/absolutism/skyyard)
+"aui" = (
+/obj/item/tool/pickaxe/diamonddrill,
+/obj/random/rig/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "auk" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2550,11 +2580,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "azd" = (
-/obj/item/modular_computer/console/preset/medical/monitor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/command/cbo)
+/obj/structure/flora/small/trailrockb5,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "azf" = (
 /obj/structure/closet/secure_closet/personal/trooper,
 /obj/structure/window/reinforced{
@@ -3643,22 +3672,9 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
 "aJC" = (
-/obj/structure/sink/kitchen{
-	name = "utility sink";
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/sleeper)
+/obj/random/mob/golem,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "aJD" = (
 /obj/random/voidsuit/damaged,
 /obj/structure/catwalk,
@@ -4224,6 +4240,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/server)
+"aQk" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/obj/item/clothing/head/helmet/handmade/greathelm,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "aQl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -4272,6 +4295,13 @@
 /obj/machinery/power/am_control_unit,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"aQQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/junkfood/rotten/low_chance,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "aQR" = (
 /obj/machinery/door/airlock{
 	name = "Toilet"
@@ -4451,6 +4481,14 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/hallway)
+"aSC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/plumpmycelium,
+/obj/item/seeds/plumpmycelium,
+/obj/item/seeds/eggplantseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "aSE" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/termite_no_despawn,
@@ -4618,6 +4656,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"aUN" = (
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "aUO" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -6361,6 +6403,11 @@
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
+"bkD" = (
+/obj/structure/flora/rock/variant1,
+/obj/item/stack/ore/coal,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "bkH" = (
 /obj/structure/table/rack/shelf,
 /obj/random/contraband/low_chance,
@@ -6528,6 +6575,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/command/hallway)
+"bmB" = (
+/obj/structure/bed/chair,
+/mob/living/carbon/superior/termite_colony/plasma,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "bmF" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -6538,6 +6591,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/navy_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"bmI" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/item/ammo_magazine/ammobox/rifle_75_small/scrap,
+/turf/simulated/floor/rock,
+/area/colony)
 "bmO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -6950,6 +7010,11 @@
 	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
+"bqy" = (
+/obj/item/remains/mouse,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "bqA" = (
 /obj/machinery/smartfridge/chemistry,
 /obj/machinery/power/apc{
@@ -7143,6 +7208,15 @@
 /obj/item/clothing/mask/gas,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"bsm" = (
+/obj/machinery/door/airlock/vault/bolted,
+/obj/structure/table/steel,
+/obj/machinery/door/blast/shutters,
+/obj/random/credits/c100,
+/obj/effect/spider/stickyweb,
+/obj/random/spider_trap/low_chance,
+/turf/simulated/floor/industrial/sierra,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "bsq" = (
 /obj/structure/sign/department/gene,
 /turf/simulated/wall/r_wall,
@@ -8243,6 +8317,17 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"bCt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/seeds/cinnamonseed,
+/obj/item/seeds/cherryseed,
+/obj/item/seeds/carrotseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "bCy" = (
 /obj/structure/lattice,
 /obj/structure/invislight,
@@ -8924,6 +9009,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
+"bIN" = (
+/obj/structure/flora/small/trailrockb1,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "bIU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -9168,7 +9257,6 @@
 "bKN" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "bKS" = (
@@ -10689,19 +10777,12 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/range)
 "caX" = (
-/obj/item/reagent_containers/blood/AMinus,
-/obj/item/reagent_containers/blood/APlus,
-/obj/item/reagent_containers/blood/BMinus,
-/obj/item/reagent_containers/blood/BPlus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OPlus,
-/obj/structure/closet/secure_closet/freezer/blood{
-	name = "secure blood fridge";
-	req_access = list(45)
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/item/storage/freezer,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/medical/sleeper)
+/turf/simulated/floor/industrial/checker_large,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "caY" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/machinery/light{
@@ -11090,6 +11171,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"cfE" = (
+/obj/structure/flora/small/lavarock1,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "cfU" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -11110,6 +11195,17 @@
 /obj/item/material/shard,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"cgc" = (
+/obj/structure/flora/pottedplant/water_root,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "cge" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor/multi_tile,
@@ -11286,8 +11382,7 @@
 "chS" = (
 /obj/random/junk/low_chance,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
@@ -11483,6 +11578,13 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"cjY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/sleeper)
 "cjZ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Hulk Internal Airlock";
@@ -11879,6 +11981,11 @@
 /obj/structure/scrap/cloth,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfacenorth)
+"cnt" = (
+/obj/structure/bed/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "cnB" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -12039,6 +12146,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"cpH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "cpR" = (
 /obj/structure/flora/big/bush3{
 	pixel_y = -10
@@ -12258,6 +12370,11 @@
 "crv" = (
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"crx" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/junk/low_chance,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "cry" = (
 /obj/machinery/seed_storage/xenobotany,
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
@@ -14418,6 +14535,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/dorm4)
+"cMs" = (
+/obj/random/junk/low_chance,
+/obj/item/toy/plushie/carp,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "cMz" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -15140,6 +15262,11 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
+"cSW" = (
+/mob/living/carbon/superior/termite_colony/plasma,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "cSX" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -15554,11 +15681,6 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "cWY" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
 /turf/simulated/floor/industrial/grey_slates_long,
@@ -15745,14 +15867,14 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/lakeside)
 "cYs" = (
-/obj/random/scrap/sparse_weighted/low_chance,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/seeds/pumpkinseed,
+/obj/item/seeds/pumpkinseed,
+/obj/item/seeds/chiliseed,
+/obj/item/tool/minihoe,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "cYv" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,17"
@@ -15928,6 +16050,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"cZX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/hydro_tray_plant_bag_nutrient,
+/obj/item/hydro_tray_plant_bag_nutrient,
+/obj/item/hydro_tray_plant_bag_nutrient,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "dac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -15965,14 +16095,9 @@
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/forest)
 "dat" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "day" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -16232,7 +16357,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "ddS" = (
 /obj/machinery/atmospherics/valve,
@@ -16894,15 +17019,11 @@
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/crew_quarters/bar)
 "dky" = (
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/table/steel,
+/obj/random/handmade_tool,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "dkE" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -17390,7 +17511,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/sleeper)
 "dpm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -17537,6 +17658,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"dqE" = (
+/obj/structure/flora/small/trailrocka2,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "dqN" = (
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/atmos)
@@ -17844,6 +17969,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dtT" = (
+/obj/machinery/door/blast/shutters,
+/obj/random/credits/c100,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/industrial/sierra,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "dtW" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/road/straight1,
@@ -18079,6 +18210,11 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dvJ" = (
+/obj/item/stack/rods/random,
+/obj/random/rig_module/low_chance,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "dvZ" = (
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/industrial/checker_large,
@@ -18156,6 +18292,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "dwN" = (
@@ -18897,6 +19034,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"dDj" = (
+/obj/random/cluster/roaches/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "dDl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -20269,6 +20411,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"dQa" = (
+/obj/structure/flora/small/lavarock2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "dQf" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/beach/sand,
@@ -21352,6 +21501,10 @@
 /obj/structure/bed/chair/sofa/black/left,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"eaK" = (
+/obj/structure/flora/small/trailrocka1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "eaL" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -21389,6 +21542,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/surfaceeast)
+"eaP" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "eaU" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/small/bushb2,
@@ -21696,7 +21854,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "edJ" = (
 /obj/effect/spider/stickyweb,
@@ -22121,6 +22279,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/main/stairwell)
+"ehu" = (
+/obj/structure/table/steel,
+/obj/random/gun_parts/low,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ehv" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4
@@ -24006,6 +24170,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"ezo" = (
+/obj/structure/flora/rock/variant2,
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "ezp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -24288,6 +24457,10 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"eBU" = (
+/obj/item/stack/ore,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "eCh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -25728,6 +25901,17 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/engineering/engine_room)
+"ePK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/structure/table/standard,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/firstaid/low_chance,
+/obj/random/pouch/low_chance,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "ePN" = (
 /obj/structure/catwalk,
 /obj/structure/invislight,
@@ -26514,8 +26698,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "eXn" = (
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/rock,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn,
+/turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "eXo" = (
 /obj/effect/spider/stickyweb,
@@ -26602,6 +26787,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/tactical_blackshield)
+"eXU" = (
+/obj/item/stack/ore/coal,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "eYc" = (
 /obj/structure/medical_stand/anesthetic,
 /obj/item/tool/wrench,
@@ -27017,6 +27206,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"fbV" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/grille,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "fbY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -27326,8 +27520,7 @@
 /area/nadezhda/outside/inside_colony)
 "ffF" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches,
@@ -27613,6 +27806,11 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"fhE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/mob/spiders,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "fhH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27855,15 +28053,13 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "fjM" = (
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
 	},
-/turf/simulated/floor/industrial/grey_slates_long,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/sleeper)
 "fjP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/cable/cyan{
@@ -28020,6 +28216,15 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
+"fli" = (
+/obj/structure/table/rack/shelf,
+/obj/item/shield/buckler/handmade/damaged,
+/obj/item/gun/projectile/boltgun/handmade,
+/obj/item/ammo_casing/rifle_75/scrap/prespawned,
+/obj/item/ammo_casing/rifle_75/scrap/prespawned,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "flq" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -28581,6 +28786,9 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "fpz" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/medical/sleeper)
@@ -29029,6 +29237,11 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfacenorth)
+"fvl" = (
+/obj/structure/flora/small/trailrockb1,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "fvs" = (
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -29073,6 +29286,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"fvF" = (
+/obj/item/clothing/gloves/thick/handmade,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "fvG" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -29102,6 +29320,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"fvS" = (
+/obj/structure/closet/random_tech,
+/obj/random/rations/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "fvU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30658,8 +30881,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /turf/simulated/floor/industrial/ceramic,
 /area/nadezhda/maintenance/surfaceeast)
@@ -30974,6 +31196,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/merchant)
+"fPS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "fPV" = (
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
@@ -31077,6 +31306,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
+"fRb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/sleeper)
 "fRc" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31494,6 +31730,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"fVq" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "fVs" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/structure/catwalk,
@@ -32018,6 +32258,16 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
+"gaq" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "gas" = (
 /obj/machinery/camera/network/engineering{
 	dir = 4
@@ -32060,15 +32310,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
 "gaP" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "gaS" = (
 /obj/structure/barricade,
 /turf/simulated/floor/rock,
@@ -33759,6 +34003,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
+"gpq" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/pouch/engineering_tools,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "gpu" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -34032,6 +34282,12 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters)
+"grI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/scrap/medical,
+/obj/random/mob/roaches,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "grM" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/decal/cleanable/rubble,
@@ -34423,8 +34679,7 @@
 "gvq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/surfaceeast)
@@ -34690,6 +34945,10 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
+"gxZ" = (
+/obj/structure/ameridian_crystal/spreading,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "gyd" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -34808,6 +35067,11 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
+"gzn" = (
+/obj/structure/barricade,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "gzo" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /obj/machinery/door/firedoor,
@@ -34980,13 +35244,16 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"gAC" = (
+/obj/structure/table/bench/marble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "gAK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
 /obj/item/storage/freezer,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /obj/item/reagent_containers/snacks/meat/monkey,
 /obj/item/reagent_containers/snacks/meat/monkey,
@@ -35957,6 +36224,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"gMa" = (
+/obj/structure/barricade,
+/obj/item/stack/ore/glass/dust,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
+"gMl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "gMn" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -36026,8 +36308,7 @@
 "gNo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /turf/simulated/floor/industrial/cafe_large,
 /area/nadezhda/maintenance/surfaceeast)
@@ -37180,6 +37461,7 @@
 	dir = 1
 	},
 /obj/structure/railing,
+/obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/beach/water/jungledeep{
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
@@ -38096,10 +38378,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "hgJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/sleeper)
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "hgO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -38276,6 +38556,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/workshop)
+"hjb" = (
+/obj/structure/flora/small/grassb2,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "hji" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -38287,6 +38572,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/quartermaster/miningdock)
+"hjl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk,
+/obj/random/pack/cloth,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
+"hjm" = (
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "hjp" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -38332,6 +38628,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"hjN" = (
+/obj/structure/table/steel,
+/obj/random/gun_energy_cheap/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "hjO" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/accessory/magatama,
@@ -38606,6 +38908,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"hlQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/reagent_containers/snacks/candy/sunflowerseeds,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "hlR" = (
 /obj/structure/table/bench/standard,
 /obj/landmark/join/start/apprentice,
@@ -38861,6 +39169,12 @@
 "hoH" = (
 /turf/simulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hoJ" = (
+/obj/structure/table/rack/shelf,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/turf/simulated/floor/rock,
+/area/colony)
 "hoR" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -38985,11 +39299,11 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "hpL" = (
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/shuttle/floor/mining{
-	icon_state = "9,23"
-	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "hpN" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "11,17"
@@ -41547,6 +41861,11 @@
 /obj/item/stool,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/miningdock)
+"hLU" = (
+/obj/structure/flora/small/lavarock1,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "hLV" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -41922,6 +42241,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"hQx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/mob/roaches,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "hQB" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -43257,6 +43581,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/cafe_large,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"icm" = (
+/obj/structure/bed/chair,
+/obj/item/remains/mouse,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "icr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/fancy_slates,
@@ -43732,7 +44062,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "igI" = (
 /obj/structure/catwalk,
@@ -43956,6 +44286,11 @@
 	},
 /turf/simulated/open,
 /area/asteroid/cave)
+"iji" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ijl" = (
 /obj/item/weldpack/canister,
 /turf/simulated/floor/rock,
@@ -44398,6 +44733,10 @@
 /obj/item/reagent_containers/cwj/container/grill_grate,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"imG" = (
+/obj/structure/flora/rock,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "imM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -45384,6 +45723,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"ivW" = (
+/obj/structure/flora/small/grassb3,
+/obj/structure/flora/small/lavarock2,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "iwq" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,11"
@@ -45891,6 +46236,10 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"iBJ" = (
+/obj/item/stack/ore,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "iBK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -46102,6 +46451,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"iDG" = (
+/obj/structure/flora/small/trailrockb1,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "iDJ" = (
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass,
@@ -46442,6 +46795,13 @@
 "iHD" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/nuke_storage)
+"iHE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/medical/sleeper)
 "iHF" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,18";
@@ -47811,6 +48171,14 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"iVH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/seeds/riceseed,
+/obj/item/seeds/riceseed,
+/obj/item/reagent_containers/glass/plastic_jug,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "iVJ" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -49491,6 +49859,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"jma" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "jmc" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -49799,6 +50171,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"joo" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water/jungledeep{
+	desc = "Filthy, stinking bilge water.";
+	name = "murky water"
+	},
+/area/nadezhda/maintenance/undergroundfloor1west)
 "jop" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/danger,
@@ -50173,6 +50554,11 @@
 /obj/structure/scrap_cube,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"jrV" = (
+/obj/structure/flora/small/trailrocka5,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "jrW" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
@@ -50559,6 +50945,11 @@
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"jvq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/scrap/medical/large,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "jvw" = (
 /obj/machinery/light{
 	dir = 1
@@ -50795,6 +51186,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"jxC" = (
+/obj/structure/flora/small/trailrocka5,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "jxK" = (
 /obj/structure/table/standard,
 /obj/item/mop,
@@ -51564,6 +51960,11 @@
 /obj/machinery/door/holy/public,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
+"jFV" = (
+/obj/random/junk/low_chance,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "jGb" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "10,0"
@@ -51638,6 +52039,7 @@
 	pixel_x = -1;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "jGM" = (
@@ -52086,15 +52488,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
 "jMe" = (
-/obj/random/scrap/sparse_weighted/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/industrial/grey_slates_long,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/catwalk,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "jMh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -52708,10 +53105,9 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "jRY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/industrial/navy_slates,
-/area/nadezhda/maintenance/undergroundfloor1south)
+/obj/structure/flora/small/lavarock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "jRZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -52967,6 +53363,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/sechall)
+"jTY" = (
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "jUb" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/plating/under,
@@ -53817,6 +54218,13 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"kdc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/poppyseed,
+/obj/item/seeds/poppyseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "kdn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -53932,6 +54340,14 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
+"keh" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "keq" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Bay";
@@ -54535,6 +54951,14 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"kka" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/random/powercell/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/pouch/low_chance,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "kkb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -54626,6 +55050,18 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
+"kkx" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "North APC";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/sleeper)
 "kky" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -55414,6 +55850,11 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/tactical)
+"ksh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/scrap_cube,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "ksk" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/industrial/black_large_slates,
@@ -56493,6 +56934,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"kBQ" = (
+/obj/structure/flora/pottedplant/water_root,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/random/junk/cigbutt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "kBV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/green_large_slates,
@@ -56760,6 +57210,14 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"kDX" = (
+/obj/effect/floor_decal/industrial/loading/white,
+/obj/effect/floor_decal/industrial/box/white/corners,
+/obj/effect/floor_decal/industrial/box/white/corners{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/medical/sleeper)
 "kDZ" = (
 /obj/machinery/button/remote/airlock{
 	id = "FS2";
@@ -56989,8 +57447,7 @@
 "kGN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /obj/structure/barricade,
 /turf/simulated/floor/industrial/white_large_slates,
@@ -57518,6 +57975,13 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
+"kNT" = (
+/obj/structure/sink/kitchen{
+	name = "utility sink";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/sleeper)
 "kOe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -58766,6 +59230,13 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/hallway)
+"lbj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "lbp" = (
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance{
@@ -58806,6 +59277,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/decal/cleanable/rubble,
+/obj/machinery/light/small,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "lbQ" = (
@@ -58863,6 +59335,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
+"lcw" = (
+/obj/effect/floor_decal/spline/wood{
+	dir = 1;
+	icon_state = "spline_fancy_corner"
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "lcx" = (
 /obj/machinery/ntnet_relay,
 /turf/simulated/floor/bluegrid{
@@ -60884,6 +61363,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/blue_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"lxP" = (
+/obj/machinery/light/small,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "lxS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -61694,6 +62179,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"lFZ" = (
+/obj/item/tool/pickaxe,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "lGe" = (
 /obj/effect/floor_decal/industrial/loading/red,
 /obj/structure/cable/green{
@@ -61760,6 +62250,10 @@
 "lGy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/cryo)
+"lGM" = (
+/obj/structure/flora/small/lavarock2,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "lGO" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/firedoor,
@@ -61813,6 +62307,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security)
+"lHw" = (
+/obj/structure/table/steel,
+/obj/random/gun_parts/low,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "lHA" = (
 /obj/structure/boulder,
 /turf/simulated/mineral,
@@ -61944,14 +62445,9 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "lIt" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/boulder,
+/turf/simulated/floor/beach/water/flooded,
+/area/colony)
 "lIu" = (
 /obj/structure/barricade,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -62767,6 +63263,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"lQO" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "lQW" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4
@@ -62932,6 +63432,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"lSt" = (
+/obj/structure/reagent_dispensers/watertank/huge/derelict,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "lSx" = (
 /obj/effect/floor_decal/fact_plaque,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -62991,6 +63495,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/surfaceeast)
+"lSX" = (
+/obj/structure/table/rack/shelf,
+/obj/item/stack/ore/diamond,
+/obj/item/clothing/accessory/choker/gold_bell_small,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/ornate,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "lTg" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -63339,6 +63854,17 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/secrecroom)
+"lVO" = (
+/obj/structure/closet/secure_closet/reinforced/CMO,
+/obj/item/pc_part/drive/disk/design/medical/cmo,
+/obj/machinery/newscaster{
+	dir = 4;
+	pixel_x = 30
+	},
+/obj/item/tool/baton,
+/obj/item/reagent_containers/enricher,
+/turf/simulated/floor/wood,
+/area/colony)
 "lVS" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -63625,9 +64151,13 @@
 /turf/simulated/floor/industrial/navy_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "lYI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/sleeper)
 "lYO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63751,6 +64281,14 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/podrooms)
+"maj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/random/boxes,
+/obj/random/medical_lowcost_handmade,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "mam" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "Sick"
@@ -64700,6 +65238,12 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/armory_blackshield)
+"mhq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mhs" = (
 /obj/structure/table/gamblingtable,
 /obj/random/lowkeyrandom,
@@ -64758,6 +65302,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
+"mhU" = (
+/obj/structure/barricade,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "mhY" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -65565,14 +66114,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "mqx" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water/jungledeep{
+	desc = "Filthy, stinking bilge water.";
+	name = "murky water"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mqA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -66455,6 +67002,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "mzy" = (
@@ -66568,6 +67116,12 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
+"mAA" = (
+/obj/effect/spider/stickyweb,
+/obj/random/mob/spiders,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mAD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green,
@@ -66620,6 +67174,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"mAO" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/effect/decal/cleanable/rubble,
+/obj/random/junkfood/rotten/low_chance,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mAQ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -67145,6 +67705,10 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
+"mFD" = (
+/obj/item/stack/ore/glass/dust,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "mFF" = (
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/plating/under,
@@ -67948,6 +68512,13 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mNX" = (
+/obj/structure/table/rack/shelf,
+/obj/random/tool_upgrade/rare/low_chance,
+/obj/random/toolbox/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mOb" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/industrial/ceramic,
@@ -68315,6 +68886,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
+"mQY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/wheatseed,
+/obj/item/seeds/wheatseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mQZ" = (
 /turf/simulated/open,
 /area/asteroid/cave)
@@ -68395,6 +68973,14 @@
 	tag = "icon-escpodwall4"
 	},
 /area/shuttle/surface_transport_lz)
+"mRY" = (
+/obj/structure/table/marble,
+/obj/random/junkfood,
+/obj/random/junkfood/low_chance,
+/obj/item/storage/hcases/cardcarp,
+/obj/item/pack_card_carp,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mRZ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/table/bench/wooden,
@@ -68760,6 +69346,11 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"mWC" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "mWF" = (
 /obj/item/bedsheet/rddouble,
 /obj/structure/bed/double/padded,
@@ -69275,18 +69866,13 @@
 	name = "Science Expedition prep"
 	})
 "nav" = (
-/obj/item/modular_computer/console/preset/command{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -19
 	},
-/obj/machinery/button/windowtint{
-	dir = 8;
-	id = "CBO";
-	pixel_x = 22;
-	pixel_y = 9;
-	range = 6
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/command/cbo)
+/turf/simulated/floor/industrial/ceramic,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "naz" = (
 /obj/random/lowkeyrandom/low_chance,
 /obj/random/mob/roaches/low_chance,
@@ -69386,8 +69972,7 @@
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -69396,6 +69981,11 @@
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"nbv" = (
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/records,
+/turf/simulated/floor/wood,
+/area/colony)
 "nby" = (
 /obj/machinery/door/airlock/glass_command{
 	id_tag = "gmdoor";
@@ -69759,6 +70349,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
+"neR" = (
+/obj/structure/flora/small/lavarock2,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "nfc" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -70291,6 +70886,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/nadezhda/hallway/surface/section1)
+"nkn" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "nkt" = (
 /obj/structure/table/gamblingtable,
 /obj/random/contraband/low_chance,
@@ -70957,6 +71557,10 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/command/tcommsat/computer)
+"nqC" = (
+/obj/structure/flora/rock/variant2,
+/turf/simulated/floor/beach/water/flooded,
+/area/colony)
 "nqF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71286,6 +71890,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/black_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"ntr" = (
+/obj/structure/flora/small/bushc3,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ntt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71309,6 +71917,10 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/hallway)
+"ntv" = (
+/obj/structure/flora/small/trailrocka5,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ntw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -72174,6 +72786,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
+"nAQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "nAW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -72694,6 +73314,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"nFi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/potatoseed,
+/obj/item/seeds/potatoseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "nFk" = (
 /obj/structure/flora/small/trailrocka1,
 /obj/effect/decal/cleanable/dirt,
@@ -72779,14 +73406,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
 "nFR" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/scrap/poor,
+/turf/simulated/floor/industrial/checker_large,
+/area/colony)
 "nFW" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/big/bush3,
@@ -72870,6 +73493,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/research)
+"nGx" = (
+/obj/structure/flora/small/trailrocka2,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "nGD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -73077,6 +73705,9 @@
 "nJc" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = 8
+	},
+/obj/machinery/holoposter{
+	pixel_y = 32
 	},
 /obj/machinery/light/small{
 	dir = 8;
@@ -74177,6 +74808,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"nTU" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/sierra,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "nTV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -74264,6 +74900,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"nUP" = (
+/obj/machinery/door/airlock/vault/bolted,
+/obj/machinery/door/blast/shutters,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap/low_chance,
+/turf/simulated/floor/industrial/sierra,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "nUY" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
@@ -74893,14 +75537,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "oaw" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/grey_slates_long,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/turf/simulated/mineral,
+/area/nadezhda/medical/morgue)
 "oax" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -75418,6 +76056,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
+"ofd" = (
+/obj/structure/flora/rock,
+/obj/structure/boulder,
+/obj/item/stack/ore/coal,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "ofg" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -75458,6 +76102,11 @@
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ofv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ofA" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -75605,6 +76254,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/command/captain)
+"ogL" = (
+/obj/structure/flora/small/lavarock2,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ogQ" = (
 /obj/structure/table/steel,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -75768,7 +76421,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/sleeper)
@@ -76803,6 +77455,15 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"osg" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/spider/stickyweb,
+/obj/random/mob/spiders,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "osj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -77498,6 +78159,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
+"oyN" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/junkfood/rotten/low_chance,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oyS" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -77551,15 +78217,10 @@
 	name = "Residential District Maintenance"
 	})
 "ozk" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/grey_slates_long,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/grille,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ozq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -77899,6 +78560,12 @@
 "oBP" = (
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/inside_colony)
+"oBU" = (
+/obj/machinery/door/airlock/maintenance_medical{
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/medical/sleeper)
 "oBX" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/bed/chair{
@@ -77991,6 +78658,11 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
+"oCO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/ore/glass/dust,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oCP" = (
 /obj/item/contraband/poster/placed/advertisement/donutcorp,
 /turf/simulated/wall,
@@ -78072,6 +78744,10 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"oDG" = (
+/obj/structure/flora/small/grassa3,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oDM" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_cee"
@@ -78235,6 +78911,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"oFc" = (
+/obj/structure/flora/small/trailrocka5,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/machinery/light/small,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oFd" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -79324,6 +80006,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"oPQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/sugarcaneseed,
+/obj/item/seeds/sugarcaneseed,
+/obj/item/tool/hatchet,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oPX" = (
 /obj/machinery/dnaforensics,
 /turf/simulated/floor/tiled/white,
@@ -79725,6 +80415,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"oTy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/tomatoseed,
+/obj/item/seeds/tomatoseed,
+/obj/item/seeds/berryseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oTM" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -79783,17 +80481,15 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "oUB" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/gloves/goldenring,
+/obj/item/stack/ore/gold/small,
+/obj/item/stack/ore/gold/small,
+/obj/item/stack/ore/gold/small,
+/obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/sleeper)
+/turf/simulated/floor/industrial/ornate,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oUJ" = (
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -80224,6 +80920,11 @@
 	icon_state = "11,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"oYT" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/turf/simulated/floor/rock,
+/area/colony)
 "oYX" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/structure/disposalpipe/segment{
@@ -80238,6 +80939,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"oZl" = (
+/obj/structure/sign/plaque/roundplaquegold{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "oZm" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/item/device/lighting/toggleable/lantern,
@@ -80617,17 +81326,11 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
 "pdf" = (
-/obj/effect/floor_decal/industrial/loading/white,
-/obj/effect/floor_decal/industrial/box/white/corners,
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/medical/sleeper)
+/obj/structure/closet/random_spareparts,
+/obj/random/rations/low_chance,
+/obj/random/rations/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "pdg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -80767,6 +81470,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
+"peG" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/checker_large,
+/area/colony)
 "peL" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/vending/wallmed/lobby{
@@ -81144,6 +81852,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"pie" = (
+/obj/structure/flora/small/lavarock2,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "pij" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/bricks,
@@ -81553,10 +82266,11 @@
 /turf/simulated/floor/industrial/sierra,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "pmA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/industrial/blue_slates,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/obj/structure/flora/ausbushes/reedbush,
+/obj/effect/decal/cleanable/rubble,
+/obj/random/boxes/low_chance,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "pmC" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white/monofloor,
@@ -81897,6 +82611,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"ppt" = (
+/obj/structure/flora/small/trailrockb5,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "ppv" = (
 /obj/machinery/light,
 /obj/structure/catwalk,
@@ -82101,6 +82819,11 @@
 	},
 /turf/simulated/mineral,
 /area/nadezhda/outside/scave)
+"prK" = (
+/obj/item/stack/rods/random,
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "prM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -82297,14 +83020,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/sec)
 "ptI" = (
-/obj/structure/boulder,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/effect/decal/cleanable/rubble,
+/obj/random/junk/low_chance,
+/obj/structure/flora/small/rock5,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ptL" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/floor_decal/industrial/warningred,
@@ -82655,6 +83376,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"pwr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/cornseed,
+/obj/item/seeds/cornseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "pww" = (
 /obj/structure/catwalk,
 /obj/random/mob/spiders,
@@ -82693,10 +83421,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "pwY" = (
@@ -83589,16 +84317,18 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "pGp" = (
-/obj/structure/closet/secure_closet/reinforced/CMO,
-/obj/item/pc_part/drive/disk/design/medical/cmo,
-/obj/machinery/newscaster{
-	dir = 4;
-	pixel_x = 30
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/tool/baton,
-/obj/item/reagent_containers/enricher,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/sleeper)
 "pGq" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags,
@@ -83735,6 +84465,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/office)
+"pHM" = (
+/obj/structure/flora/small/trailrockb5,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "pHN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/office/light{
@@ -83820,6 +84554,10 @@
 "pIF" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/hallways)
+"pIG" = (
+/obj/structure/flora/small/trailrocka3,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "pIH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -84181,6 +84919,11 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"pMk" = (
+/obj/structure/boulder,
+/obj/structure/table/steel,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "pMl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -84213,6 +84956,16 @@
 "pMx" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"pMC" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/item/trash/cigbutt/khi,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "pMM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -84397,14 +85150,10 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/genetics)
 "pOd" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random/traps/wire_splicing/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures/low_chance,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "pOf" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/bushb1,
@@ -85925,6 +86674,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"qbl" = (
+/obj/random/junk/low_chance,
+/obj/structure/flora/small/rock4,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "qbm" = (
 /obj/structure/cardboardbox,
 /obj/machinery/alarm{
@@ -86452,6 +87206,10 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/industrial/white_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"qfS" = (
+/obj/machinery/door/airlock/maintenance_common,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "qfU" = (
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -86463,6 +87221,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "qgc" = (
@@ -86632,6 +87391,12 @@
 /mob/living/simple/frog,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qhX" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/card_carp/kingfisher,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "qif" = (
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -86963,6 +87728,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"qlf" = (
+/obj/structure/flora/small/lavarock1,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "qlg" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "1,8"
@@ -87463,6 +88233,10 @@
 	name = "Service Maintenance";
 	req_access = list(12)
 	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
+"qpF" = (
+/obj/structure/grille,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "qpM" = (
@@ -88384,19 +89158,10 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
 "qyv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/industrial/grey_slates_long,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/table/rack/shelf,
+/obj/random/gun_handmade/willspawn,
+/turf/simulated/floor/rock,
+/area/colony)
 "qyw" = (
 /obj/structure/flora/small/grassa3,
 /obj/structure/flora/big/bush2,
@@ -88922,17 +89687,10 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/command/gmaster)
 "qDS" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/grille,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor1west)
 "qDV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -89623,6 +90381,10 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
+"qKL" = (
+/obj/structure/flora/rock/variant1,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "qKT" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint,
@@ -89909,6 +90671,11 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
+"qNX" = (
+/obj/item/tool/pickaxe/drill,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "qNY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91045,16 +91812,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "qZO" = (
 /obj/structure/low_wall,
@@ -92008,6 +92773,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/crew_quarters/toilet/public)
+"riI" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/checker_large,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "riM" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -92021,15 +92790,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rjr" = (
-/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/turf/simulated/floor/rock,
+/area/colony)
 "rjt" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio8";
@@ -92442,6 +93206,10 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"rmU" = (
+/obj/item/stack/ore/glass/dust,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "rmX" = (
 /obj/structure/bed/chair,
 /obj/machinery/alarm{
@@ -92464,13 +93232,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "rns" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy_corner"
-	},
-/obj/item/reagent_containers/snacks/meat/runtimes_dinner,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/machinery/microwave/burnbarrel,
+/obj/item/reagent_containers/snacks/meat/monkey,
+/obj/item/reagent_containers/snacks/meat/monkey,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "rny" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -93959,6 +94726,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/security/nuke_storage)
+"rCM" = (
+/obj/structure/flora/small/grassb2,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "rCQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -94128,6 +94899,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/fancy_slates,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"rEO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "rEP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/book/manual/fiction/warandpeace,
@@ -94583,6 +95358,10 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"rJN" = (
+/obj/structure/flora/rock,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "rJR" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -95101,6 +95880,20 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"rOh" = (
+/obj/structure/closet/secure_closet/freezer/blood{
+	name = "secure blood fridge";
+	req_access = list(45)
+	},
+/obj/item/storage/freezer,
+/obj/item/reagent_containers/blood/OPlus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/BPlus,
+/obj/item/reagent_containers/blood/BMinus,
+/obj/item/reagent_containers/blood/APlus,
+/obj/item/reagent_containers/blood/AMinus,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/medical/sleeper)
 "rOs" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/regular,
@@ -95941,6 +96734,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/grey_slates,
 /area/colony)
+"rWw" = (
+/obj/random/junk/low_chance,
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "rWI" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -97871,6 +98669,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"soa" = (
+/obj/effect/spider/stickyweb,
+/obj/structure/spider_nest,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "soj" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -98210,6 +99015,10 @@
 /obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/industrial/cafe_large,
 /area/nadezhda/maintenance/surfaceeast)
+"srb" = (
+/obj/item/reagent_containers/snacks/meat/runtimes_dinner,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "srf" = (
 /obj/machinery/light{
 	dir = 4
@@ -99369,7 +100178,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "sBa" = (
 /obj/machinery/vending/cola,
@@ -100257,6 +101066,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
+"sKN" = (
+/obj/item/remains/deer,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock,
+/area/colony)
 "sKZ" = (
 /obj/structure/table,
 /obj/item/material/shard,
@@ -100884,6 +101699,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"sQE" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/beach/water/jungledeep{
+	desc = "Filthy, stinking bilge water.";
+	name = "murky water"
+	},
+/area/nadezhda/maintenance/undergroundfloor1west)
 "sQG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -100911,6 +101736,15 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/crew_quarters/toilet/public)
+"sRg" = (
+/obj/structure/table/bench/marble,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/flora/small/trailrocka5,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "sRi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -101081,6 +101915,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"sTv" = (
+/obj/structure/table/steel,
+/obj/random/handmade_tool,
+/obj/item/tool_upgrade/reinforcement/heatsink,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "sTy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
@@ -101183,8 +102024,10 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "sUv" = (
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/laptop/preset/records,
+/obj/effect/floor_decal/spline/wood{
+	dir = 8
+	},
+/obj/structure/coatrack,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "sUw" = (
@@ -102302,6 +103145,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"tfN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "tfP" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -102415,6 +103263,12 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/command/captain)
+"thh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/scrap/medical/large,
+/obj/random/mob/roaches,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "thj" = (
 /obj/item/stool,
 /obj/machinery/light/small{
@@ -103054,11 +103908,6 @@
 "tnI" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tnO" = (
@@ -103369,6 +104218,7 @@
 	})
 "tqH" = (
 /obj/structure/table/standard,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
 "tqK" = (
@@ -104613,11 +105463,6 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
 "tCG" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mecha/damaged/low_chance,
 /turf/simulated/floor/industrial/grey_slates_long,
@@ -104655,6 +105500,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tCV" = (
+/obj/structure/table/rack/shelf,
+/obj/random/tool,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "tCY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/blue_slates_long,
@@ -105446,7 +106299,7 @@
 /area/nadezhda/engineering/atmos/surface)
 "tJu" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
@@ -105475,6 +106328,11 @@
 "tJI" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/smc/quarters)
+"tJJ" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "tJQ" = (
 /obj/structure/multiz/stairs/active,
 /obj/structure/window/reinforced{
@@ -105545,6 +106403,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain,
+/obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/beach/water/jungledeep{
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
@@ -105777,11 +106636,6 @@
 "tNa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -106005,6 +106859,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate)
+"tOZ" = (
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "tPc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -106193,13 +107050,9 @@
 /area/nadezhda/dungeon/outside/farm)
 "tQg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/industrial/grey_slates_long,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/scrap/medical,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "tQk" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -106285,6 +107138,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
+"tQT" = (
+/obj/random/pack/rare,
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "tQY" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -106898,6 +107756,10 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
+"tXq" = (
+/obj/structure/flora/small/trailrocka1,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "tXu" = (
 /obj/random/mob/excelsior,
 /turf/simulated/floor/industrial/concrete_bricks,
@@ -107203,6 +108065,10 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"uac" = (
+/obj/structure/flora/small/trailrocka3,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "uae" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -107384,6 +108250,14 @@
 	icon_state = "7,10"
 	},
 /area/nadezhda/hallway/side/f2section1)
+"ubJ" = (
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/accessory/bracelet/watch/leather,
+/obj/item/clothing/gloves/dusters/silver,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/ornate,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "uca" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/computer/cryopod{
@@ -107583,6 +108457,13 @@
 "udz" = (
 /turf/simulated/mineral,
 /area/nadezhda/quartermaster/miningdock)
+"udD" = (
+/obj/structure/table/steel,
+/obj/random/tool/low_chance,
+/obj/item/tool_upgrade/reinforcement/rubbermesh,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "udG" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -107716,6 +108597,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"ueR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/hydro_tray_plant_bag_water,
+/obj/item/hydro_tray_plant_bag_water,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "ueX" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -108046,8 +108934,7 @@
 /obj/random/melee/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -108621,6 +109508,11 @@
 	layer = 1
 	},
 /area/nadezhda/crew_quarters/arcade)
+"ump" = (
+/obj/item/stack/cement_bag/five,
+/obj/item/tool_upgrade/reinforcement/stick,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "umv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -108656,6 +109548,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/sleeper)
+"umF" = (
+/obj/random/structures/low_chance,
+/turf/simulated/floor/industrial/checker_large,
+/area/colony)
 "umI" = (
 /obj/structure/curtain/open/privacy,
 /obj/structure/girder,
@@ -108845,7 +109741,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/sleeper)
 "uou" = (
@@ -108900,6 +109795,13 @@
 /obj/landmark/join/late/cyborg,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
+"uoR" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "uoU" = (
 /mob/living/simple/hostile/dino/tagilla,
 /turf/simulated/floor/wood/wild3,
@@ -109189,6 +110091,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"urW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "urZ" = (
 /obj/machinery/door/holy{
 	name = "Church"
@@ -109742,6 +110649,10 @@
 "uyN" = (
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"uyO" = (
+/obj/structure/boulder,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "uyQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -110274,6 +111185,14 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"uDV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "uEc" = (
 /obj/item/storage/backpack/clown,
 /obj/item/clothing/mask/costume/job/clown,
@@ -112484,18 +113403,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uXa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/sleeper)
+/obj/structure/table/bench/marble,
+/obj/structure/flora/small/trailrocka2,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "uXc" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -112523,6 +113434,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"uXA" = (
+/obj/item/stack/ore/coal/dust,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "uXC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -112793,13 +113708,10 @@
 /area/nadezhda/rnd/xenobiology)
 "vaj" = (
 /obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/box/red,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "vaq" = (
@@ -113753,14 +114665,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "vjp" = (
 /obj/machinery/power/smes/buildable{
@@ -114758,7 +115670,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "vsH" = (
 /obj/structure/multiz/stairs/enter/bottom{
@@ -115363,6 +116275,10 @@
 /obj/machinery/suit_storage_unit/engineering/atmos,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
+"vyq" = (
+/obj/random/junkfood/rotten/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "vyv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -115631,6 +116547,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/blue_slates_long,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"vBv" = (
+/obj/item/remains/mouse,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/rock,
+/area/colony)
 "vBE" = (
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /obj/structure/largecrate/animal/cow,
@@ -117600,6 +118522,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"vTL" = (
+/obj/structure/boulder,
+/obj/structure/flora/small/lavarock1,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "vTN" = (
 /obj/machinery/light{
 	dir = 4
@@ -118277,6 +119204,13 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"vYJ" = (
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/gloves/dusters/gold,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/ornate,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "vYM" = (
 /obj/machinery/hologram/holopad,
 /obj/item/contraband/poster/placed/generic/no_erp{
@@ -118515,6 +119449,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/security/maingate)
+"wbh" = (
+/obj/structure/safe,
+/obj/item/stack/material/diamond/random,
+/obj/item/stack/material/gold/random,
+/obj/item/stack/material/silver/random,
+/obj/item/stack/material/silver/random,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/ornate,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "wbl" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -120723,6 +121667,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"wvw" = (
+/obj/machinery/door/airlock/glass,
+/obj/item/device/assembly/mousetrap/armed,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "wvy" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -121192,10 +122141,10 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "wAm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/industrial/bricks,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/machinery/door/blast/shutters,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/industrial/sierra,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "wAo" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -121983,6 +122932,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/vectorrooms)
+"wIN" = (
+/obj/structure/table/steel,
+/obj/random/gun_parts/low,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/clarissa/preloaded,
+/turf/simulated/floor/industrial/white_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "wIQ" = (
 /obj/structure/table/standard,
 /obj/random/pack/tech_loot,
@@ -122129,6 +123085,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
+"wJG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "wJP" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/beach/sand,
@@ -122634,6 +123595,9 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"wOP" = (
+/turf/simulated/wall,
+/area/nadezhda/medical/morgue)
 "wOV" = (
 /obj/structure/flora/small/trailrockb4,
 /turf/simulated/floor/rock,
@@ -122835,6 +123799,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"wQk" = (
+/obj/item/stack/cement_bag/five,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "wQn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -123058,12 +124026,10 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "wSS" = (
-/obj/structure/coatrack,
-/obj/effect/floor_decal/spline/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/random/mob/termite_no_despawn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "wST" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -123258,10 +124224,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "wVa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/industrial/grey_slates_long,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -123599,6 +124565,10 @@
 /obj/machinery/vending/neko,
 /turf/simulated/floor/industrial/ceramic,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"wYs" = (
+/obj/structure/flora/small/lavarock2,
+/turf/simulated/floor/asteroid/dirt/mud,
+/area/colony)
 "wYy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -124019,6 +124989,11 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
+"xdm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "xdw" = (
 /obj/item/contraband/poster/placed/generic/high_class_martini,
 /turf/simulated/wall,
@@ -124472,8 +125447,7 @@
 /area/nadezhda/maintenance/undergroundfloor2east)
 "xib" = (
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacesec)
@@ -124912,15 +125886,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -124928,7 +125893,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "xmf" = (
 /obj/structure/disposalpipe/segment{
@@ -124979,6 +125949,12 @@
 "xmQ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/surfaceeast)
+"xmW" = (
+/obj/item/modular_computer/console/preset/medical/monitor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/colony)
 "xmY" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -125273,15 +126249,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "xpJ" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/item/remains/lizard,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/turf/simulated/floor/rock,
+/area/colony)
 "xpO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/random_milsupply,
@@ -125322,6 +126294,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"xqD" = (
+/obj/item/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/machinery/button/windowtint{
+	dir = 8;
+	id = "CBO";
+	pixel_x = 22;
+	pixel_y = 9;
+	range = 6
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/colony)
 "xqH" = (
 /obj/structure/flora/small/grassb5,
 /obj/structure/flora/small/bushb2,
@@ -125376,12 +126361,9 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "xrn" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/ceramic,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/obj/random/pack/junk_machine,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "xro" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "13,15"
@@ -125470,12 +126452,6 @@
 /obj/item/mine/excelsior{
 	armed = 1
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xrT" = (
@@ -125626,6 +126602,10 @@
 /obj/random/mecha_equipment/low_chance,
 /turf/simulated/floor/industrial/checker_large,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"xtp" = (
+/obj/item/tool_upgrade/reinforcement/plating,
+/turf/simulated/wall,
+/area/colony)
 "xty" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -126608,6 +127588,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"xCm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/seeds/whitebeetseed,
+/obj/item/seeds/whitebeetseed,
+/obj/item/reagent_containers/glass/plastic_jug,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "xCn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -127636,14 +128624,10 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "xLq" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/barricade,
+/obj/item/stack/ore/glass/dust,
+/turf/simulated/floor/asteroid/dirt,
+/area/colony)
 "xLr" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/random/flora/small_jungle_tree,
@@ -127843,6 +128827,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/green_large_slates,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"xNE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/spiders/low_chance,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "xNG" = (
 /obj/structure/closet/wardrobe/misc/pjs,
 /obj/item/clothing/under/medigown,
@@ -129562,17 +130551,18 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "yeQ" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/sleeper)
+/obj/structure/table/standard,
+/obj/random/medical_lowcost_handmade,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lathe_disk/low_chance,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
+"yeR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/industrial/fancy_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "yeS" = (
 /obj/structure/table/standard,
 /obj/random/toolbox,
@@ -129652,9 +130642,12 @@
 /area/nadezhda/rnd/docking)
 "yfP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/obj/structure/table/rack/shelf,
+/obj/item/seeds/grapeseed,
+/obj/item/seeds/grapeseed,
+/obj/item/seeds/cabbageseed,
+/turf/simulated/floor/industrial/black_large_slates,
+/area/nadezhda/maintenance/undergroundfloor1west)
 "yfR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/external{
@@ -129913,6 +130906,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"yjr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "yjw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4;
@@ -132088,9 +133086,9 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
+gaP
+kUx
+kUx
 cZb
 cZb
 cZb
@@ -132288,11 +133286,11 @@ aME
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+aui
+ofd
+xLq
+xtp
+kUx
 cZb
 cZb
 cZb
@@ -132489,13 +133487,13 @@ aTa
 kCS
 rhy
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+gxZ
+jRY
+pHM
+mhU
+dat
+dat
+dat
 cZb
 cZb
 cZb
@@ -132664,13 +133662,13 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+bbA
+bbA
+bbA
+bbA
+bbA
+bbA
+bbA
 cZb
 cZb
 cZb
@@ -132691,13 +133689,13 @@ jum
 jum
 rhy
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+dvJ
+tOZ
+aJC
+rmU
+pIG
+wYs
+ezo
 cZb
 cZb
 cZb
@@ -132866,13 +133864,13 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+bbA
+oUB
+lSX
+ubJ
+vYJ
+wbh
+bbA
 cZb
 cZb
 cZb
@@ -132893,14 +133891,14 @@ aYy
 hyw
 toi
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+bkD
+cfE
+tOZ
+bIN
+hgJ
+iBJ
+eXU
+tQT
 cZb
 cZb
 cZb
@@ -133068,20 +134066,20 @@ cZb
 cZb
 cZb
 cZb
+bbA
+hjm
+mAA
+hjm
+mAA
+hjm
+bbA
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+hoH
+wVa
+qhX
+xrn
+pmA
+hoH
 cZb
 cZb
 eQa
@@ -133096,17 +134094,17 @@ otG
 toi
 cZb
 cZb
+vTL
+iBJ
+dat
+gaP
+gaP
+gzn
+aME
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+lIt
+lIt
+lIt
 cZb
 cZb
 cZb
@@ -133268,23 +134266,23 @@ cZb
 cZb
 cZb
 cZb
+wwo
 cZb
+bbA
+bbA
+bsm
+bbA
+bbA
+lxP
+bbA
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+nkn
+oyN
+rWw
+aQQ
+crx
+wVa
+wVa
 cZb
 toi
 epW
@@ -133299,17 +134297,17 @@ toi
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+tXq
+dat
+kUx
+kUx
+gMa
+ppt
+aME
+aME
+lIt
+lIt
+lIt
 cZb
 cZb
 cZb
@@ -133332,7 +134330,7 @@ toi
 toi
 toi
 toi
-toi
+cZb
 cZb
 cZb
 cZb
@@ -133468,25 +134466,25 @@ toi
 cZb
 cZb
 cZb
+wwo
+urW
+pMC
 cZb
+bbA
+kBQ
+qKu
+jTY
+dtT
+keh
+bbA
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+jma
+nGx
+rCM
+toi
+fVq
+ptI
+wVa
 cZb
 toi
 mvC
@@ -133501,17 +134499,17 @@ toi
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+tOZ
+dat
+kUx
+kUx
+dat
+tOZ
+nqC
+aME
+lIt
+lIt
+lIt
 rtR
 cZb
 cZb
@@ -133529,12 +134527,12 @@ qpC
 eQw
 gLJ
 pwb
+gLJ
+gLJ
 pwb
 gLJ
-gLJ
-vpP
-lUO
 toi
+cZb
 cZb
 cZb
 cZb
@@ -133668,27 +134666,27 @@ tpN
 voK
 qgN
 wwo
+kUx
+pMk
+urW
+lHw
+hjN
 cZb
+bbA
+cnt
+xNE
+qKu
+wAm
+osg
+bbA
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+jxC
+eaK
+uXa
+sRg
+ntr
+qbl
+mAO
 cZb
 toi
 ukJ
@@ -133702,16 +134700,16 @@ toi
 cZb
 cZb
 cZb
+rJN
+tOZ
+mhU
+gaP
+gaP
+gaP
+aJC
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+lIt
+lIt
 rhy
 pKS
 jum
@@ -133732,11 +134730,11 @@ dIu
 toi
 toi
 toi
-toi
-rfU
 gLJ
-vqG
+vpP
+lUO
 toi
+cZb
 cZb
 cZb
 cZb
@@ -133871,26 +134869,26 @@ voK
 qyc
 qyc
 toi
+nAQ
+iji
+nho
+mhq
 cZb
+bbA
+cnt
+fhE
+oZl
+bbA
+lxP
+bbA
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+dqE
+vyq
+mRY
+auc
+hjb
+rWw
+jFV
 cZb
 toi
 toi
@@ -133903,14 +134901,14 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+prK
+tXq
+uXA
+hgJ
+uac
+jRY
+eBU
+gxZ
 cZb
 cZb
 cZb
@@ -133934,11 +134932,11 @@ cUT
 oFI
 oFI
 toi
-toi
-emX
+rfU
 gLJ
-ssN
+vqG
 toi
+cZb
 cZb
 cZb
 cZb
@@ -134073,26 +135071,26 @@ hoH
 qyc
 qyc
 toi
+ehu
+wIN
+ehu
+nho
 cZb
+bbA
+cgc
+qKu
+fhE
+nUP
+soa
+bbA
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+pie
+ntv
+gAC
+gAC
+jum
+fVq
+cMs
 cZb
 cZb
 cZb
@@ -134102,16 +135100,16 @@ qPD
 aKR
 toi
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+lSt
+iBJ
+iDG
+tOZ
+mFD
+eBU
+gaP
+gaP
+xLq
+gaP
 cZb
 cZb
 cZb
@@ -134136,11 +135134,11 @@ baG
 xvH
 lyK
 toi
-toi
-xGq
+emX
 gLJ
 ssN
 toi
+cZb
 cZb
 cZb
 cZb
@@ -134275,44 +135273,44 @@ cha
 qyc
 sLQ
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+fbV
+fbV
+fbV
+mWC
+toi
+bbA
+qDS
+nTU
+nTU
+qDS
+bbA
+bbA
+toi
+hyw
+wvw
+hyw
+hyw
+hyw
+hyw
+hyw
+toi
+toi
+toi
 toi
 aNf
 qPD
-fbO
+gMl
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ozk
+ozk
+hjl
+wJG
+ozk
+lGM
+uac
+mhU
+xtp
+kUx
 cZb
 cZb
 cZb
@@ -134338,11 +135336,11 @@ tdD
 uKq
 den
 toi
-toi
-oxg
-oxg
+xGq
+gLJ
 ssN
 hlV
+cZb
 cZb
 cZb
 cZb
@@ -134476,45 +135474,45 @@ cha
 rRg
 qyc
 tOb
-toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-toi
-fby
+qfS
+tVT
+tVT
+jMe
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+jNm
+rDb
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+tVT
+qfS
+lte
 syv
-fjM
-toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+fbO
+qfS
+qPD
+cpH
+qPD
+lFZ
+wJG
+aJC
+hgJ
+xLq
+kUx
+kUx
 cZb
 cZb
 cZb
@@ -134540,11 +135538,11 @@ tdD
 iey
 cQJ
 toi
+oxg
+oxg
+ssN
 toi
-toi
-toi
-toi
-toi
+cZb
 cZb
 cZb
 cZb
@@ -134574,7 +135572,7 @@ dkh
 eXB
 nJN
 nJN
-jRY
+rbC
 eEL
 cZb
 tad
@@ -134678,43 +135676,43 @@ wne
 tVT
 jQp
 qyc
-toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-toi
-toi
+qfS
+tVT
+tVT
+qcY
+tVT
+tVT
+tVT
+tVT
+qcY
+tVT
+tVT
+tVT
+qcY
+tVT
+tVT
+tVT
+tVT
+tVT
+jNm
+qcY
+tVT
+tVT
+tVT
+tVT
+qfS
+lte
 syv
 fbO
-toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+qfS
+qPD
+qPD
+qNX
+oCO
+wJG
+hgJ
+eBU
+gaP
 cZb
 cZb
 cZb
@@ -134881,10 +135879,10 @@ gfF
 tVT
 tVT
 toi
-cZb
-cZb
-cZb
-cZb
+hyw
+hyw
+hyw
+mWC
 toi
 toi
 toi
@@ -134893,30 +135891,30 @@ toi
 toi
 toi
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+hyw
+hyw
+aUN
+hyw
 toi
+toi
+toi
+toi
+toi
+toi
+toi
+toi
+fby
 qPD
 fbO
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+ozk
+ozk
+wJG
+wJG
+ozk
+fvS
+pdf
+imG
 cZb
 cZb
 cZb
@@ -134947,7 +135945,7 @@ cUT
 vDw
 vYG
 toi
-toi
+cZb
 cZb
 cZb
 cZb
@@ -135083,10 +136081,10 @@ toi
 tVT
 tVT
 toi
-cZb
-cZb
-cZb
-cZb
+gpq
+qyc
+udD
+wSS
 toi
 nFA
 det
@@ -135095,26 +136093,26 @@ maO
 sQz
 prT
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+uDV
+qyc
+qyc
+hpL
+hyw
+aki
+jrV
+uyO
+hoH
+hoH
+hoH
 toi
+fby
 qPD
 fbO
 toi
 cZb
-cZb
-cZb
-cZb
+qKL
+ump
+wQk
 cZb
 cZb
 cZb
@@ -135149,7 +136147,7 @@ rkB
 iam
 lyK
 toi
-toi
+cZb
 cZb
 cZb
 cZb
@@ -135285,10 +136283,10 @@ toi
 tVT
 jNm
 toi
-cZb
-cZb
-cZb
-cZb
+tCV
+qyc
+dky
+qyc
 toi
 rPC
 det
@@ -135297,18 +136295,18 @@ qdu
 sQz
 mcc
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+mQY
+qyc
+qyc
+iVH
+hyw
+lQO
+fvl
+oFc
+toi
+hoH
+hoH
+toi
 toi
 qww
 bct
@@ -135351,7 +136349,7 @@ fbB
 vDw
 uab
 toi
-toi
+cZb
 cZb
 cZb
 cZb
@@ -135487,10 +136485,10 @@ toi
 tVT
 tDE
 toi
-cZb
-cZb
-cZb
-cZb
+gaq
+bmB
+sTv
+tOb
 toi
 gRG
 upE
@@ -135499,18 +136497,18 @@ upE
 upE
 mCK
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-aME
-cZb
-cZb
-cZb
+oTy
+qyc
+qyc
+cYs
+hyw
+neR
+qlf
+azd
+uyO
+hoH
+hoH
+hoH
 toi
 qPD
 fbO
@@ -135689,10 +136687,10 @@ toi
 tVT
 tVT
 toi
-cZb
-cZb
-cZb
-cZb
+mNX
+qyc
+dky
+qyc
 toi
 mEW
 upE
@@ -135701,18 +136699,18 @@ upE
 upE
 vfh
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-aME
+nFi
+qyc
+qyc
+xCm
+hyw
+hLU
+ivW
+ogL
 bWx
 lbN
-kUx
-cZb
+toi
+hoH
 toi
 qPD
 fbO
@@ -135891,10 +136889,10 @@ toi
 lFT
 tVT
 toi
-cZb
-cZb
-cZb
-cZb
+uoR
+wSS
+qyc
+cSW
 toi
 mEW
 upE
@@ -135903,18 +136901,18 @@ upE
 upE
 jPO
 toi
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-aME
+uDV
+qyc
+qyc
+hpL
+hyw
+oDG
+dQa
 tHv
 rwZ
 vKr
-cZb
-cZb
+hoH
+hoH
 toi
 eyo
 cpX
@@ -136105,10 +137103,10 @@ ltj
 ltj
 toi
 toi
-cZb
-cZb
-cZb
-cZb
+ueR
+hlQ
+ofv
+cZX
 toi
 toi
 paC
@@ -136307,10 +137305,10 @@ tzM
 nAl
 nAl
 toi
-cZb
-cZb
-cZb
-cZb
+fPS
+qyc
+qyc
+qyc
 toi
 rmj
 tPd
@@ -136484,7 +137482,7 @@ cZb
 cZb
 cZb
 xBz
-gnX
+mqx
 rNf
 gnX
 vCf
@@ -136509,10 +137507,10 @@ qyc
 ddC
 lMd
 toi
-cZb
-cZb
-cZb
-cZb
+aSC
+qyc
+oPQ
+qyc
 toi
 oEk
 xYY
@@ -136711,10 +137709,10 @@ bgB
 bgB
 etY
 toi
-cZb
-cZb
-cZb
-cZb
+bCt
+qyc
+yfP
+xdm
 cTR
 rmj
 xYY
@@ -136913,10 +137911,10 @@ qyc
 pZu
 nAl
 toi
-cZb
-cZb
-cZb
-cZb
+kdc
+qyc
+pwr
+qyc
 toi
 rmj
 xYY
@@ -137295,7 +138293,7 @@ ePg
 gHu
 gnX
 awh
-uCO
+joo
 vCf
 tVT
 toi
@@ -137339,9 +138337,9 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
+oYT
+hoJ
+qyv
 cZb
 toi
 brA
@@ -137538,12 +138536,12 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+aQk
+adQ
+fvF
+xpJ
+rEO
+bqy
 cZb
 toi
 iRW
@@ -137740,14 +138738,14 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-toi
+icm
+rns
+dDj
+rEO
+rEO
+rEO
+rjr
+qpF
 iRW
 wCl
 xyx
@@ -137943,13 +138941,13 @@ cZb
 cZb
 cZb
 cZb
+bmI
+fli
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-toi
+rEO
+rjr
+eaP
 iRW
 wCl
 gxE
@@ -138149,9 +139147,9 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-toi
+sKN
+vBv
+tJJ
 iRW
 wCl
 xyx
@@ -139111,7 +140109,7 @@ tQY
 awh
 jas
 hcb
-gnX
+mqx
 aYA
 uyo
 wwo
@@ -139310,7 +140308,7 @@ cZb
 cZb
 cZb
 cZb
-anK
+sQE
 awh
 gnX
 awh
@@ -142950,7 +143948,7 @@ dpT
 uyF
 bVu
 roZ
-hpL
+bVu
 uyF
 cZb
 cZb
@@ -145188,7 +146186,7 @@ cZb
 cZb
 uyF
 uyF
-ptI
+rDo
 fgl
 fgl
 abl
@@ -145239,11 +146237,11 @@ qUI
 qUI
 cZb
 cZb
-wGH
-wGH
-wGH
-wGH
-wGH
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -145390,7 +146388,7 @@ cZb
 cZb
 uyF
 lrA
-dat
+vtI
 rDo
 arU
 cZb
@@ -145440,13 +146438,13 @@ fkD
 jMh
 qUI
 cZb
+cZb
 wGH
 wGH
 wGH
 wGH
 wGH
-wGH
-wGH
+cZb
 cZb
 cZb
 tad
@@ -145592,7 +146590,7 @@ cZb
 cZb
 uyF
 uWV
-nFR
+she
 ony
 uyF
 cZb
@@ -145642,13 +146640,13 @@ gQZ
 qYr
 qUI
 cZb
-wGH
+cZb
 wGH
 ils
 qFE
 vHl
 wGH
-wGH
+cZb
 cZb
 cZb
 tad
@@ -145794,7 +146792,7 @@ cZb
 cZb
 uyF
 uWV
-nFR
+she
 lrA
 uyF
 cZb
@@ -145844,15 +146842,15 @@ vby
 qUI
 qUI
 cZb
-wGH
+cZb
 wGH
 noB
 tqK
 tUN
 wGH
-wGH
-wGH
-wGH
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -145996,7 +146994,7 @@ uyF
 cZb
 uyF
 she
-nFR
+eKr
 lrA
 uyF
 cZb
@@ -146044,18 +147042,18 @@ bYI
 bYI
 qUI
 qUI
-wGH
-wGH
-wGH
+cZb
+cZb
+cZb
 wGH
 wGH
 cVw
-hfp
-hfp
-hfp
-hfp
-hfp
 wGH
+wGH
+wGH
+wGH
+wGH
+cZb
 cZb
 cZb
 cZb
@@ -146198,7 +147196,7 @@ uyF
 uyF
 uyF
 she
-rjr
+she
 oBo
 uyF
 cZb
@@ -146256,8 +147254,8 @@ bFY
 gWK
 hLi
 kws
-hfp
 wGH
+cZb
 cZb
 cZb
 cZb
@@ -146400,7 +147398,7 @@ vtB
 skV
 crI
 eKr
-dky
+she
 lrA
 uyF
 cZb
@@ -146458,8 +147456,8 @@ bvj
 hlr
 kws
 lCy
-hfp
 wGH
+cZb
 cZb
 cZb
 cZb
@@ -146602,7 +147600,7 @@ skV
 crI
 cFd
 she
-qDS
+she
 uyF
 uyF
 cZb
@@ -146660,8 +147658,8 @@ bFY
 iJu
 dED
 kws
-hfp
 wGH
+cZb
 cZb
 cZb
 cZb
@@ -146804,7 +147802,7 @@ arU
 uyF
 uyF
 she
-nFR
+she
 uyF
 cZb
 cZb
@@ -146858,12 +147856,12 @@ qXJ
 wGH
 nCu
 nrg
-hfp
-hfp
-hfp
-hfp
-hfp
 wGH
+wGH
+wGH
+wGH
+wGH
+cZb
 rGU
 cZb
 cZb
@@ -147006,7 +148004,7 @@ arU
 arU
 uyF
 uWV
-nFR
+eKr
 uyF
 cZb
 cZb
@@ -147064,8 +148062,8 @@ bFY
 gWK
 kws
 urG
-hfp
 wGH
+cZb
 sYJ
 xSO
 sYJ
@@ -147208,7 +148206,7 @@ arU
 arU
 uyF
 uWV
-nFR
+she
 uyF
 cZb
 cZb
@@ -147266,8 +148264,8 @@ qNz
 mMf
 kws
 lCy
-hfp
 wGH
+cZb
 cZb
 sYJ
 efb
@@ -147410,7 +148408,7 @@ arU
 arU
 uyF
 oBo
-nFR
+she
 uyF
 cZb
 cZb
@@ -147468,8 +148466,8 @@ bFY
 iJu
 dED
 kws
-hfp
 wGH
+cZb
 gga
 cOg
 sYJ
@@ -147666,12 +148664,12 @@ sRJ
 wGH
 huv
 nrg
-hfp
-hfp
-hfp
-hfp
-hfp
 wGH
+wGH
+wGH
+wGH
+wGH
+cZb
 rGU
 dxp
 sYJ
@@ -147814,7 +148812,7 @@ arU
 arU
 uyF
 uRM
-whp
+qDY
 uyF
 cZb
 cZb
@@ -147872,8 +148870,8 @@ bFY
 gWK
 kws
 kws
-hfp
 wGH
+cZb
 cZb
 sYJ
 sYJ
@@ -148016,7 +149014,7 @@ arU
 arU
 uyF
 qDY
-whp
+qDY
 uyF
 cZb
 cZb
@@ -148060,7 +149058,7 @@ vTT
 nzG
 cWX
 qUI
-cZb
+oaw
 sRJ
 wRa
 gvo
@@ -148074,8 +149072,8 @@ ved
 mMf
 kws
 lCy
-hfp
 wGH
+cZb
 cZb
 sYJ
 trv
@@ -148218,7 +149216,7 @@ arU
 arU
 uyF
 qDY
-whp
+qDY
 uyF
 cZb
 cZb
@@ -148262,7 +149260,7 @@ qUI
 qUI
 qUI
 qUI
-cZb
+wOP
 sRJ
 sRJ
 sRJ
@@ -148276,8 +149274,8 @@ lNn
 iJu
 dED
 bhB
-hfp
 wGH
+cZb
 cZb
 rGU
 sYJ
@@ -148420,7 +149418,7 @@ xhA
 arU
 uyF
 qDY
-jMe
+uRM
 uyF
 cZb
 cZb
@@ -148457,29 +149455,29 @@ xLW
 syN
 teI
 ttd
-tqH
-qUI
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+crv
+oBU
+oBx
+oBx
+oBx
+oBx
+oBx
+lbj
+oBx
+oBx
+oBx
+oBx
+ePK
+wGH
+wGH
 wGH
 wGH
 wGH
 wGH
 hfp
-hfp
-hfp
-hfp
-hfp
 wGH
+wGH
+cZb
 cZb
 cZb
 cZb
@@ -148622,7 +149620,7 @@ xhA
 arU
 uyF
 qDY
-whp
+qDY
 uyF
 cZb
 cZb
@@ -148661,11 +149659,18 @@ uzs
 kSi
 tqH
 qUI
-ooI
-ooI
-ooI
-ooI
-ooI
+iHE
+oBx
+oBx
+maj
+yeQ
+kka
+ksh
+ksh
+oBx
+oBx
+oBx
+mcl
 cZb
 cZb
 cZb
@@ -148673,14 +149678,7 @@ cZb
 cZb
 cZb
 cZb
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
+cZb
 cZb
 cZb
 cZb
@@ -148824,7 +149822,7 @@ xhA
 arU
 uyF
 qDY
-whp
+qDY
 uyF
 cZb
 cZb
@@ -148863,23 +149861,23 @@ cTe
 goL
 cTe
 ooI
-wSS
-rns
-oxD
-kwl
-ooI
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
+oBx
+oBx
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
 cZb
 cZb
 cZb
@@ -149026,7 +150024,7 @@ xhA
 arU
 uyF
 esy
-whp
+qDY
 uyF
 cZb
 cZb
@@ -149065,29 +150063,29 @@ ldf
 ePq
 tXl
 ooI
-voL
-tjH
-cFI
-kwf
-buo
+ooI
+ooI
+ooI
+ooI
+ooI
+cZb
+kUx
+umF
+caX
+yjr
+oBx
+eXn
+tQg
+grI
+pOd
+pOd
+mcl
 cZb
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-saK
-saK
-saK
-saK
-saK
-cZb
-cZb
-cZb
-cZb
-cZb
-sYJ
+viV
 sYJ
 sYJ
 cZb
@@ -149228,7 +150226,7 @@ xhA
 arU
 uyF
 esy
-whp
+qDY
 uyF
 cZb
 cZb
@@ -149268,22 +150266,22 @@ qOg
 qUO
 vUu
 tJu
-dpy
-cFI
-qbm
+lcw
+oxD
+kwl
 ooI
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-saK
-izT
-nNi
-gPg
-saK
+kUx
+peG
+riI
+yjr
+oBx
+yeR
+tfN
+hQx
+tQg
+pOd
+mcl
 cZb
 cZb
 cZb
@@ -149430,7 +150428,7 @@ xhA
 arU
 uyF
 uRM
-whp
+qDY
 uyF
 kUx
 kUx
@@ -149469,23 +150467,23 @@ vPL
 nNE
 ukw
 ooI
-vCx
-knR
+voL
+tjH
 cFI
-cFI
-ooI
+kwf
+buo
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-saK
-xrn
-nNi
-vtu
-saK
+peG
+riI
+oBx
+oBx
+eXn
+bAe
+bAe
+grI
+thh
+mcl
 cZb
 cZb
 cZb
@@ -149632,7 +150630,7 @@ xhA
 arU
 uyF
 qDY
-whp
+qDY
 qDY
 vtI
 rDo
@@ -149672,22 +150670,22 @@ hRA
 uyM
 ooI
 sUv
-nav
-azd
-pGp
+dpy
+cFI
+qbm
 ooI
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-saK
-nNi
-nNi
-nNi
-saK
+peG
+riI
+oBx
+oBx
+mcl
+grI
+tQg
+grI
+jvq
+mcl
 cZb
 cZb
 cZb
@@ -149834,21 +150832,21 @@ xhA
 arU
 uyF
 qDY
-tQg
-oaw
-oaw
-cYs
-mqx
+qDY
+qDY
+qDY
+qhB
+vtI
 xrO
-cYs
-oaw
-ozk
-xLq
-xLq
-oaw
-pOd
-lIt
-mqx
+qhB
+qDY
+krV
+wXd
+wXd
+qDY
+sJn
+vtI
+vtI
 tNa
 xKB
 knm
@@ -149873,29 +150871,29 @@ aBH
 wkt
 wWw
 ooI
-ooI
-ooI
-ooI
-ooI
+vCx
+knR
+cFI
+srb
 ooI
 cZb
 cZb
-cZb
+nFR
+riI
+oBx
+oBx
 mcl
 mcl
 mcl
 mcl
-saK
-nqh
-nqh
-kDw
-saK
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
+mcl
 cZb
 cZb
 mcl
@@ -150051,7 +151049,7 @@ uyF
 uyF
 arU
 jho
-gaP
+ecX
 ecX
 wXd
 ecX
@@ -150075,14 +151073,17 @@ ooI
 ooI
 ooI
 ooI
+nbv
+xqD
+xmW
+lVO
+hLL
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+anW
+oBx
+oBx
 mcl
 cof
 oRs
@@ -150090,14 +151091,11 @@ uuM
 fyU
 kBV
 kBV
-kBV
+kDw
+nNi
+nav
+gPg
 mcl
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
 cZb
 cZb
 mcl
@@ -150255,10 +151253,10 @@ arU
 arU
 cWY
 tCG
-xpJ
-xpJ
-oaw
-qyv
+ecX
+ecX
+qDY
+whp
 qDY
 uyF
 cZb
@@ -150277,29 +151275,29 @@ cZb
 cZb
 cZb
 cZb
+hLL
+hLL
+hLL
+hLL
+hLL
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+qIn
 mcl
 mcl
+oBx
+oBx
 mcl
 fdo
 kBV
 kBV
 tup
-kBV
 uZN
 nlJ
+nqh
+nNi
+nNi
+vtu
 mcl
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
 cZb
 cZb
 mcl
@@ -150488,20 +151486,20 @@ cZb
 kGl
 mLO
 mcl
+oBx
+oBx
+mcl
 iGo
 xNw
 jyn
 fyU
-kBV
 uZN
 qPv
+nqh
+izT
+nNi
+nNi
 mcl
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
 cZb
 cZb
 mcl
@@ -150690,6 +151688,8 @@ kGl
 mLO
 hps
 mcl
+oBx
+nwq
 mcl
 mcl
 mcl
@@ -150702,10 +151702,8 @@ mcl
 mcl
 mcl
 mcl
+qIn
 mcl
-mcl
-kGl
-cZb
 mcl
 mcl
 mcl
@@ -153459,7 +154457,7 @@ arU
 uyF
 vtG
 oCZ
-yfP
+giu
 uyF
 uyF
 eQv
@@ -154493,7 +155491,7 @@ cZb
 cZb
 cZb
 uyF
-wAm
+pij
 lcE
 lcE
 ooF
@@ -158189,7 +159187,7 @@ mcl
 tCY
 tCY
 mcl
-pmA
+jtg
 bKJ
 bKJ
 wNq
@@ -158751,7 +159749,7 @@ eNS
 fHi
 mcl
 ivI
-eXn
+tpD
 sLV
 qeO
 nse
@@ -162420,7 +163418,7 @@ iKq
 syz
 mPx
 kOh
-wVa
+oBx
 oBx
 jqZ
 oQt
@@ -185005,7 +186003,6 @@ vLU
 fws
 iwW
 btQ
-kHv
 hgw
 umh
 bHF
@@ -185013,6 +186010,7 @@ umh
 umh
 bHF
 umh
+hgw
 vsF
 aDP
 cDr
@@ -185206,16 +186204,16 @@ djj
 iUG
 fws
 taH
-uXa
+vjl
 lYI
-oUB
 jbu
 yhO
 aUO
 aUO
 jbu
 jbu
-aJC
+kNT
+btQ
 dEn
 bbV
 doN
@@ -185408,16 +186406,16 @@ wAc
 vvQ
 fws
 gQj
-btQ
-kHv
+pwX
 umh
-pdf
+kDX
 gan
 pnj
 pnj
 gan
 hMF
-vjl
+umh
+btQ
 jGJ
 bbV
 iiN
@@ -185611,7 +186609,6 @@ rkC
 fws
 wOy
 btQ
-kHv
 umh
 tXH
 rlb
@@ -185619,6 +186616,7 @@ lEP
 lEP
 rlb
 tXH
+umh
 vjl
 mzv
 qUI
@@ -185813,14 +186811,14 @@ oJN
 fws
 pxV
 btQ
-kHv
 nie
 jEC
 jEC
 jEC
-jEC
-jEC
-jEC
+umh
+umh
+umh
+cjY
 qZJ
 oiB
 rJk
@@ -186014,8 +187012,7 @@ ntE
 pug
 duz
 sPZ
-btQ
-kHv
+pwX
 nie
 jEC
 jEC
@@ -186023,7 +187020,8 @@ dPj
 jEC
 jEC
 jEC
-qZJ
+fRb
+pGp
 uoq
 wdH
 fCT
@@ -186217,7 +187215,6 @@ bVo
 xUJ
 nWf
 lbQ
-kHv
 umh
 fxD
 rmk
@@ -186225,7 +187222,8 @@ lEP
 lEP
 rmk
 fxD
-vjl
+umh
+btQ
 qgb
 qUI
 qUI
@@ -186418,8 +187416,7 @@ lkQ
 mLo
 sVE
 xEp
-btQ
-kHv
+pwX
 umh
 aOs
 vAy
@@ -186427,7 +187424,8 @@ kpR
 kMG
 vAy
 hMF
-vjl
+umh
+btQ
 uMK
 qUI
 whO
@@ -186621,14 +187619,14 @@ uiH
 otc
 kHv
 pwX
-hgJ
-yeQ
+lYI
 jbu
 jbu
 aUO
 aUO
 jbu
 jbu
+kkx
 xmb
 dwK
 qUI
@@ -186823,14 +187821,14 @@ pWe
 bGf
 nUH
 byv
-kHv
 umh
+rOh
 fpz
 vaj
-caX
 jeN
 wMO
 isb
+umh
 sAV
 edG
 nal
@@ -187227,7 +188225,7 @@ mTl
 fws
 slp
 ckU
-kHv
+fjM
 ajq
 rTv
 amY

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -3999,6 +3999,11 @@
 	},
 /turf/simulated/floor/industrial/grey_slates,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"aNi" = (
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/sechall)
 "aNk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9163,6 +9168,7 @@
 "bKN" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "bKS" = (
@@ -10193,6 +10199,7 @@
 "bVT" = (
 /obj/machinery/light/small,
 /obj/item/stack/rods/random,
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/industrial/bricks,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -11573,6 +11580,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/industrial/blue_slates_long,
 /area/nadezhda/maintenance{
@@ -17135,6 +17145,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
 "dmZ" = (
@@ -18398,6 +18409,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "dyt" = (
@@ -20238,6 +20250,16 @@
 "dPU" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/robotics)
+"dPV" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/substation/science)
 "dPX" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -20710,6 +20732,7 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/sec)
 "dVn" = (
@@ -26490,6 +26513,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"eXn" = (
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/rock,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "eXo" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small,
@@ -36632,6 +36659,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "gSt" = (
@@ -38956,6 +38984,12 @@
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
+"hpL" = (
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/shuttle/floor/mining{
+	icon_state = "9,23"
+	},
+/area/nadezhda/maintenance/undergroundfloor1north)
 "hpN" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "11,17"
@@ -40645,11 +40679,8 @@
 	},
 /area/nadezhda/hallway/main/stairwell)
 "hFk" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/industrial/blue_slates_long,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/industrial/grey_slates_long,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
@@ -42920,6 +42951,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/hcases/parts/scrap/has_items_spawn,
 /obj/structure/table/bench/wooden,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/industrial/blue_slates_long,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -44062,6 +44096,7 @@
 "iks" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "ikw" = (
@@ -45024,6 +45059,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "itr" = (
@@ -47469,6 +47505,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/cargo)
 "iSz" = (
@@ -52670,6 +52707,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"jRY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/industrial/navy_slates,
+/area/nadezhda/maintenance/undergroundfloor1south)
 "jRZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -56073,6 +56115,11 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate/east)
+"kyx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "kyy" = (
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/command/tcommsat/computer)
@@ -56368,6 +56415,7 @@
 /obj/effect/floor_decal/industrial/box/white/corners{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/science)
 "kAJ" = (
@@ -57564,6 +57612,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "kPg" = (
@@ -63414,6 +63463,7 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "lXt" = (
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "lXv" = (
@@ -81502,6 +81552,11 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/industrial/sierra,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"pmA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/industrial/blue_slates,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "pmC" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white/monofloor,
@@ -84895,8 +84950,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
 "pRW" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -98150,6 +98205,11 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm3)
+"sqX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/industrial/cafe_large,
+/area/nadezhda/maintenance/surfaceeast)
 "srf" = (
 /obj/machinery/light{
 	dir = 4
@@ -100774,6 +100834,7 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/sec)
 "sQo" = (
@@ -102973,6 +103034,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/cargo)
 "tnu" = (
@@ -106921,6 +106983,11 @@
 /mob/living/carbon/superior/spider/nurse/recluse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"tYo" = (
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/sechall)
 "tYr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -107867,6 +107934,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
 "ugq" = (
@@ -109167,9 +109235,6 @@
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "usT" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/hcases/cardcarp,
 /obj/random/card_carp,
@@ -112827,6 +112892,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"vbc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "vbg" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -115036,6 +115106,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "vvI" = (
@@ -117074,6 +117145,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
 "vQm" = (
@@ -121119,6 +121191,11 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"wAm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/industrial/bricks,
+/area/nadezhda/maintenance/undergroundfloor1north)
 "wAo" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -123180,6 +123257,11 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"wVa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/industrial/grey_slates_long,
+/area/nadezhda/maintenance/undergroundfloor1east)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -126085,6 +126167,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"xyz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "xyB" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_corner"
@@ -126772,6 +126859,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/substation/servist)
 "xFb" = (
@@ -129171,6 +129259,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
 "ybw" = (
@@ -129209,6 +129298,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
 "ycd" = (
@@ -129560,6 +129650,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"yfP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor1north)
 "yfR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/external{
@@ -134479,7 +134574,7 @@ dkh
 eXB
 nJN
 nJN
-rbC
+jRY
 eEL
 cZb
 tad
@@ -142855,7 +142950,7 @@ dpT
 uyF
 bVu
 roZ
-bVu
+hpL
 uyF
 cZb
 cZb
@@ -153364,7 +153459,7 @@ arU
 uyF
 vtG
 oCZ
-giu
+yfP
 uyF
 uyF
 eQv
@@ -154398,7 +154493,7 @@ cZb
 cZb
 cZb
 uyF
-pij
+wAm
 lcE
 lcE
 ooF
@@ -158094,7 +158189,7 @@ mcl
 tCY
 tCY
 mcl
-jtg
+pmA
 bKJ
 bKJ
 wNq
@@ -158656,7 +158751,7 @@ eNS
 fHi
 mcl
 ivI
-tpD
+eXn
 sLV
 qeO
 nse
@@ -162325,7 +162420,7 @@ iKq
 syz
 mPx
 kOh
-oBx
+wVa
 oBx
 jqZ
 oQt
@@ -188924,7 +189019,7 @@ gRx
 erG
 kAI
 wSi
-iCG
+dPV
 uLW
 eqq
 whU
@@ -191613,7 +191708,7 @@ rHi
 jVT
 tqA
 tqA
-hFk
+tqA
 hZy
 rPr
 rWi
@@ -191814,8 +191909,8 @@ osE
 caN
 rWi
 oQN
+oQN
 pRW
-rWi
 rWi
 rWi
 rWi
@@ -193477,7 +193572,7 @@ qMI
 qMI
 ubh
 rAZ
-sjq
+hFk
 rWi
 cZb
 cZb
@@ -218805,7 +218900,7 @@ kRY
 kRY
 kRY
 kRY
-kRY
+xyz
 kOR
 uSy
 vZg
@@ -219007,7 +219102,7 @@ cUq
 cUq
 kRY
 ozq
-kRY
+kyx
 kOR
 uSy
 eHj
@@ -220828,7 +220923,7 @@ lnp
 ajp
 gBD
 uSy
-cKc
+aNi
 tWk
 rRv
 rRv
@@ -221030,7 +221125,7 @@ wHe
 ajp
 gBD
 uSy
-cKc
+tYo
 cKc
 cKc
 cKc
@@ -243051,7 +243146,7 @@ liT
 liT
 liT
 liT
-liT
+sqX
 tDR
 gBD
 gBD
@@ -246728,7 +246823,7 @@ tLG
 rIq
 bcM
 hXE
-vjP
+vbc
 yjc
 gBD
 gBD

--- a/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony.dmm
@@ -32549,9 +32549,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -91101,8 +91098,8 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/camera/network/research{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)


### PR DESCRIPTION
## About The Pull Request
Touches up SI robotics, and RnD room to look nicer, inspiration by RuCat, from Coffee Station
Adds a new maints section to medical by the CBO room for faster movement for paramedics to lower areas
Adds new sections of maints north lowest level
Tweaks some lighting placement
Moves medical sleepers and advanced scanners up 2 tiles

Tweaks much of Residental Maints by the pool and dorms
Tweaks a little of north maints store section
Adds srubbers and pumps to each substation as well as a few random pumps around the colony