### PR TITLE
Ritual Style

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -934,6 +934,17 @@
 
 /obj/item/tool/knife/neotritual/resolve_attackby(atom/target, mob/user, relay = TRUE)
 
+	var/credit_kill = FALSE
+	if(isliving(user) && isliving(target))
+		var/mob/living/L = target
+		//message_admins("user is living, A is living")
+		var/mob/living/ritual_arts = user
+		var/tasklevel = (ritual_arts.learnt_tasks.get_task_mastery_level("RITUAL_ARTS"))
+		force += tasklevel
+		if(L.stat != DEAD)
+			credit_kill = TRUE
+		//message_admins("tasklevel [tasklevel]")
+
 	if(is_neotheology_disciple(user))
 		if(isliving(target))
 			var/mob/living/M = target
@@ -968,3 +979,24 @@
 	.=..()
 
 	refresh_upgrades()
+
+	if(isliving(user) && isliving(target))
+		var/mob/living/L = target
+		if(L.stat == DEAD && credit_kill)
+			//message_admins("user is living, A is living")
+			var/mob/living/ritual_arts = user
+			//message_admins("melee arts")
+			ritual_arts.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/ritual_arts, "RITUAL_ARTS", skill_gained = 1, learner = ritual_arts)
+			var/tasklevel = (ritual_arts.learnt_tasks.get_task_mastery_level("RITUAL_ARTS"))
+			if(tasklevel)
+				if(ishuman(ritual_arts))
+					var/mob/living/carbon/human/H = ritual_arts
+					H.sanity.changeLevel(tasklevel*10)
+					var/obj/item/organ/internal/psionic_tumor/PT = H.random_organ_by_process(BP_PSION)
+					if(PT)
+						if(PT.max_psi_points > PT.psi_points)
+							PT.psi_points += tasklevel
+				var/obj/item/implant/core_implant/cruciform/CI = ritual_arts.get_core_implant()
+				if(CI)
+					if(CI.power < CI.max_power)
+						CI.power += tasklevel

--- a/code/game/objects/items/weapons/tools/knifes_daggers.dm
+++ b/code/game/objects/items/weapons/tools/knifes_daggers.dm
@@ -115,6 +115,42 @@
 	backstab_damage = 14
 	price_tag = 7
 
+/obj/item/tool/knife/ritual/resolve_attackby(atom/A as mob|obj|turf|area, mob/user, proximity, params)
+	var/credit_kill = FALSE
+	if(isliving(user) && isliving(A))
+		var/mob/living/L = A
+		//message_admins("user is living, A is living")
+		var/mob/living/ritual_arts = user
+		var/tasklevel = (ritual_arts.learnt_tasks.get_task_mastery_level("RITUAL_ARTS"))
+		force += tasklevel
+		if(L.stat != DEAD)
+			credit_kill = TRUE
+		//message_admins("tasklevel [tasklevel]")
+
+	.=..()
+	refresh_upgrades()
+
+	if(isliving(user) && isliving(A))
+		var/mob/living/L = A
+		if(L.stat == DEAD && credit_kill)
+			//message_admins("user is living, A is living")
+			var/mob/living/ritual_arts = user
+			//message_admins("melee arts")
+			ritual_arts.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/ritual_arts, "RITUAL_ARTS", skill_gained = 1, learner = ritual_arts)
+			var/tasklevel = (ritual_arts.learnt_tasks.get_task_mastery_level("RITUAL_ARTS"))
+			if(tasklevel)
+				if(ishuman(ritual_arts))
+					var/mob/living/carbon/human/H = ritual_arts
+					H.sanity.changeLevel(tasklevel*10)
+					var/obj/item/organ/internal/psionic_tumor/PT = H.random_organ_by_process(BP_PSION)
+					if(PT)
+						if(PT.max_psi_points > PT.psi_points)
+							PT.psi_points += tasklevel
+				var/obj/item/implant/core_implant/cruciform/CI = ritual_arts.get_core_implant()
+				if(CI)
+					if(CI.power < CI.max_power)
+						CI.power += tasklevel
+
 /obj/item/tool/knife/ritual/sickle
 	name = "bloodletter"
 	desc = "A ritual knife, its latent unearthly energies partly awoken by forces unknown. \
@@ -196,6 +232,43 @@
 	embed_mult = 0.6
 	max_upgrades = 4
 	price_tag = 300 // Fancy expensive paper weight.
+
+//Counts for Ritual Arts
+/obj/item/tool/knife/dagger/ceremonial/resolve_attackby(atom/A as mob|obj|turf|area, mob/user, proximity, params)
+	var/credit_kill = FALSE
+	if(isliving(user) && isliving(A))
+		var/mob/living/L = A
+		//message_admins("user is living, A is living")
+		var/mob/living/ritual_arts = user
+		var/tasklevel = (ritual_arts.learnt_tasks.get_task_mastery_level("RITUAL_ARTS"))
+		force += tasklevel
+		if(L.stat != DEAD)
+			credit_kill = TRUE
+		//message_admins("tasklevel [tasklevel]")
+
+	.=..()
+	refresh_upgrades()
+
+	if(isliving(user) && isliving(A))
+		var/mob/living/L = A
+		if(L.stat == DEAD && credit_kill)
+			//message_admins("user is living, A is living")
+			var/mob/living/ritual_arts = user
+			//message_admins("melee arts")
+			ritual_arts.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/ritual_arts, "RITUAL_ARTS", skill_gained = 1, learner = ritual_arts)
+			var/tasklevel = (ritual_arts.learnt_tasks.get_task_mastery_level("RITUAL_ARTS"))
+			if(tasklevel)
+				if(ishuman(ritual_arts))
+					var/mob/living/carbon/human/H = ritual_arts
+					H.sanity.changeLevel(tasklevel*10)
+					var/obj/item/organ/internal/psionic_tumor/PT = H.random_organ_by_process(BP_PSION)
+					if(PT)
+						if(PT.max_psi_points > PT.psi_points)
+							PT.psi_points += tasklevel
+				var/obj/item/implant/core_implant/cruciform/CI = ritual_arts.get_core_implant()
+				if(CI)
+					if(CI.power < CI.max_power)
+						CI.power += tasklevel
 
 /obj/item/tool/knife/dagger/heirloom_knife
 	name = "heirloom dagger"

--- a/modular_sojourn/task_master/_task_master_defines.dm
+++ b/modular_sojourn/task_master/_task_master_defines.dm
@@ -13,7 +13,11 @@
 #define PARCORE /datum/task_master/task/parcours
 #define SLIP_N_DIE /datum/task_master/task/slip_n_die
 #define SLAB_CLEARER /datum/task_master/task/slab_clearer
+
+//Weapon Arts/Styles
 #define SHEATH_ARTS /datum/task_master/task/sheath_arts
+#define RITUAL_ARTS /datum/task_master/task/ritual_arts
+
 #define FLOOR_FIXER /datum/task_master/task/floor_fixer
 #define BUTTER_MAKER /datum/task_master/task/butter_maker
 #define BOTTLER /datum/task_master/task/bottler

--- a/modular_sojourn/task_master/tasks.dm
+++ b/modular_sojourn/task_master/tasks.dm
@@ -301,3 +301,15 @@
 	unlocked = FALSE
 
 //no boons for walnut seeker by itself, it does a few intractions tho
+
+//Complex tasks
+/datum/task_master/task/ritual_arts
+	name = "Ritual Style"
+	key = "RITUAL_ARTS"
+	desc = "An art form that requires a once living medium to complete."
+	gain_text = "Bladework of ritual blade is uncannily easy to learn..."
+	level_thresholds = 10 // 10->20->40->80 ect
+	alt_scaling_number = 2
+	unlocked = FALSE
+
+//no boons for ritual style by itself, it does a few intractions tho


### PR DESCRIPTION
TL:DR
when stabbing with a rital type blade (only counts like 4 items in the game)
get force += task level
onkill get 1 task exp
onkill recover 10 x task level sanity
onkill if church: get task level church power
onkill if psionic: get task level psionic points
Does NOT count psionic blade
DOES count absolutism ritual knife

Adds a tasks that slowly on kill upscales ritual type blades (Ritual knife, absolutism ritual knife, Crayon Magic Knife, ceremonial dagger)
When getting a kill with said knife with any level of task, recharge eather psionic points or church power equal to task level
Before hitting a monster add 1 force for every level of the task, This is post-upgrades so does NOT scale with mods.
Does NOT interact with backstabs as those are their own mechanic and damage system
