### PR TITLE
Medical item chem dosing

### DIFF
--- a/code/game/objects/items/stacks/medical_stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical_stacks/medical.dm
@@ -28,6 +28,8 @@
 	var/always_useful = FALSE
 	var/use_timer = 30
 	var/prevent_wasting = FALSE
+	var/chemical_injecting = FALSE //1 = Touch 2 = Blood 3 = Eaten
+	var/reagent_transfer_rate = 0.2 //20% of reagents inside the medical item if chemical injecting will be added when used to eather blood/skin/eaten
 
 /obj/item/stack/medical/proc/try_to_save_use(mob/living/user)
 	if(ishuman(user))

--- a/code/game/objects/items/stacks/medical_stacks/ointment_stacks.dm
+++ b/code/game/objects/items/stacks/medical_stacks/ointment_stacks.dm
@@ -10,6 +10,7 @@
 	preloaded_reagents = list("silicon" = 4, "carbon" = 8)
 	fancy_icon = TRUE
 	disinfectant  = TRUE
+	chemical_injecting = 1 //We add some kelotine to the skin
 
 /obj/item/stack/medical/ointment/attack(mob/living/carbon/M, mob/living/user)
 	if(..())
@@ -73,6 +74,14 @@
 			affecting.heal_damage(0,heal_burn)
 			affecting.salve()
 			try_to_pain(M, user)
+			if(chemical_injecting && reagents)
+				switch(chemical_injecting)
+					if(1) //Touch
+						reagents.trans_to_mob(M, reagents.total_volume * reagent_transfer_rate, CHEM_TOUCH)
+					if(2) //Blood
+						reagents.trans_to_mob(M, reagents.total_volume * reagent_transfer_rate, CHEM_BLOOD)
+					if(3) //Eaten
+						reagents.trans_to_mob(M, reagents.total_volume * reagent_transfer_rate, CHEM_INGEST)
 			return
 
 		if(can_operate(H, user))        //Checks if mob is lying down on table for surgery
@@ -122,7 +131,7 @@
 	automatic_charge_overlays = TRUE
 	consumable = FALSE	// Will the stack disappear entirely once the amount is used up?
 	splittable = FALSE	// Is the stack capable of being splitted?
-	preloaded_reagents = list("silicon" = 4, "ethanol" = 10, "mercury" = 4)
+	preloaded_reagents = list("silicon" = 4, "ethanol" = 10, "carbon" = 4)
 	w_class = ITEM_SIZE_SMALL
 	perk_required = TRUE
 	needed_perk = PERK_MEDICAL_EXPERT
@@ -259,3 +268,4 @@
 	always_useful = TRUE
 	extra_bulk = 2
 	prevent_wasting = TRUE
+	chemical_injecting = 2 //We add some chemicals to blood

--- a/code/game/objects/items/stacks/medical_stacks/splint_stacks.dm
+++ b/code/game/objects/items/stacks/medical_stacks/splint_stacks.dm
@@ -76,6 +76,18 @@
 						SPAN_DANGER("You hear something being wrapped.")
 					)
 					return
+
+			//In case anyone ever wants to make this a thing.
+			if(chemical_injecting && reagents)
+				switch(chemical_injecting)
+					if(1) //Touch
+						reagents.trans_to_mob(M, (reagents.total_volume / amount) * reagent_transfer_rate, CHEM_TOUCH)
+					if(2) //Blood
+						reagents.trans_to_mob(M, (reagents.total_volume / amount) * reagent_transfer_rate, CHEM_BLOOD)
+					if(3) //Eaten
+						reagents.trans_to_mob(M, (reagents.total_volume / amount) * reagent_transfer_rate, CHEM_INGEST)
+
+
 			affecting.status |= ORGAN_SPLINTED
 			use(1) //You cannot "waste less" of a splint! Their uses are supposed to be expended since it's one whole item not some ointment!
 		return

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -310,6 +310,18 @@
 					S.blood_DNA = list()
 				LAZYINITLIST(S.blood_DNA)
 				S.blood_DNA |= blood_DNA
+
+		//Hack to prevent reagent loss
+		if(reagents)
+			reagent_flags |= REFILLABLE | DRAINABLE | DRAWABLE | INJECTABLE
+
+			var/difference = abs(orig_amount - transfer)
+			var/transfer_persent = difference / orig_amount
+
+			reagents.trans_to_obj(S, reagents.total_volume * transfer_persent)
+			reagent_flags = initial(reagent_flags)
+
+
 		return transfer
 	return 0
 
@@ -340,6 +352,21 @@
 	var/orig_amount = src.amount
 	if (transfer && src.use(transfer))
 		var/obj/item/stack/S = new src.type(loc, transfer)
+
+		//Prevents douping with preloaded reagents
+		if(S.reagents)
+			S.reagents.clear_reagents()
+
+		//Hack to prevent reagent loss
+		if(reagents)
+			reagent_flags |= REFILLABLE | DRAINABLE | DRAWABLE | INJECTABLE
+
+			var/difference = abs(orig_amount - transfer)
+			var/transfer_persent = difference / orig_amount
+
+			reagents.trans_to_obj(S, reagents.total_volume * transfer_persent)
+			reagent_flags = initial(reagent_flags)
+
 		S.color = color
 		if (prob(transfer/orig_amount * 100))
 			transfer_fingerprints_to(S)

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -137,6 +137,9 @@
 	if(istype(L))
 		L.adjust_fire_stacks(amount / 15)
 
+/datum/reagent/ethanol/affect_touch(var/mob/living/carbon/M, var/alien, var/effect_multiplier) // Hydrazine is both toxic and flammable.
+	M.add_chemical_effect(CE_TOXIN, -0.1) //Small affect to make this slightly useful to splash on
+
 /datum/reagent/ethanol/on_mob_add(mob/living/L)
 	..()
 	LEGACY_SEND_SIGNAL(L, COMSIG_CARBON_HAPPY, src, MOB_ADD_DRUG)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -2,6 +2,15 @@
 /datum/reagent/medicine
 	reagent_type = "Medicine"
 
+//Unless over-coded affect touch is affectively the same as injecting. This is done at a even worse rate do to skin layer
+/datum/reagent/medicine/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
+	var/bio_armor_protection = 100 - M.getarmor(null, ARMOR_BIO)
+	if(bio_armor_protection > 19) // 80 armor or more = dont do this
+		return
+	bio_armor_protection = min(0.1, 0.01 * bio_armor_protection)
+
+	affect_blood(M, alien, 0.1 - bio_armor_protection)
+
 /datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"
 	id = "inaprovaline"


### PR DESCRIPTION
Math is painful

## About The Pull Request
Spliting a stack of items now dosnt magically create new chemicals
Spliting a stack will now with some loss transfer over the chemicals at a % rate based on the splits

Medical items such as oitment and bruise packs now add chemicals to skin based on internal chemicals
This means some chemical items are toxic if used excessively

All medical chemicals unless over-rote now process as they do in blood when on skin at a reduced rate of effectiveness

With bruise packs (aka gauze) you can dose them with chemicals, this will in most cases will add a little bit of chemicals to the skin of target

Advanced trama kits rather then lithium now have somnadine (aka when asleep heal a bit of brute damage) chemical