### PR TITLE
Makes Artificer 'Breakers' obtainable, air pumps/scrubbers purchaseable

### DIFF
--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -278,6 +278,10 @@
 	name = "rapid piping device"
 	build_path = /obj/item/rpd
 
+/datum/design/autolathe/tool/breaker
+	name = "Artificer \"Breaker\""
+	build_path = /obj/item/gun/matter/launcher/breaker
+
 //Sun Branch
 /datum/design/autolathe/tool/dawn
 	name = "\"Crack of Dawn\""

--- a/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
@@ -189,6 +189,7 @@
 		/datum/design/autolathe/tool/ducttape/fiber,
 		/datum/design/autolathe/tool/ducttape/glue,
 		/datum/design/autolathe/tool/rpd,
+		/datum/design/autolathe/tool/breaker,
 		// From Circuits
 		/datum/design/autolathe/circuit/airlockmodule,
 		/datum/design/autolathe/circuit/airalarm,

--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -926,6 +926,11 @@
 	required_reagents = list("cleaner" = 2, "pacid" = 1, "sulfur" = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/matter_deconstructor
+	result = "deconstructor"
+	required_reagents = list("rejuvenating_agent" = 2, "nanites" = 3, "woodpulp" = 5)
+	result_amount = 1
+
 /datum/chemical_reaction/glue
 	result = "glue"
 	required_reagents = list("plasticide" = 1, "ethanol" = 1, "carbon" = 1)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
@@ -24,7 +24,7 @@
 			/obj/machinery/pipedispenser/orderable,
 			/obj/machinery/pipedispenser/disposal/orderable,
 			/obj/machinery/portable_atmospherics/powered/pump,
-			/obj/machinery/portable_atmospherics/powered/scrubber,
+			/obj/machinery/portable_atmospherics/powered/scrubber
 		),
 		"Energiya" = list(
 			/obj/item/cell/large,

--- a/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
@@ -22,7 +22,9 @@
 			/obj/machinery/portable_atmospherics/canister/oxygen,
 			/obj/item/tank/plasma,
 			/obj/machinery/pipedispenser/orderable,
-			/obj/machinery/pipedispenser/disposal/orderable
+			/obj/machinery/pipedispenser/disposal/orderable,
+			/obj/machinery/portable_atmospherics/powered/pump,
+			/obj/machinery/portable_atmospherics/powered/scrubber,
 		),
 		"Energiya" = list(
 			/obj/item/cell/large,
@@ -65,6 +67,7 @@
 		"Bystroye Stroitel'stvo" = list(
 			/obj/item/rcd/industrial = good_data("Industrial RCD", list(-1, 1), 4500),
 			/obj/item/rcd = good_data("RCD", list(1, 2), 2500),
+			/obj/item/gun/matter/launcher/breaker = good_data("\"Breaker\" Deconstructor", list(1, 2), 3000),
 			/obj/item/hatton_magazine= good_data("Hatton TUBE", list(3, 5), 1000)
 		),
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
The artificer disassembly guns being literally unobtainable bothered me, so I added them to the artificer factory disk, as well as a favored cargo station (Zarya, where the RCDs are). Also made a pretty expensive recipe for the raw disassembly reagent you can use for spray bottles.

Also made air pumps and scrubbers purchaseable, since the air pumps are literally the rarest object in existence, with only 2-3 on the map.

- Made the Artificer 'Breaker' craftable via the artificer factory disk
- Added a recipe for the 'Deconstructor Solution'
- Added air pumps/scrubbers to Zarya's "Vozdukh" section
- Added Artificer 'Breakers' to Zarya's "Bystroye Stroitel'stvo" section (favored)

(To-Do: Go over the stations and actually put names to the seeds, since they all show as 'packet of seeds', so you don't know what you're buying)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>
