### PR TITLE
Bolt gun toggleable

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -350,6 +350,24 @@
 	name = "Bolt Action Rifle Training"
 	desc = "Through intense and repetitive training with bolt-action and lever-action rifles, you will always chamber a new round instantly after firing."
 	icon_state = "boltactionrifletraining"
+	active = FALSE
+	passivePerk = FALSE
+	var/chichink = TRUE
+
+/datum/perk/laststand/activate()
+	var/mob/living/user = holder
+	if(!isliving(user))
+		return ..()
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("Flipping back and forth from training is taxing on the mind, wait a second!"))
+		return FALSE
+	cooldown_time = world.time + 1 SECOND //So people that doble click dont instantly toggle it off and on
+	chichink = !chichink
+	if(chichink)
+		to_chat(usr, SPAN_NOTICE("You will now mindlessly cycle the bolt action."))
+	else
+		to_chat(usr, SPAN_NOTICE("You will no longer cycle the bolt automatically mindlessly. What was the point of basic training?"))
+	return ..()
 
 /datum/perk/job/jingle_jangle
 	name = "Key Smith"

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -354,7 +354,7 @@
 	passivePerk = FALSE
 	var/chichink = TRUE
 
-/datum/perk/laststand/activate()
+/datum/perk/job/bolt_reflect/activate()
 	var/mob/living/user = holder
 	if(!isliving(user))
 		return ..()

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -98,14 +98,27 @@
 
 /obj/item/gun/projectile/boltgun/handle_post_fire(mob/user)
 	..()
-	if(bolt_training && user.stats.getPerk(PERK_BOLT_REFLECT) && loaded.len>1)
-		to_chat(user, SPAN_NOTICE("Your hands move instinctively to chamber a new round!"))
-		bolt_act(user)
-		bolt_act(user)
-		return
-	if(bolt_training && user.stats.getPerk(PERK_BOLT_REFLECT) && loaded.len==1)
-		to_chat(user, SPAN_NOTICE("You stop your hands from instinctively chambering a new round."))
-		bolt_act(user)
+
+	//Makes sure we dont runtime by asking ghosts/proc calls
+	if(isliving(user))
+		var/bolt_perk = user.stats.getPerk(PERK_BOLT_REFLECT) //Do we even have it? Try and get it
+		if(!bolt_perk)
+			return
+
+		// /datum/perk/job/bolt_reflect in perks/job.dm basically a "is this perk active on or not?" var
+		if(bolt_perk.chichink)
+			//We have ammo so cycle it to the next shot instently.
+			if(bolt_training && user.stats.getPerk(PERK_BOLT_REFLECT) && loaded.len>1)
+				to_chat(user, SPAN_NOTICE("Your hands move instinctively to chamber a new round!"))
+				bolt_act(user)
+				bolt_act(user)
+				return
+			//Out of ammo, just cycle once so that way we dont close the bolt with a unloaded gun before reloading
+			if(bolt_training && user.stats.getPerk(PERK_BOLT_REFLECT) && loaded.len==1)
+				to_chat(user, SPAN_NOTICE("You stop your hands from instinctively chambering a new round."))
+				bolt_act(user)
+				return
+
 		return
 
 /obj/item/gun/projectile/boltgun/proc/bolt_act(mob/living/user)

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -101,7 +101,7 @@
 
 	//Makes sure we dont runtime by asking ghosts/proc calls
 	if(isliving(user))
-		var/bolt_perk = user.stats.getPerk(PERK_BOLT_REFLECT) //Do we even have it? Try and get it
+		var/datum/perk/job/bolt_reflect/bolt_perk = user.stats.getPerk(PERK_BOLT_REFLECT) //Do we even have it? Try and get it
 		if(!bolt_perk)
 			return
 


### PR DESCRIPTION
## About The Pull Request
Makes bolt gun perk toggle.
Adds some more logic to prevent runtimes if nonusers fire a bolt gun (such as procalls)